### PR TITLE
PR-3: external matrix generalization

### DIFF
--- a/docs/human-briefs/2026-06-27-external-matrix-generalization.html
+++ b/docs/human-briefs/2026-06-27-external-matrix-generalization.html
@@ -30,7 +30,7 @@
 
     <h2>本阶段改动</h2>
     <ul>
-      <li><a href="../../src/hermes_skilleval/external/skillrouter_matrix.py"><code>src/hermes_skilleval/external/skillrouter_matrix.py</code></a>：新增 frozen plan writer、matrix runner、field views、candidate subset sampling、paired bootstrap CI、held-out splits、SkillRouter/SkillsBench overlap scaffold。</li>
+      <li><a href="../../src/hermes_skilleval/external/skillrouter_matrix.py"><code>src/hermes_skilleval/external/skillrouter_matrix.py</code></a>：新增 frozen plan writer、matrix runner、field views、candidate subset sampling、paired bootstrap CI、held-out splits、SkillRouter/SkillsBench overlap scaffold，并在 matrix run 时校验 frozen prediction/data hashes。</li>
       <li><a href="../../src/hermes_skilleval/cli.py"><code>src/hermes_skilleval/cli.py</code></a>：新增 <code>external-plan</code> 和 <code>external-matrix</code> 命令。</li>
       <li><a href="../../tests/test_external_skillrouter_matrix.py"><code>tests/test_external_skillrouter_matrix.py</code></a>：新增 tiny-fixture TDD tests，覆盖冻结计划、CLI smoke、official/diagnostic 分离、stress subset、bootstrap、split 和 overlap scaffold。</li>
       <li><a href="../../openspec/changes/external-matrix-generalization/specs/external-evaluation-matrix/spec.md"><code>openspec/changes/external-matrix-generalization/specs/external-evaluation-matrix/spec.md</code></a>：定义 PR-3 外部矩阵 contract。</li>
@@ -39,7 +39,7 @@
     <h2>关键边界</h2>
     <ul>
       <li>矩阵 runner 只消费 frozen prediction files，不训练、不调阈值、不挖 hard negatives、不跑 embeddings/rerankers/model inference。</li>
-      <li>official SkillRouter Easy/Hard results 通过 PR-2 scorer 生成；candidate-pool stress tests 只在 <code>hermes_diagnostics</code> 中出现。</li>
+      <li>official SkillRouter Easy/Hard results 通过 PR-2 scorer 生成，并按 frozen <code>config_id</code> keyed；candidate-pool stress tests 只在 <code>hermes_diagnostics</code> 中出现。</li>
       <li>held-out-source metadata 不足时输出 field-level <code>UNAVAILABLE</code>，不伪造 split。</li>
       <li>SkillRouter 没有显式 negative labels 时不输出 Hermes Negative Hit Rate。</li>
     </ul>

--- a/docs/human-briefs/2026-06-27-external-matrix-generalization.html
+++ b/docs/human-briefs/2026-06-27-external-matrix-generalization.html
@@ -1,0 +1,62 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>External Matrix Generalization - Human Brief</title>
+  <style>
+    body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; margin: 0; color: #16202a; background: #f7f8fb; }
+    main { max-width: 980px; margin: 0 auto; padding: 40px 24px 64px; }
+    h1 { font-size: 32px; margin: 0 0 8px; }
+    h2 { font-size: 18px; margin-top: 28px; border-bottom: 1px solid #d9e0ea; padding-bottom: 6px; }
+    p, li { line-height: 1.62; }
+    code { background: #eef2f7; padding: 1px 4px; border-radius: 4px; }
+    a { color: #175a9c; }
+    .status { display: inline-block; padding: 4px 10px; border: 1px solid #bcc6d4; border-radius: 999px; background: #fff; font-size: 13px; }
+    .panel { background: #fff; border: 1px solid #dfe5ef; border-radius: 8px; padding: 18px 20px; margin-top: 18px; }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>External Matrix Generalization</h1>
+    <span class="status">applying / PR-3 matrix only</span>
+
+    <div class="panel">
+      <p><strong>一句话结论：</strong>本阶段新增 frozen zero-shot external evaluation matrix：先写冻结计划，再消费冻结 predictions 做 SkillRouter official Easy/Hard scoring，并把 Hermes stress diagnostics、split、bootstrap、overlap scaffold 分开输出。</p>
+    </div>
+
+    <h2>当前状态</h2>
+    <p>OpenSpec change：<code>external-matrix-generalization</code>。PR-1 adapter/provenance 和 PR-2 official scorer 是稳定依赖；本阶段不改 scorer 公式，也不运行 router/model/live-agent。</p>
+
+    <h2>本阶段改动</h2>
+    <ul>
+      <li><a href="../../src/hermes_skilleval/external/skillrouter_matrix.py"><code>src/hermes_skilleval/external/skillrouter_matrix.py</code></a>：新增 frozen plan writer、matrix runner、field views、candidate subset sampling、paired bootstrap CI、held-out splits、SkillRouter/SkillsBench overlap scaffold。</li>
+      <li><a href="../../src/hermes_skilleval/cli.py"><code>src/hermes_skilleval/cli.py</code></a>：新增 <code>external-plan</code> 和 <code>external-matrix</code> 命令。</li>
+      <li><a href="../../tests/test_external_skillrouter_matrix.py"><code>tests/test_external_skillrouter_matrix.py</code></a>：新增 tiny-fixture TDD tests，覆盖冻结计划、CLI smoke、official/diagnostic 分离、stress subset、bootstrap、split 和 overlap scaffold。</li>
+      <li><a href="../../openspec/changes/external-matrix-generalization/specs/external-evaluation-matrix/spec.md"><code>openspec/changes/external-matrix-generalization/specs/external-evaluation-matrix/spec.md</code></a>：定义 PR-3 外部矩阵 contract。</li>
+    </ul>
+
+    <h2>关键边界</h2>
+    <ul>
+      <li>矩阵 runner 只消费 frozen prediction files，不训练、不调阈值、不挖 hard negatives、不跑 embeddings/rerankers/model inference。</li>
+      <li>official SkillRouter Easy/Hard results 通过 PR-2 scorer 生成；candidate-pool stress tests 只在 <code>hermes_diagnostics</code> 中出现。</li>
+      <li>held-out-source metadata 不足时输出 field-level <code>UNAVAILABLE</code>，不伪造 split。</li>
+      <li>SkillRouter 没有显式 negative labels 时不输出 Hermes Negative Hit Rate。</li>
+    </ul>
+
+    <h2>验证计划</h2>
+    <ul>
+      <li><code>python -m pytest -q tests/test_external_skillrouter_matrix.py</code></li>
+      <li><code>python -m pytest -q</code></li>
+      <li><code>OPENSPEC_TELEMETRY=0 openspec validate --all --strict</code></li>
+      <li><code>release-check</code>、<code>git diff --check</code>、v0.3 YAML parse、CRLF/new-file line-ending check</li>
+    </ul>
+
+    <h2>剩余风险</h2>
+    <p>本阶段证明的是 deterministic local machinery 和 tiny fixture path；真实 external matrix 仍需要后续提供冻结预测文件和固定 upstream data root。不要把 stress subsets 描述为 official SkillRouter results，也不要把本 PR 说成 live-agent evidence。</p>
+
+    <h2>推荐下一步</h2>
+    <p>完成 PR-3 review 后，再决定是否进入 PR-4 live-agent runtime abstraction；不要在 PR-3 分支追加 live-agent 或 model execution。</p>
+  </main>
+</body>
+</html>

--- a/docs/v0.3/codex-implementation-guide.md
+++ b/docs/v0.3/codex-implementation-guide.md
@@ -115,6 +115,8 @@ Acceptance:
 Goal: run frozen routers without scored-label tuning and produce external
 routing evidence with deterministic diagnostics.
 
+Human brief: `docs/human-briefs/2026-06-27-external-matrix-generalization.html`
+
 Expected work:
 
 - Generate a frozen evaluation plan before running scored evaluation.

--- a/openspec/changes/external-matrix-generalization/.openspec.yaml
+++ b/openspec/changes/external-matrix-generalization/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-27

--- a/openspec/changes/external-matrix-generalization/design.md
+++ b/openspec/changes/external-matrix-generalization/design.md
@@ -42,25 +42,31 @@ explicit negative labels exist.
 
 1. **Frozen plan as the matrix entry point.** The matrix runner consumes a
    plan JSON produced by a separate plan command. The plan records run ID,
-   git commit, dirty summary, seed, data provenance, frozen router configs,
-   field views, tiers, stress subset sizes, and output paths. This makes any
-   scored report auditable against preregistered inputs.
+   git commit, dirty summary, seed, data provenance with data file hashes,
+   frozen router configs with prediction file hashes, field views, tiers,
+   stress subset sizes, bootstrap settings, and output paths. The runner
+   recomputes those hashes before scoring and fails closed on drift.
 
 2. **Prediction-input matrix, not live router execution.** PR-3 compares frozen
    routers/configs by consuming ranked prediction files declared in the plan.
    It does not import model libraries or compute embeddings. This keeps the
    change bounded and prevents accidental tuning or inference on final labels.
 
-3. **Official results delegate to PR-2.** Full Easy/Hard official scoring calls
+3. **Config identity is separate from router identity.** Official matrix
+   reports are keyed by `config_id`, defaulting to `{router_id}__{field_view}`
+   when not provided. This preserves field-view ablations for the same router
+   without overwriting reports.
+
+4. **Official results delegate to PR-2.** Full Easy/Hard official scoring calls
    the PR-2 scorer for each frozen router/config and field view. Hermes
    diagnostics wrap those official outputs but do not modify metric formulas.
 
-4. **Stress subsets are diagnostics only.** Candidate subsets use the protocol
+5. **Stress subsets are diagnostics only.** Candidate subsets use the protocol
    rule: include all selected GT skills first, then add distractors sorted by
    `sha256("20260625:" + skill_id)`. If a target size cannot contain the GT
    union, the subset result is field-level `UNAVAILABLE` with a reason.
 
-5. **Split and overlap reports are deterministic scaffolds.** Held-out-skill
+6. **Split and overlap reports are deterministic scaffolds.** Held-out-skill
    split generation builds connected components over task and selected GT skill
    nodes. Held-out-source runs only when enough source metadata exists.
    SkillRouter/SkillsBench overlap reporting starts with exact IDs and

--- a/openspec/changes/external-matrix-generalization/design.md
+++ b/openspec/changes/external-matrix-generalization/design.md
@@ -1,0 +1,96 @@
+## Context
+
+PR-1 introduced the SkillRouter external adapter/provenance boundary and PR-2
+introduced official SkillRouter scorer parity for already-ranked predictions.
+PR-3 builds the frozen zero-shot matrix layer on top of those stable surfaces:
+it prepares evaluation plans, builds deterministic field-view candidate text,
+records frozen router configs, runs only precomputed/frozen prediction inputs,
+and emits official SkillRouter reports plus separate Hermes diagnostics.
+
+The v0.3 protocol requires scored labels to remain evaluation-only. The matrix
+must not train, tune thresholds, select routers after seeing results, run live
+agents, promote release artifacts, or compute Hermes Negative Hit Rate unless
+explicit negative labels exist.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Generate a frozen evaluation plan before any scored matrix report.
+- Reuse the PR-1 adapter for tasks, relevance, skill pools, and provenance.
+- Reuse the PR-2 scorer for full Easy/Hard official SkillRouter scoring.
+- Add deterministic field views: `name_only`, `metadata`, and `full_body`.
+- Add deterministic candidate subset sampling for Hermes stress diagnostics.
+- Add paired bootstrap confidence intervals over task-level paired deltas.
+- Add held-out-skill split generation using task-skill connected components.
+- Add held-out-source diagnostics that fail closed to field-level
+  `UNAVAILABLE` when source metadata is insufficient.
+- Add a SkillRouter/SkillsBench overlap scaffold without requiring live task
+  selection.
+
+**Non-Goals:**
+
+- No router training, threshold tuning, hard-negative mining from scored data,
+  model inference, embedding generation, reranking, live-agent runtime, release
+  promotion, or router promotion.
+- No changes to PR-1 adapter/provenance APIs or PR-2 official scorer semantics
+  unless a narrow compatibility bug is proven by tests.
+- No commitment of full external datasets, model checkpoints, embedding caches,
+  credentials, raw traces, or unredacted logs.
+
+## Decisions
+
+1. **Frozen plan as the matrix entry point.** The matrix runner consumes a
+   plan JSON produced by a separate plan command. The plan records run ID,
+   git commit, dirty summary, seed, data provenance, frozen router configs,
+   field views, tiers, stress subset sizes, and output paths. This makes any
+   scored report auditable against preregistered inputs.
+
+2. **Prediction-input matrix, not live router execution.** PR-3 compares frozen
+   routers/configs by consuming ranked prediction files declared in the plan.
+   It does not import model libraries or compute embeddings. This keeps the
+   change bounded and prevents accidental tuning or inference on final labels.
+
+3. **Official results delegate to PR-2.** Full Easy/Hard official scoring calls
+   the PR-2 scorer for each frozen router/config and field view. Hermes
+   diagnostics wrap those official outputs but do not modify metric formulas.
+
+4. **Stress subsets are diagnostics only.** Candidate subsets use the protocol
+   rule: include all selected GT skills first, then add distractors sorted by
+   `sha256("20260625:" + skill_id)`. If a target size cannot contain the GT
+   union, the subset result is field-level `UNAVAILABLE` with a reason.
+
+5. **Split and overlap reports are deterministic scaffolds.** Held-out-skill
+   split generation builds connected components over task and selected GT skill
+   nodes. Held-out-source runs only when enough source metadata exists.
+   SkillRouter/SkillsBench overlap reporting starts with exact IDs and
+   normalized text hashes, leaving high-similarity diagnostics as structured
+   placeholders.
+
+## Risks / Trade-offs
+
+- **Risk: frozen-router comparison is mistaken for live inference.** →
+  Mitigation: require prediction files in frozen configs, document no
+  embeddings/model inference, and test that plan/run paths do not instantiate
+  router runtimes.
+- **Risk: stress subsets get described as official SkillRouter results.** →
+  Mitigation: write stress outputs only under `hermes_diagnostics` and keep
+  official Easy/Hard reports separate.
+- **Risk: held-out-source metadata is incomplete.** → Mitigation: output
+  `UNAVAILABLE` with a precise reason rather than fabricating a split.
+- **Risk: bootstrap intervals imply independent samples.** → Mitigation: use
+  paired task-level deltas for shared eligible tasks and record seed,
+  iteration count, and metric names.
+
+## Migration Plan
+
+PR-3 adds new modules, CLI commands, tests, OpenSpec artifacts, and a Human
+Brief. Existing PR-1 validation and PR-2 scorer commands remain stable.
+Rollback is removal of the new matrix modules/CLI surface and OpenSpec change
+without altering adapter or scorer behavior.
+
+## Open Questions
+
+- Which real frozen router prediction files will be used for a full external
+  matrix outside CI remains a run-configuration decision. PR-3 only defines the
+  deterministic local machinery and tiny-fixture proof path.

--- a/openspec/changes/external-matrix-generalization/proposal.md
+++ b/openspec/changes/external-matrix-generalization/proposal.md
@@ -1,0 +1,57 @@
+## Why
+
+PR-1 can validate real-shaped SkillRouter data and PR-2 can score ranked
+predictions with official SkillRouter semantics, but v0.3 still needs a frozen
+zero-shot evaluation matrix before any external routing claims are credible.
+PR-3 creates that matrix boundary while keeping scored labels evaluation-only
+and avoiding training, threshold tuning, live agents, release promotion, or
+router selection after results are visible.
+
+## What Changes
+
+- Add a frozen evaluation plan artifact that must be generated before any
+  scored matrix output.
+- Compare only preregistered frozen routers/configs against the PR-1 adapter
+  and PR-2 scorer surfaces.
+- Add field views for `name_only`, `metadata`, and `full_body` skill text.
+- Produce full Easy/Hard official scoring runs through the PR-2 scorer.
+- Add separate Hermes diagnostics for candidate pool stress tests, including
+  deterministic subsets that always include all selected GT skills.
+- Add deterministic paired bootstrap confidence intervals over task-level
+  paired router deltas.
+- Add held-out-skill split generation using task-skill connected components.
+- Add held-out-source diagnostics only when source metadata is sufficient;
+  otherwise write a field-level `UNAVAILABLE` marker with a reason.
+- Add a SkillRouter/SkillsBench overlap report scaffold for exact ID,
+  normalized text hash, and future high-similarity diagnostics.
+- Do not train, tune thresholds, mine hard negatives from scored data, run
+  live agents, promote routers, or calculate Hermes Negative Hit Rate for
+  SkillRouter without explicit negative labels.
+
+## Capabilities
+
+### New Capabilities
+
+- `external-evaluation-matrix`: Defines frozen external routing matrix plans,
+  field views, official SkillRouter scoring orchestration, Hermes stress
+  diagnostics, paired confidence intervals, split reports, and overlap report
+  scaffolding.
+
+### Modified Capabilities
+
+- None.
+
+## Impact
+
+- Affected code: new external matrix planning/running/report modules and
+  scoped CLI commands in `src/hermes_skilleval/cli.py`.
+- Affected tests: new deterministic fixture tests for frozen plans, field
+  views, candidate subsets, bootstrap intervals, connected-component
+  held-out-skill splits, held-out-source availability, and overlap scaffolds.
+- Affected docs/OpenSpec: PR-3 OpenSpec artifacts and a concise Human Brief.
+- Stable dependencies: PR-1 SkillRouter adapter/provenance and PR-2 official
+  scorer APIs.
+- Out of scope: model training, threshold tuning, scored-set hard-negative
+  mining, embeddings/rerankers unless represented as frozen input configs, live
+  agents, release promotion, raw external dataset commits, and Hermes Negative
+  Hit Rate without explicit negative labels.

--- a/openspec/changes/external-matrix-generalization/specs/external-evaluation-matrix/spec.md
+++ b/openspec/changes/external-matrix-generalization/specs/external-evaluation-matrix/spec.md
@@ -12,12 +12,20 @@ any scored external matrix report.
   summary, benchmark ID, data root provenance, upstream reference, license
   note, frozen router configs, field views, tiers, candidate subset sizes, and
   output paths
+- **AND** each frozen router config MUST include a unique `config_id` plus
+  prediction file size and SHA-256 metadata
+- **AND** bootstrap confidence interval iteration count and confidence level
+  MUST be frozen in the plan
 - **AND** the plan MUST be written before any scored matrix output is written
 
 #### Scenario: Matrix requires existing plan
 
 - **WHEN** a caller runs a scored external matrix
 - **THEN** the runner MUST consume an existing frozen plan
+- **AND** it MUST fail closed if prediction file hashes differ from the plan
+- **AND** it MUST fail closed if adapter data file hashes differ from the plan
+- **AND** it MUST fail closed if a requested output path differs from the
+  frozen matrix output path recorded in the plan
 - **AND** it MUST NOT rewrite router IDs, thresholds, prediction paths, field
   views, tiers, or scoring dimensions from scored-label results
 
@@ -30,7 +38,8 @@ preregistered ranked prediction inputs.
 
 - **WHEN** the matrix runner evaluates frozen router configs
 - **THEN** each config MUST identify a router ID, field view, prediction file,
-  top-k or threshold metadata when present, and version metadata
+  unique config ID, top-k or threshold metadata when present, and version
+  metadata
 - **AND** the runner MUST NOT train, tune thresholds, mine hard negatives, run
   embeddings, run rerankers, run model inference, run live agents, promote
   routers, or promote release artifacts
@@ -61,6 +70,8 @@ diagnostics.
   router/config and tier
 - **AND** official reports MUST include Easy and Hard scoring over full tier
   candidate pools
+- **AND** official reports MUST be keyed by frozen `config_id`, while
+  preserving `router_id` and `field_view` inside each report
 - **AND** missing task predictions MUST follow PR-2 scorer parity semantics
 
 #### Scenario: Emit stress diagnostics separately

--- a/openspec/changes/external-matrix-generalization/specs/external-evaluation-matrix/spec.md
+++ b/openspec/changes/external-matrix-generalization/specs/external-evaluation-matrix/spec.md
@@ -1,0 +1,141 @@
+## ADDED Requirements
+
+### Requirement: Generate frozen evaluation plans
+
+The system SHALL generate a frozen external evaluation plan before producing
+any scored external matrix report.
+
+#### Scenario: Plan records frozen inputs
+
+- **WHEN** a caller creates an external matrix plan
+- **THEN** the plan MUST record the run ID, seed, git commit, dirty-state
+  summary, benchmark ID, data root provenance, upstream reference, license
+  note, frozen router configs, field views, tiers, candidate subset sizes, and
+  output paths
+- **AND** the plan MUST be written before any scored matrix output is written
+
+#### Scenario: Matrix requires existing plan
+
+- **WHEN** a caller runs a scored external matrix
+- **THEN** the runner MUST consume an existing frozen plan
+- **AND** it MUST NOT rewrite router IDs, thresholds, prediction paths, field
+  views, tiers, or scoring dimensions from scored-label results
+
+### Requirement: Compare frozen prediction inputs only
+
+The system SHALL compare only frozen routers/configs represented by
+preregistered ranked prediction inputs.
+
+#### Scenario: Run frozen router matrix
+
+- **WHEN** the matrix runner evaluates frozen router configs
+- **THEN** each config MUST identify a router ID, field view, prediction file,
+  top-k or threshold metadata when present, and version metadata
+- **AND** the runner MUST NOT train, tune thresholds, mine hard negatives, run
+  embeddings, run rerankers, run model inference, run live agents, promote
+  routers, or promote release artifacts
+
+### Requirement: Build deterministic field views
+
+The system SHALL build deterministic skill text views for name-only, metadata,
+and full-body comparisons.
+
+#### Scenario: Build skill field views
+
+- **WHEN** the matrix prepares candidate skill text
+- **THEN** `name_only` MUST contain only the skill name
+- **AND** `metadata` MUST contain the skill name plus description metadata
+- **AND** `full_body` MUST contain skill name, description metadata, and body
+  text
+- **AND** each view builder MUST be versioned in the frozen plan or report
+
+### Requirement: Produce official SkillRouter scores and Hermes diagnostics
+
+The system SHALL keep official SkillRouter scoring separate from Hermes
+diagnostics.
+
+#### Scenario: Score full Easy and Hard tiers
+
+- **WHEN** a matrix plan includes SkillRouter Easy and Hard tiers
+- **THEN** the runner MUST invoke the PR-2 official scorer for each frozen
+  router/config and tier
+- **AND** official reports MUST include Easy and Hard scoring over full tier
+  candidate pools
+- **AND** missing task predictions MUST follow PR-2 scorer parity semantics
+
+#### Scenario: Emit stress diagnostics separately
+
+- **WHEN** the matrix computes candidate-pool stress checks
+- **THEN** stress results MUST be written under a Hermes diagnostics namespace
+- **AND** stress subsets MUST NOT be described as official SkillRouter results
+- **AND** Hermes Negative Hit Rate MUST NOT be calculated for SkillRouter
+  unless explicit negative labels exist
+
+### Requirement: Sample deterministic candidate subsets
+
+The system SHALL produce deterministic candidate subsets for Hermes stress
+diagnostics.
+
+#### Scenario: Build candidate subset
+
+- **WHEN** a candidate subset target size is requested
+- **THEN** the subset MUST include all unique selected GT skill IDs before any
+  distractors
+- **AND** distractors MUST be selected by sorting remaining skill IDs by
+  `sha256("20260625:" + skill_id)`
+- **AND** the subset MUST record the selected candidate hash and sampling seed
+
+#### Scenario: Target smaller than GT union
+
+- **WHEN** the requested subset size is smaller than the unique selected GT
+  skill count
+- **THEN** the subset result MUST be field-level `UNAVAILABLE`
+- **AND** it MUST include a reason
+
+### Requirement: Compute paired bootstrap confidence intervals
+
+The system SHALL compute deterministic paired bootstrap confidence intervals
+for frozen router comparisons.
+
+#### Scenario: Bootstrap paired deltas
+
+- **WHEN** two frozen router reports share eligible task-level metric rows
+- **THEN** the confidence interval MUST sample paired task-level metric deltas
+  with seed `20260625`
+- **AND** it MUST report point estimate, lower bound, upper bound, confidence
+  level, iteration count, metric name, and paired task count
+
+### Requirement: Generate leakage and split diagnostics
+
+The system SHALL generate held-out-skill and held-out-source diagnostics for
+external matrix evidence.
+
+#### Scenario: Held-out-skill connected components
+
+- **WHEN** tasks and selected GT skills are available
+- **THEN** held-out-skill split generation MUST use connected components over
+  task-to-selected-GT-skill edges
+- **AND** it MUST report component IDs, task IDs, skill IDs, split assignment,
+  and overlap assertions
+
+#### Scenario: Held-out-source unavailable
+
+- **WHEN** source metadata is missing or insufficient for a held-out-source
+  split
+- **THEN** the held-out-source result MUST be field-level `UNAVAILABLE`
+- **AND** it MUST include a reason
+
+### Requirement: Scaffold SkillRouter and SkillsBench overlap reports
+
+The system SHALL provide a deterministic overlap report scaffold between
+SkillRouter tasks and future SkillsBench live tasks.
+
+#### Scenario: Create overlap scaffold
+
+- **WHEN** SkillRouter tasks are available and SkillsBench live tasks are not
+  selected yet
+- **THEN** the overlap report MUST still include schema version, source counts,
+  exact ID overlap, normalized text hash overlap, and a high-similarity
+  diagnostics placeholder
+- **AND** unavailable live-task inputs MUST be represented as field-level
+  `UNAVAILABLE` with a reason

--- a/openspec/changes/external-matrix-generalization/tasks.md
+++ b/openspec/changes/external-matrix-generalization/tasks.md
@@ -1,0 +1,84 @@
+## 1. OpenSpec And Scope
+
+- [x] 1.1 Create change `external-matrix-generalization` with proposal,
+  design, tasks, and `external-evaluation-matrix` spec.
+- [x] 1.2 Keep PR-3 limited to frozen external matrix planning, scoring
+  orchestration, and diagnostics; do not implement training, threshold tuning,
+  scored-set hard-negative mining, model inference, embeddings, rerankers,
+  live-agent runtime, release promotion, router promotion, or Hermes Negative
+  Hit Rate without explicit negative labels.
+
+## 2. Frozen Plan And Field Views
+
+- [x] 2.1 Add RED tests for frozen evaluation plan generation before scored
+  matrix output, including run ID, seed, git commit, dirty summary, adapter
+  provenance, frozen router configs, field views, tiers, subset sizes, and
+  output paths.
+- [x] 2.2 Implement frozen plan data structures, writer, and validation
+  helpers using the PR-1 adapter/provenance surface.
+- [x] 2.3 Add RED tests for `name_only`, `metadata`, and `full_body` field
+  view builders.
+- [x] 2.4 Implement versioned deterministic field view builders for SkillRouter
+  skill records.
+
+## 3. Official Matrix Scoring
+
+- [x] 3.1 Add RED tests that a matrix run consumes an existing frozen plan and
+  invokes PR-2 official scoring for full Easy/Hard tiers.
+- [x] 3.2 Implement matrix runner orchestration for frozen prediction files
+  without running routers, embeddings, rerankers, models, training, live agents,
+  or release promotion.
+- [x] 3.3 Add RED tests that official results and Hermes diagnostics are
+  separated and that missing predictions follow PR-2 scorer parity semantics.
+
+## 4. Hermes Stress Diagnostics
+
+- [x] 4.1 Add RED tests for deterministic candidate subset sampling that always
+  includes all unique selected GT skills before distractors.
+- [x] 4.2 Add RED tests for `UNAVAILABLE` subset output when the target size is
+  smaller than the selected GT union.
+- [x] 4.3 Implement candidate subset sampling with
+  `sha256("20260625:" + skill_id)` distractor ordering and subset hashes.
+- [x] 4.4 Add RED tests and implementation for Hermes candidate-pool stress
+  diagnostics that never appear as official SkillRouter results.
+
+## 5. Confidence Intervals And Splits
+
+- [x] 5.1 Add RED tests for paired bootstrap confidence intervals using
+  task-level paired metric deltas, seed `20260625`, and deterministic output.
+- [x] 5.2 Implement paired bootstrap confidence interval helpers.
+- [x] 5.3 Add RED tests for held-out-skill split generation using task-skill
+  connected components.
+- [x] 5.4 Implement held-out-skill split generation and overlap assertions.
+- [x] 5.5 Add RED tests for held-out-source field-level `UNAVAILABLE` when
+  source metadata is insufficient.
+- [x] 5.6 Implement held-out-source split diagnostics for sufficient metadata
+  and `UNAVAILABLE` output for insufficient metadata.
+
+## 6. Overlap Scaffold And CLI
+
+- [x] 6.1 Add RED tests for SkillRouter/SkillsBench overlap scaffold with
+  exact ID overlap, normalized text hash overlap, and high-similarity
+  diagnostic placeholder.
+- [x] 6.2 Implement overlap report scaffold that supports missing live tasks as
+  field-level `UNAVAILABLE`.
+- [x] 6.3 Add scoped CLI commands for plan generation and matrix execution.
+- [x] 6.4 Add CLI tests for frozen plan generation and matrix execution on the
+  tiny fixture.
+
+## 7. Documentation And Human Brief
+
+- [x] 7.1 Add concise Chinese Human Brief for PR-3 with status, changed files,
+  verification, limits, and next step.
+- [x] 7.2 Update v0.3 docs only as needed to link PR-3 artifacts without
+  changing historical phase docs or release logic.
+
+## 8. Validation
+
+- [x] 8.1 Run focused external matrix tests.
+- [x] 8.2 Run `python -m pytest -q`.
+- [x] 8.3 Run `OPENSPEC_TELEMETRY=0 openspec validate --all --strict`.
+- [x] 8.4 Run `PYTHONPATH=src python -m hermes_skilleval.cli release-check --phase17-output-dir docs/demo/phase17-calibrated-release-selector --release-output-dir docs/demo/phase18-ci-release-reproducibility`.
+- [x] 8.5 Run `git diff --check`.
+- [x] 8.6 Run v0.3 YAML parse check.
+- [x] 8.7 Run CRLF/new-file line-ending check.

--- a/openspec/changes/external-matrix-generalization/tasks.md
+++ b/openspec/changes/external-matrix-generalization/tasks.md
@@ -14,8 +14,9 @@
   matrix output, including run ID, seed, git commit, dirty summary, adapter
   provenance, frozen router configs, field views, tiers, subset sizes, and
   output paths.
-- [x] 2.2 Implement frozen plan data structures, writer, and validation
-  helpers using the PR-1 adapter/provenance surface.
+- [x] 2.2 Implement frozen plan data structures, writer, prediction file
+  fingerprints, adapter provenance drift checks, and validation helpers using
+  the PR-1 adapter/provenance surface.
 - [x] 2.3 Add RED tests for `name_only`, `metadata`, and `full_body` field
   view builders.
 - [x] 2.4 Implement versioned deterministic field view builders for SkillRouter
@@ -23,8 +24,9 @@
 
 ## 3. Official Matrix Scoring
 
-- [x] 3.1 Add RED tests that a matrix run consumes an existing frozen plan and
-  invokes PR-2 official scoring for full Easy/Hard tiers.
+- [x] 3.1 Add RED tests that a matrix run consumes an existing frozen plan,
+  rejects input drift, preserves config IDs, and invokes PR-2 official scoring
+  for full Easy/Hard tiers.
 - [x] 3.2 Implement matrix runner orchestration for frozen prediction files
   without running routers, embeddings, rerankers, models, training, live agents,
   or release promotion.
@@ -45,7 +47,8 @@
 ## 5. Confidence Intervals And Splits
 
 - [x] 5.1 Add RED tests for paired bootstrap confidence intervals using
-  task-level paired metric deltas, seed `20260625`, and deterministic output.
+  task-level paired metric deltas, frozen plan bootstrap settings, seed
+  `20260625`, and deterministic output.
 - [x] 5.2 Implement paired bootstrap confidence interval helpers.
 - [x] 5.3 Add RED tests for held-out-skill split generation using task-skill
   connected components.

--- a/src/hermes_skilleval/cli.py
+++ b/src/hermes_skilleval/cli.py
@@ -334,7 +334,10 @@ def _build_parser() -> argparse.ArgumentParser:
         "--router-config",
         action="append",
         required=True,
-        help="frozen router config as router_id:field_view:predictions_path",
+        help=(
+            "frozen router config as router_id:field_view:predictions_path "
+            "or config_id:router_id:field_view:predictions_path"
+        ),
     )
     external_plan_parser.add_argument(
         "--field-view",
@@ -355,6 +358,8 @@ def _build_parser() -> argparse.ArgumentParser:
         default=[],
     )
     external_plan_parser.add_argument("--matrix-output", default=None)
+    external_plan_parser.add_argument("--bootstrap-iterations", type=int, default=10000)
+    external_plan_parser.add_argument("--bootstrap-confidence", type=float, default=0.95)
     external_plan_parser.set_defaults(handler=_run_external_plan)
 
     external_matrix_parser = subparsers.add_parser(
@@ -1015,6 +1020,8 @@ def _run_external_plan(args: argparse.Namespace) -> None:
         if args.stress_candidate_size
         else (1000, 10000),
         matrix_output_path=args.matrix_output,
+        bootstrap_iterations=args.bootstrap_iterations,
+        bootstrap_confidence=args.bootstrap_confidence,
     )
     print(
         "External matrix plan "
@@ -1035,18 +1042,29 @@ def _run_external_matrix(args: argparse.Namespace) -> None:
 
 
 def _parse_external_router_config(value: str) -> dict[str, str]:
-    parts = value.split(":", 2)
-    if len(parts) != 3 or not all(part.strip() for part in parts):
+    parts = value.split(":", 3)
+    if len(parts) == 3 and all(part.strip() for part in parts):
+        router_id, field_view, predictions_path = parts
+        return {
+            "router_id": router_id,
+            "field_view": field_view,
+            "predictions_path": predictions_path,
+            "version": "frozen-cli",
+        }
+    if len(parts) == 4 and all(part.strip() for part in parts):
+        config_id, router_id, field_view, predictions_path = parts
+        return {
+            "config_id": config_id,
+            "router_id": router_id,
+            "field_view": field_view,
+            "predictions_path": predictions_path,
+            "version": "frozen-cli",
+        }
+    else:
         raise ValueError(
-            "--router-config must use router_id:field_view:predictions_path"
+            "--router-config must use router_id:field_view:predictions_path "
+            "or config_id:router_id:field_view:predictions_path"
         )
-    router_id, field_view, predictions_path = parts
-    return {
-        "router_id": router_id,
-        "field_view": field_view,
-        "predictions_path": predictions_path,
-        "version": "frozen-cli",
-    }
 
 
 def _parse_ci_checks(values: list[str]) -> list[tuple[str, str]]:

--- a/src/hermes_skilleval/cli.py
+++ b/src/hermes_skilleval/cli.py
@@ -35,6 +35,10 @@ from hermes_skilleval.embedding_training import (
     write_training_pairs,
 )
 from hermes_skilleval.external.skillrouter import write_external_validation
+from hermes_skilleval.external.skillrouter_matrix import (
+    run_skillrouter_matrix,
+    write_skillrouter_matrix_plan,
+)
 from hermes_skilleval.external.skillrouter_scorer import write_skillrouter_score_report
 from hermes_skilleval.failure_analysis import (
     result_paths_from_comparison_dir,
@@ -311,6 +315,60 @@ def _build_parser() -> argparse.ArgumentParser:
         default="core",
     )
     external_score_parser.set_defaults(handler=_run_external_score)
+
+    external_plan_parser = subparsers.add_parser(
+        "external-plan",
+        help="write a frozen external SkillRouter matrix plan without scoring",
+    )
+    external_plan_parser.add_argument(
+        "--benchmark",
+        choices=("skillrouter",),
+        required=True,
+    )
+    external_plan_parser.add_argument("--data-root", required=True)
+    external_plan_parser.add_argument("--output", required=True)
+    external_plan_parser.add_argument("--upstream-ref", required=True)
+    external_plan_parser.add_argument("--license-note", required=True)
+    external_plan_parser.add_argument("--run-id", required=True)
+    external_plan_parser.add_argument(
+        "--router-config",
+        action="append",
+        required=True,
+        help="frozen router config as router_id:field_view:predictions_path",
+    )
+    external_plan_parser.add_argument(
+        "--field-view",
+        choices=("name_only", "metadata", "full_body"),
+        action="append",
+        default=[],
+    )
+    external_plan_parser.add_argument(
+        "--tier",
+        choices=("easy", "hard"),
+        action="append",
+        default=[],
+    )
+    external_plan_parser.add_argument(
+        "--stress-candidate-size",
+        type=int,
+        action="append",
+        default=[],
+    )
+    external_plan_parser.add_argument("--matrix-output", default=None)
+    external_plan_parser.set_defaults(handler=_run_external_plan)
+
+    external_matrix_parser = subparsers.add_parser(
+        "external-matrix",
+        help="run a frozen external SkillRouter matrix from an existing plan",
+    )
+    external_matrix_parser.add_argument(
+        "--benchmark",
+        choices=("skillrouter",),
+        required=True,
+    )
+    external_matrix_parser.add_argument("--plan", required=True)
+    external_matrix_parser.add_argument("--output", required=True)
+    external_matrix_parser.set_defaults(handler=_run_external_matrix)
 
     index_parser = subparsers.add_parser("index", help="scan skills and write an index")
     index_parser.add_argument("--skills-path", required=True)
@@ -935,6 +993,60 @@ def _run_external_score(args: argparse.Namespace) -> None:
         f"{report['mode']}: {args.output} "
         f"({report['task_count']} tasks)"
     )
+
+
+def _run_external_plan(args: argparse.Namespace) -> None:
+    if args.benchmark != "skillrouter":
+        raise ValueError(f"unsupported external benchmark: {args.benchmark}")
+    plan = write_skillrouter_matrix_plan(
+        data_root=args.data_root,
+        output_path=args.output,
+        upstream_ref=args.upstream_ref,
+        license_note=args.license_note,
+        run_id=args.run_id,
+        routers=[_parse_external_router_config(value) for value in args.router_config],
+        field_views=tuple(args.field_view) if args.field_view else (
+            "name_only",
+            "metadata",
+            "full_body",
+        ),
+        tiers=tuple(args.tier) if args.tier else ("easy", "hard"),
+        stress_candidate_sizes=tuple(args.stress_candidate_size)
+        if args.stress_candidate_size
+        else (1000, 10000),
+        matrix_output_path=args.matrix_output,
+    )
+    print(
+        "External matrix plan "
+        f"{plan['run_id']}: {args.output} "
+        f"({len(plan['frozen_routers'])} frozen routers)"
+    )
+
+
+def _run_external_matrix(args: argparse.Namespace) -> None:
+    if args.benchmark != "skillrouter":
+        raise ValueError(f"unsupported external benchmark: {args.benchmark}")
+    report = run_skillrouter_matrix(plan_path=args.plan, output_path=args.output)
+    print(
+        "External matrix "
+        f"{report['run_id']}: {args.output} "
+        f"({len(report['official'])} frozen routers)"
+    )
+
+
+def _parse_external_router_config(value: str) -> dict[str, str]:
+    parts = value.split(":", 2)
+    if len(parts) != 3 or not all(part.strip() for part in parts):
+        raise ValueError(
+            "--router-config must use router_id:field_view:predictions_path"
+        )
+    router_id, field_view, predictions_path = parts
+    return {
+        "router_id": router_id,
+        "field_view": field_view,
+        "predictions_path": predictions_path,
+        "version": "frozen-cli",
+    }
 
 
 def _parse_ci_checks(values: list[str]) -> list[tuple[str, str]]:

--- a/src/hermes_skilleval/external/skillrouter.py
+++ b/src/hermes_skilleval/external/skillrouter.py
@@ -96,6 +96,7 @@ class SkillRouterAdapter:
                 record,
                 (*TASK_ID_FIELDS, *QUERY_FIELDS, *TASK_TYPE_FIELDS),
             )
+            metadata.update(_task_relevance_metadata(relevance_entry))
             tasks.append(
                 ExternalTask(
                     benchmark_id=self.benchmark_id,
@@ -597,6 +598,14 @@ def _first_present(record: dict[str, Any], fields: tuple[str, ...]) -> Any:
 def _metadata_without(record: dict[str, Any], fields: tuple[str, ...]) -> dict[str, Any]:
     excluded = set(fields)
     return {key: value for key, value in record.items() if key not in excluded}
+
+
+def _task_relevance_metadata(entry: dict[str, Any]) -> dict[str, Any]:
+    metadata = {}
+    for field in ("gt_skill_ids", "core_gt_ids", "auxiliary_gt_ids", "task_type"):
+        if field in entry:
+            metadata[field] = entry[field]
+    return metadata
 
 
 def _missing_file_record(role: str, exc: Exception) -> dict[str, Any]:

--- a/src/hermes_skilleval/external/skillrouter_matrix.py
+++ b/src/hermes_skilleval/external/skillrouter_matrix.py
@@ -1,0 +1,547 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import random
+import subprocess
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Iterable
+
+from hermes_skilleval.external.skillrouter import (
+    ExternalSkill,
+    ExternalTask,
+    SkillRouterAdapter,
+)
+from hermes_skilleval.external.skillrouter_scorer import score_skillrouter_predictions
+from hermes_skilleval.provenance import _reject_sensitive_values
+
+
+SEED = 20260625
+FIELD_VIEW_VERSION = "v0.3.pr3.field-view.v1"
+PLAN_SCHEMA = "v0.3.skillrouter-matrix-plan.v1"
+REPORT_SCHEMA = "v0.3.skillrouter-matrix-report.v1"
+UNAVAILABLE = "UNAVAILABLE"
+
+
+def write_skillrouter_matrix_plan(
+    *,
+    data_root: Path | str,
+    output_path: Path | str,
+    upstream_ref: str,
+    license_note: str,
+    run_id: str,
+    routers: Iterable[dict[str, Any]],
+    field_views: Iterable[str] = ("name_only", "metadata", "full_body"),
+    tiers: Iterable[str] = ("easy", "hard"),
+    stress_candidate_sizes: Iterable[int] = (1000, 10000),
+    matrix_output_path: Path | str | None = None,
+) -> dict[str, Any]:
+    router_configs = [_frozen_router_config(router) for router in routers]
+    if not router_configs:
+        raise ValueError("at least one frozen router config is required")
+    selected_field_views = [_field_view_name(view) for view in field_views]
+    selected_tiers = [str(tier) for tier in tiers]
+    selected_sizes = [int(size) for size in stress_candidate_sizes]
+    if any(size <= 0 for size in selected_sizes):
+        raise ValueError("stress candidate sizes must be positive")
+
+    adapter = SkillRouterAdapter(
+        data_root=data_root,
+        upstream_ref=upstream_ref,
+        license_note=license_note,
+    )
+    validation = adapter.validate()
+    if validation["status"] != "PASS":
+        raise ValueError("external validation failed")
+    plan = {
+        "schema_version": PLAN_SCHEMA,
+        "benchmark_id": "skillrouter",
+        "run_id": _non_empty(run_id, "run_id"),
+        "seed": SEED,
+        "created_at": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+        "git": _git_state(),
+        "data_root": str(data_root),
+        "adapter_provenance": adapter.provenance(validation),
+        "validation": validation,
+        "frozen_routers": router_configs,
+        "field_views": selected_field_views,
+        "field_view_builder_version": FIELD_VIEW_VERSION,
+        "tiers": selected_tiers,
+        "stress_candidate_sizes": selected_sizes,
+        "matrix_output_path": str(matrix_output_path) if matrix_output_path else None,
+        "scope_guards": {
+            "prediction_inputs_only": True,
+            "no_training": True,
+            "no_threshold_tuning": True,
+            "no_hard_negative_mining": True,
+            "no_model_inference": True,
+            "no_embeddings": True,
+            "no_rerankers": True,
+            "no_live_agents": True,
+            "no_release_promotion": True,
+            "no_skillrouter_negative_hit_rate_without_negative_labels": True,
+        },
+    }
+    _reject_sensitive_values(plan)
+    output = Path(output_path)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(plan, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return plan
+
+
+def run_skillrouter_matrix(*, plan_path: Path | str, output_path: Path | str) -> dict[str, Any]:
+    plan_file = Path(plan_path)
+    if not plan_file.exists():
+        raise ValueError(f"frozen plan does not exist: {plan_file}")
+    plan = json.loads(plan_file.read_text(encoding="utf-8"))
+    if plan.get("schema_version") != PLAN_SCHEMA:
+        raise ValueError("unsupported frozen plan schema")
+    data_root = Path(_non_empty(plan.get("data_root"), "data_root"))
+    tiers = tuple(plan.get("tiers") or ("easy", "hard"))
+    adapter = SkillRouterAdapter(
+        data_root=data_root,
+        upstream_ref=plan["adapter_provenance"]["upstream_ref"],
+        license_note=plan["adapter_provenance"]["license_note"],
+        tiers=tiers,
+    )
+
+    official: dict[str, Any] = {}
+    for router in plan["frozen_routers"]:
+        router_id = router["router_id"]
+        official[router_id] = {
+            "router_id": router_id,
+            "field_view": router["field_view"],
+            "version": router.get("version"),
+            "score": score_skillrouter_predictions(
+                data_root=data_root,
+                predictions_path=router["predictions_path"],
+                mode="core",
+                tiers=tiers,
+            ),
+        }
+
+    diagnostics = _hermes_diagnostics(adapter, plan, official)
+    report = {
+        "schema_version": REPORT_SCHEMA,
+        "benchmark_id": "skillrouter",
+        "run_id": plan["run_id"],
+        "plan_path": str(plan_file),
+        "seed": plan["seed"],
+        "official": {
+            router_id: router_report["score"] | {
+                "router_id": router_report["router_id"],
+                "field_view": router_report["field_view"],
+                "version": router_report["version"],
+            }
+            for router_id, router_report in official.items()
+        },
+        "hermes_diagnostics": diagnostics,
+    }
+    output = Path(output_path)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(
+        json.dumps(report, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return report
+
+
+def build_field_view(skill: ExternalSkill, view: str) -> dict[str, Any]:
+    selected_view = _field_view_name(view)
+    parts = [skill.name]
+    if selected_view in {"metadata", "full_body"} and skill.description:
+        parts.append(skill.description)
+    if selected_view == "full_body" and skill.body:
+        parts.append(skill.body)
+    return {
+        "schema_version": "v0.3.skillrouter-field-view.v1",
+        "view": selected_view,
+        "builder_version": FIELD_VIEW_VERSION,
+        "skill_id": skill.skill_id,
+        "text": "\n".join(parts),
+    }
+
+
+def candidate_subset(
+    *,
+    all_skill_ids: Iterable[str],
+    gt_skill_ids: Iterable[str],
+    target_size: int,
+    seed: int = SEED,
+) -> dict[str, Any]:
+    gt_ids = _unique(gt_skill_ids)
+    if target_size < len(gt_ids):
+        return {
+            "status": UNAVAILABLE,
+            "reason": (
+                f"target_size {target_size} is smaller than selected GT union "
+                f"{len(gt_ids)}"
+            ),
+            "seed": seed,
+            "target_size": target_size,
+            "required_gt_count": len(gt_ids),
+        }
+    gt_set = set(gt_ids)
+    distractors = sorted(
+        (skill_id for skill_id in _unique(all_skill_ids) if skill_id not in gt_set),
+        key=lambda skill_id: hashlib.sha256(f"{seed}:{skill_id}".encode()).hexdigest(),
+    )
+    selected = gt_ids + distractors[: max(0, target_size - len(gt_ids))]
+    return {
+        "status": "PASS",
+        "seed": seed,
+        "target_size": target_size,
+        "required_gt_count": len(gt_ids),
+        "selected_skill_ids": selected,
+        "candidate_hash": _hash_json(selected),
+    }
+
+
+def paired_bootstrap_ci(
+    rows_a: list[dict[str, Any]],
+    rows_b: list[dict[str, Any]],
+    *,
+    metric: str,
+    iterations: int = 1000,
+    seed: int = SEED,
+    confidence: float = 0.95,
+) -> dict[str, Any]:
+    by_task_b = {row["task_id"]: row for row in rows_b}
+    deltas = [
+        float(row["metrics"][metric])
+        - float(by_task_b[row["task_id"]]["metrics"][metric])
+        for row in rows_a
+        if row["task_id"] in by_task_b
+        and metric in row.get("metrics", {})
+        and metric in by_task_b[row["task_id"]].get("metrics", {})
+    ]
+    if not deltas:
+        return {
+            "schema_version": "v0.3.paired-bootstrap-ci.v1",
+            "status": UNAVAILABLE,
+            "reason": "no paired task metric rows",
+            "metric": metric,
+            "paired_task_count": 0,
+        }
+    rng = random.Random(seed)
+    estimates = []
+    for _ in range(iterations):
+        sample = [deltas[rng.randrange(len(deltas))] for _ in deltas]
+        estimates.append(sum(sample) / len(sample))
+    estimates.sort()
+    alpha = 1.0 - confidence
+    lower = estimates[max(0, int(math.floor((alpha / 2) * (iterations - 1))))]
+    upper = estimates[min(iterations - 1, int(math.ceil((1 - alpha / 2) * (iterations - 1))))]
+    return {
+        "schema_version": "v0.3.paired-bootstrap-ci.v1",
+        "status": "PASS",
+        "metric": metric,
+        "seed": seed,
+        "iterations": iterations,
+        "confidence": confidence,
+        "paired_task_count": len(deltas),
+        "point_estimate": sum(deltas) / len(deltas),
+        "lower": lower,
+        "upper": upper,
+    }
+
+
+def held_out_skill_split(tasks: list[ExternalTask]) -> dict[str, Any]:
+    graph: dict[str, set[str]] = {}
+    node_kind: dict[str, str] = {}
+    for task in tasks:
+        task_node = f"task:{task.task_id}"
+        graph.setdefault(task_node, set())
+        node_kind[task_node] = "task"
+        for skill_id in _selected_task_gt_ids(task):
+            skill_node = f"skill:{skill_id}"
+            graph.setdefault(skill_node, set())
+            node_kind[skill_node] = "skill"
+            graph[task_node].add(skill_node)
+            graph[skill_node].add(task_node)
+
+    components = []
+    seen: set[str] = set()
+    for node in sorted(graph):
+        if node in seen:
+            continue
+        stack = [node]
+        component: set[str] = set()
+        seen.add(node)
+        while stack:
+            current = stack.pop()
+            component.add(current)
+            for neighbor in graph[current]:
+                if neighbor not in seen:
+                    seen.add(neighbor)
+                    stack.append(neighbor)
+        task_ids = sorted(item.removeprefix("task:") for item in component if item.startswith("task:"))
+        skill_ids = sorted(item.removeprefix("skill:") for item in component if item.startswith("skill:"))
+        task_type = "generic_only" if task_ids and not skill_ids else "scored"
+        components.append(
+            {
+                "component_id": f"component-{len(components):03d}",
+                "task_ids": task_ids,
+                "skill_ids": skill_ids,
+                "task_type": task_type,
+                "split": "held_out" if len(components) % 2 else "train",
+            }
+        )
+    train_tasks = {
+        task_id
+        for component in components
+        if component["split"] == "train"
+        for task_id in component["task_ids"]
+    }
+    held_out_tasks = {
+        task_id
+        for component in components
+        if component["split"] == "held_out"
+        for task_id in component["task_ids"]
+    }
+    train_skills = {
+        skill_id
+        for component in components
+        if component["split"] == "train"
+        for skill_id in component["skill_ids"]
+    }
+    held_out_skills = {
+        skill_id
+        for component in components
+        if component["split"] == "held_out"
+        for skill_id in component["skill_ids"]
+    }
+    return {
+        "schema_version": "v0.3.held-out-skill-split.v1",
+        "status": "PASS",
+        "components": components,
+        "overlap_assertions": {
+            "task_overlap": sorted(train_tasks & held_out_tasks),
+            "skill_overlap": sorted(train_skills & held_out_skills),
+        },
+    }
+
+
+def held_out_source_split(tasks: list[ExternalTask]) -> dict[str, Any]:
+    sources_by_task = {}
+    for task in tasks:
+        source = (
+            task.metadata.get("source")
+            or task.metadata.get("source_path")
+            or task.metadata.get("path")
+        )
+        if not isinstance(source, str) or not source.strip():
+            return {
+                "schema_version": "v0.3.held-out-source-split.v1",
+                "status": UNAVAILABLE,
+                "reason": "source metadata is insufficient for held-out-source split",
+            }
+        sources_by_task[task.task_id] = source
+    sources = sorted(set(sources_by_task.values()))
+    if len(sources) < 2:
+        return {
+            "schema_version": "v0.3.held-out-source-split.v1",
+            "status": UNAVAILABLE,
+            "reason": (
+                "source metadata is insufficient for held-out-source split: "
+                "at least two distinct sources are required"
+            ),
+        }
+    held_out_sources = set(sources[1::2])
+    return {
+        "schema_version": "v0.3.held-out-source-split.v1",
+        "status": "PASS",
+        "held_out_sources": sorted(held_out_sources),
+        "assignments": {
+            task_id: "held_out" if source in held_out_sources else "train"
+            for task_id, source in sorted(sources_by_task.items())
+        },
+    }
+
+
+def overlap_scaffold(
+    *,
+    skillrouter_tasks: list[ExternalTask],
+    skillsbench_tasks: list[dict[str, Any]] | None,
+) -> dict[str, Any]:
+    if skillsbench_tasks is None:
+        return {
+            "schema_version": "v0.3.skillrouter-skillsbench-overlap.v1",
+            "skillrouter_task_count": len(skillrouter_tasks),
+            "skillsbench_task_count": {
+                "status": UNAVAILABLE,
+                "reason": "SkillsBench live tasks not selected in PR-3",
+            },
+            "exact_id_overlap": [],
+            "normalized_text_hash_overlap": [],
+            "high_similarity_diagnostics": {
+                "status": UNAVAILABLE,
+                "reason": "high-similarity diagnostics require selected live tasks",
+            },
+        }
+    skillrouter_by_id = {task.task_id: task for task in skillrouter_tasks}
+    skillsbench_by_id = {
+        str(task["task_id"]): task for task in skillsbench_tasks if "task_id" in task
+    }
+    sr_hashes = {_normalized_hash(task.query): task.task_id for task in skillrouter_tasks}
+    sb_hashes = {
+        _normalized_hash(str(task.get("query", ""))): task_id
+        for task_id, task in skillsbench_by_id.items()
+    }
+    return {
+        "schema_version": "v0.3.skillrouter-skillsbench-overlap.v1",
+        "skillrouter_task_count": len(skillrouter_tasks),
+        "skillsbench_task_count": len(skillsbench_tasks),
+        "exact_id_overlap": sorted(set(skillrouter_by_id) & set(skillsbench_by_id)),
+        "normalized_text_hash_overlap": sorted(set(sr_hashes) & set(sb_hashes)),
+        "high_similarity_diagnostics": {
+            "status": UNAVAILABLE,
+            "reason": "high-similarity diagnostics not selected in PR-3",
+        },
+    }
+
+
+def _hermes_diagnostics(
+    adapter: SkillRouterAdapter,
+    plan: dict[str, Any],
+    official: dict[str, Any],
+) -> dict[str, Any]:
+    stress: dict[str, dict[str, Any]] = {}
+    for tier in plan["tiers"]:
+        skills = list(adapter.iter_skills(tier))
+        all_skill_ids = [skill.skill_id for skill in skills]
+        gt_skill_ids = _selected_gt_union(adapter, tier)
+        stress[tier] = {
+            str(size): candidate_subset(
+                all_skill_ids=all_skill_ids,
+                gt_skill_ids=gt_skill_ids,
+                target_size=int(size),
+                seed=int(plan["seed"]),
+            )
+            for size in plan["stress_candidate_sizes"]
+        }
+
+    ci: dict[str, Any] = {}
+    router_ids = list(official)
+    if len(router_ids) >= 2:
+        for first_index, first in enumerate(router_ids):
+            for second in router_ids[first_index + 1 :]:
+                for tier in plan["tiers"]:
+                    rows_a = official[first]["score"]["by_tier"][tier]["tasks"]
+                    rows_b = official[second]["score"]["by_tier"][tier]["tasks"]
+                    ci[f"{first}__minus__{second}__{tier}__MRR@10"] = paired_bootstrap_ci(
+                        rows_a,
+                        rows_b,
+                        metric="MRR@10",
+                        iterations=200,
+                        seed=int(plan["seed"]),
+                    )
+
+    tasks = adapter.load_tasks()
+    return {
+        "schema_version": "v0.3.skillrouter-hermes-diagnostics.v1",
+        "field_view_builder_version": FIELD_VIEW_VERSION,
+        "candidate_count_by_tier": {
+            tier: sum(1 for _ in adapter.iter_skills(tier)) for tier in plan["tiers"]
+        },
+        "stress_candidate_subsets": stress,
+        "paired_bootstrap_confidence_intervals": ci,
+        "held_out_skill": held_out_skill_split(tasks),
+        "held_out_source": held_out_source_split(tasks),
+        "skillrouter_skillsbench_overlap": overlap_scaffold(
+            skillrouter_tasks=tasks,
+            skillsbench_tasks=None,
+        ),
+    }
+
+
+def _selected_gt_union(adapter: SkillRouterAdapter, tier: str) -> list[str]:
+    relevance_entries = adapter._load_relevance_entries()
+    tier_pool = {skill.skill_id for skill in adapter.iter_skills(tier)}
+    gt_ids = []
+    for task in adapter.load_tasks():
+        entry = relevance_entries.get(task.task_id, {})
+        if task.task_type == "generic_only":
+            continue
+        selected = _selected_gt_ids(entry)
+        gt_ids.extend(skill_id for skill_id in selected if skill_id in tier_pool)
+    return _unique(gt_ids)
+
+
+def _selected_task_gt_ids(task: ExternalTask) -> list[str]:
+    for field in ("core_gt_ids", "gt_skill_ids"):
+        values = task.metadata.get(field)
+        if isinstance(values, list):
+            return [item for item in values if isinstance(item, str)]
+    return [
+        skill_id
+        for skill_id, relevance in task.graded_relevance.items()
+        if str(skill_id).startswith("gt/") and float(relevance) > 0
+    ]
+
+
+def _selected_gt_ids(entry: dict[str, Any]) -> list[str]:
+    if "core_gt_ids" in entry:
+        return [item for item in entry.get("core_gt_ids", []) if isinstance(item, str)]
+    return [item for item in entry.get("gt_skill_ids", []) if isinstance(item, str)]
+
+
+def _frozen_router_config(router: dict[str, Any]) -> dict[str, Any]:
+    router_id = _non_empty(router.get("router_id"), "router_id")
+    field_view = _field_view_name(router.get("field_view", "full_body"))
+    predictions_path = _non_empty(router.get("predictions_path"), "predictions_path")
+    if not Path(predictions_path).exists():
+        raise ValueError(f"predictions file does not exist: {predictions_path}")
+    config = {
+        "router_id": router_id,
+        "field_view": field_view,
+        "predictions_path": predictions_path,
+        "version": router.get("version", "UNSPECIFIED"),
+        "top_k": router.get("top_k"),
+        "threshold": router.get("threshold"),
+        "normalization": router.get("normalization"),
+    }
+    _reject_sensitive_values(config)
+    return config
+
+
+def _field_view_name(view: Any) -> str:
+    if view not in {"name_only", "metadata", "full_body"}:
+        raise ValueError(f"unsupported SkillRouter field view: {view}")
+    return str(view)
+
+
+def _non_empty(value: Any, field: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{field} must be a non-empty string")
+    return value
+
+
+def _git_state() -> dict[str, Any]:
+    return {
+        "commit": _git_output(("rev-parse", "HEAD")) or "UNKNOWN",
+        "dirty": bool(_git_output(("status", "--porcelain"))),
+    }
+
+
+def _git_output(args: tuple[str, ...]) -> str:
+    try:
+        return subprocess.check_output(("git", *args), text=True, stderr=subprocess.DEVNULL).strip()
+    except (OSError, subprocess.CalledProcessError):
+        return ""
+
+
+def _unique(values: Iterable[str]) -> list[str]:
+    return list(dict.fromkeys(str(value) for value in values))
+
+
+def _hash_json(value: Any) -> str:
+    payload = json.dumps(value, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(payload.encode()).hexdigest()
+
+
+def _normalized_hash(text: str) -> str:
+    normalized = " ".join(text.casefold().split())
+    return hashlib.sha256(normalized.encode()).hexdigest()

--- a/src/hermes_skilleval/external/skillrouter_matrix.py
+++ b/src/hermes_skilleval/external/skillrouter_matrix.py
@@ -16,6 +16,7 @@ from hermes_skilleval.external.skillrouter import (
 )
 from hermes_skilleval.external.skillrouter_scorer import score_skillrouter_predictions
 from hermes_skilleval.provenance import _reject_sensitive_values
+from hermes_skilleval.release_manifest import sha256_file
 
 
 SEED = 20260625
@@ -37,15 +38,22 @@ def write_skillrouter_matrix_plan(
     tiers: Iterable[str] = ("easy", "hard"),
     stress_candidate_sizes: Iterable[int] = (1000, 10000),
     matrix_output_path: Path | str | None = None,
+    bootstrap_iterations: int = 10000,
+    bootstrap_confidence: float = 0.95,
 ) -> dict[str, Any]:
     router_configs = [_frozen_router_config(router) for router in routers]
     if not router_configs:
         raise ValueError("at least one frozen router config is required")
+    _assert_unique_config_ids(router_configs)
     selected_field_views = [_field_view_name(view) for view in field_views]
     selected_tiers = [str(tier) for tier in tiers]
     selected_sizes = [int(size) for size in stress_candidate_sizes]
     if any(size <= 0 for size in selected_sizes):
         raise ValueError("stress candidate sizes must be positive")
+    if bootstrap_iterations <= 0:
+        raise ValueError("bootstrap iterations must be positive")
+    if not 0.0 < bootstrap_confidence < 1.0:
+        raise ValueError("bootstrap confidence must be between 0 and 1")
 
     adapter = SkillRouterAdapter(
         data_root=data_root,
@@ -70,6 +78,10 @@ def write_skillrouter_matrix_plan(
         "field_view_builder_version": FIELD_VIEW_VERSION,
         "tiers": selected_tiers,
         "stress_candidate_sizes": selected_sizes,
+        "bootstrap": {
+            "iterations": bootstrap_iterations,
+            "confidence": bootstrap_confidence,
+        },
         "matrix_output_path": str(matrix_output_path) if matrix_output_path else None,
         "scope_guards": {
             "prediction_inputs_only": True,
@@ -98,6 +110,8 @@ def run_skillrouter_matrix(*, plan_path: Path | str, output_path: Path | str) ->
     plan = json.loads(plan_file.read_text(encoding="utf-8"))
     if plan.get("schema_version") != PLAN_SCHEMA:
         raise ValueError("unsupported frozen plan schema")
+    _validate_frozen_plan(plan)
+    _verify_matrix_output_path(plan, output_path)
     data_root = Path(_non_empty(plan.get("data_root"), "data_root"))
     tiers = tuple(plan.get("tiers") or ("easy", "hard"))
     adapter = SkillRouterAdapter(
@@ -106,12 +120,15 @@ def run_skillrouter_matrix(*, plan_path: Path | str, output_path: Path | str) ->
         license_note=plan["adapter_provenance"]["license_note"],
         tiers=tiers,
     )
+    _verify_adapter_provenance(adapter, plan)
+    _verify_frozen_predictions(plan)
 
     official: dict[str, Any] = {}
     for router in plan["frozen_routers"]:
-        router_id = router["router_id"]
-        official[router_id] = {
-            "router_id": router_id,
+        config_id = router["config_id"]
+        official[config_id] = {
+            "config_id": config_id,
+            "router_id": router["router_id"],
             "field_view": router["field_view"],
             "version": router.get("version"),
             "score": score_skillrouter_predictions(
@@ -130,12 +147,13 @@ def run_skillrouter_matrix(*, plan_path: Path | str, output_path: Path | str) ->
         "plan_path": str(plan_file),
         "seed": plan["seed"],
         "official": {
-            router_id: router_report["score"] | {
+            config_id: router_report["score"] | {
+                "config_id": router_report["config_id"],
                 "router_id": router_report["router_id"],
                 "field_view": router_report["field_view"],
                 "version": router_report["version"],
             }
-            for router_id, router_report in official.items()
+            for config_id, router_report in official.items()
         },
         "hermes_diagnostics": diagnostics,
     }
@@ -431,12 +449,14 @@ def _hermes_diagnostics(
                 for tier in plan["tiers"]:
                     rows_a = official[first]["score"]["by_tier"][tier]["tasks"]
                     rows_b = official[second]["score"]["by_tier"][tier]["tasks"]
+                    bootstrap = plan.get("bootstrap", {})
                     ci[f"{first}__minus__{second}__{tier}__MRR@10"] = paired_bootstrap_ci(
                         rows_a,
                         rows_b,
                         metric="MRR@10",
-                        iterations=200,
+                        iterations=int(bootstrap.get("iterations", 10000)),
                         seed=int(plan["seed"]),
+                        confidence=float(bootstrap.get("confidence", 0.95)),
                     )
 
     tasks = adapter.load_tasks()
@@ -492,12 +512,16 @@ def _frozen_router_config(router: dict[str, Any]) -> dict[str, Any]:
     router_id = _non_empty(router.get("router_id"), "router_id")
     field_view = _field_view_name(router.get("field_view", "full_body"))
     predictions_path = _non_empty(router.get("predictions_path"), "predictions_path")
-    if not Path(predictions_path).exists():
+    prediction_file = Path(predictions_path)
+    if not prediction_file.exists():
         raise ValueError(f"predictions file does not exist: {predictions_path}")
+    config_id = router.get("config_id") or f"{router_id}__{field_view}"
     config = {
+        "config_id": _non_empty(config_id, "config_id"),
         "router_id": router_id,
         "field_view": field_view,
         "predictions_path": predictions_path,
+        "prediction_file": _file_fingerprint(prediction_file),
         "version": router.get("version", "UNSPECIFIED"),
         "top_k": router.get("top_k"),
         "threshold": router.get("threshold"),
@@ -505,6 +529,85 @@ def _frozen_router_config(router: dict[str, Any]) -> dict[str, Any]:
     }
     _reject_sensitive_values(config)
     return config
+
+
+def _assert_unique_config_ids(router_configs: list[dict[str, Any]]) -> None:
+    seen = set()
+    for config in router_configs:
+        config_id = config["config_id"]
+        if config_id in seen:
+            raise ValueError(f"duplicate config_id: {config_id}")
+        seen.add(config_id)
+
+
+def _validate_frozen_plan(plan: dict[str, Any]) -> None:
+    _assert_unique_config_ids(plan.get("frozen_routers", []))
+    bootstrap = plan.get("bootstrap")
+    if not isinstance(bootstrap, dict):
+        raise ValueError("bootstrap settings must be frozen in the plan")
+    iterations = bootstrap.get("iterations")
+    confidence = bootstrap.get("confidence")
+    if not isinstance(iterations, int) or iterations <= 0:
+        raise ValueError("bootstrap settings must include positive iterations")
+    if not isinstance(confidence, (int, float)) or not 0.0 < float(confidence) < 1.0:
+        raise ValueError("bootstrap settings must include confidence between 0 and 1")
+
+
+def _verify_matrix_output_path(plan: dict[str, Any], output_path: Path | str) -> None:
+    expected = plan.get("matrix_output_path")
+    if expected and str(output_path) != expected:
+        raise ValueError(
+            "matrix output path does not match frozen plan: "
+            f"expected {expected}, got {output_path}"
+        )
+
+
+def _verify_adapter_provenance(
+    adapter: SkillRouterAdapter,
+    plan: dict[str, Any],
+) -> None:
+    validation = adapter.validate()
+    if validation["status"] != "PASS":
+        raise ValueError("external validation failed")
+    current = _adapter_file_fingerprints(adapter.provenance(validation))
+    frozen = _adapter_file_fingerprints(plan["adapter_provenance"])
+    if current != frozen:
+        raise ValueError("adapter provenance changed since frozen plan")
+
+
+def _verify_frozen_predictions(plan: dict[str, Any]) -> None:
+    for router in plan["frozen_routers"]:
+        current = _file_fingerprint(Path(router["predictions_path"]))
+        frozen = router.get("prediction_file")
+        if current != frozen:
+            raise ValueError(
+                "prediction file changed since frozen plan: "
+                f"{router['config_id']}"
+            )
+
+
+def _adapter_file_fingerprints(provenance: dict[str, Any]) -> list[dict[str, Any]]:
+    return sorted(
+        (
+            {
+                "path": record.get("path"),
+                "role": record.get("role"),
+                "size_bytes": record.get("size_bytes"),
+                "sha256": record.get("sha256"),
+                "record_count": record.get("record_count"),
+            }
+            for record in provenance.get("files", [])
+        ),
+        key=lambda record: (str(record["role"]), str(record["path"])),
+    )
+
+
+def _file_fingerprint(path: Path) -> dict[str, Any]:
+    return {
+        "path": str(path),
+        "size_bytes": path.stat().st_size,
+        "sha256": sha256_file(path),
+    }
 
 
 def _field_view_name(view: Any) -> str:

--- a/tests/test_external_skillrouter_adapter.py
+++ b/tests/test_external_skillrouter_adapter.py
@@ -87,6 +87,15 @@ def test_skillrouter_adapter_loads_official_eval_core_fixture():
     assert task_by_id["task-single-easy"].metadata["skill_names"] == ["Browser Login"]
     assert task_by_id["task-single-easy"].metadata["domain"] == "web"
     assert task_by_id["task-single-easy"].metadata["excluded"] is False
+    assert task_by_id["task-single-easy"].metadata["gt_skill_ids"] == [
+        "gt/browser-login"
+    ]
+    assert task_by_id["task-single-easy"].metadata["core_gt_ids"] == [
+        "gt/browser-login"
+    ]
+    assert task_by_id["task-single-easy"].metadata["auxiliary_gt_ids"] == [
+        "degraded/browser-login"
+    ]
     assert task_by_id["task-single-easy"].graded_relevance == {
         "gt/browser-login": 3,
         "degraded/browser-login": 1,

--- a/tests/test_external_skillrouter_matrix.py
+++ b/tests/test_external_skillrouter_matrix.py
@@ -45,6 +45,7 @@ def test_skillrouter_matrix_plan_freezes_inputs_before_scoring(tmp_path):
         tiers=("easy", "hard"),
         stress_candidate_sizes=(1, 3, 10),
         matrix_output_path=matrix_output,
+        bootstrap_iterations=200,
     )
 
     assert plan_path.exists()
@@ -57,11 +58,16 @@ def test_skillrouter_matrix_plan_freezes_inputs_before_scoring(tmp_path):
     assert written["benchmark_id"] == "skillrouter"
     assert written["adapter_provenance"]["upstream_ref"] == "fixture-ref"
     assert written["adapter_provenance"]["license_note"] == "fixture-only"
+    assert written["frozen_routers"][0]["config_id"] == "baseline-minilm__name_only"
     assert written["frozen_routers"][0]["router_id"] == "baseline-minilm"
     assert written["frozen_routers"][0]["field_view"] == "name_only"
+    assert written["frozen_routers"][0]["prediction_file"]["size_bytes"] > 0
+    assert written["frozen_routers"][0]["prediction_file"]["sha256"]
     assert written["field_views"] == ["name_only", "metadata", "full_body"]
     assert written["tiers"] == ["easy", "hard"]
     assert written["stress_candidate_sizes"] == [1, 3, 10]
+    assert written["bootstrap"]["iterations"] == 200
+    assert written["bootstrap"]["confidence"] == 0.95
     assert written["matrix_output_path"] == str(matrix_output)
     assert written["git"]["commit"]
     assert "dirty" in written["git"]
@@ -111,6 +117,7 @@ def test_skillrouter_matrix_uses_plan_and_separates_official_from_diagnostics(tm
         ],
         stress_candidate_sizes=(1, 3),
         matrix_output_path=output_path,
+        bootstrap_iterations=200,
     )
 
     report = run_skillrouter_matrix(plan_path=plan_path, output_path=output_path)
@@ -118,9 +125,12 @@ def test_skillrouter_matrix_uses_plan_and_separates_official_from_diagnostics(tm
     assert output_path.exists()
     assert report["schema_version"] == "v0.3.skillrouter-matrix-report.v1"
     assert report["plan_path"] == str(plan_path)
-    assert set(report["official"]) == {"baseline-minilm", "finetuned-embedding"}
-    easy = report["official"]["baseline-minilm"]["by_tier"]["easy"]
-    hard = report["official"]["baseline-minilm"]["by_tier"]["hard"]
+    assert set(report["official"]) == {
+        "baseline-minilm__name_only",
+        "finetuned-embedding__full_body",
+    }
+    easy = report["official"]["baseline-minilm__name_only"]["by_tier"]["easy"]
+    hard = report["official"]["baseline-minilm__name_only"]["by_tier"]["hard"]
     assert easy["aggregates"]["all"]["task_count"] == 2
     assert hard["aggregates"]["all"]["task_count"] == 1
     assert "hermes_diagnostics" in report
@@ -163,19 +173,23 @@ def test_skillrouter_matrix_emits_pairwise_ci_for_all_router_pairs(tmp_path):
             },
         ],
         matrix_output_path=output_path,
+        bootstrap_iterations=200,
     )
 
     report = run_skillrouter_matrix(plan_path=plan_path, output_path=output_path)
 
     ci_keys = report["hermes_diagnostics"]["paired_bootstrap_confidence_intervals"]
     assert {
-        "baseline-minilm__minus__finetuned-embedding__easy__MRR@10",
-        "baseline-minilm__minus__lexical-control__easy__MRR@10",
-        "finetuned-embedding__minus__lexical-control__easy__MRR@10",
-        "baseline-minilm__minus__finetuned-embedding__hard__MRR@10",
-        "baseline-minilm__minus__lexical-control__hard__MRR@10",
-        "finetuned-embedding__minus__lexical-control__hard__MRR@10",
+        "baseline-minilm__name_only__minus__finetuned-embedding__metadata__easy__MRR@10",
+        "baseline-minilm__name_only__minus__lexical-control__full_body__easy__MRR@10",
+        "finetuned-embedding__metadata__minus__lexical-control__full_body__easy__MRR@10",
+        "baseline-minilm__name_only__minus__finetuned-embedding__metadata__hard__MRR@10",
+        "baseline-minilm__name_only__minus__lexical-control__full_body__hard__MRR@10",
+        "finetuned-embedding__metadata__minus__lexical-control__full_body__hard__MRR@10",
     } <= set(ci_keys)
+    assert ci_keys[
+        "baseline-minilm__name_only__minus__finetuned-embedding__metadata__easy__MRR@10"
+    ]["iterations"] == 200
 
 
 def test_skillrouter_matrix_refuses_missing_plan(tmp_path):
@@ -188,6 +202,210 @@ def test_skillrouter_matrix_refuses_missing_plan(tmp_path):
         assert "frozen plan" in str(exc)
     else:
         raise AssertionError("missing frozen plan should fail closed")
+
+
+def test_skillrouter_matrix_fails_when_predictions_change_after_plan(tmp_path):
+    root, plan_path, output_path = _frozen_fixture_plan(tmp_path)
+    predictions = root / "predictions.json"
+    payload = json.loads(predictions.read_text(encoding="utf-8"))
+    payload["task-single-easy"] = ["gt/browser-login"]
+    predictions.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+
+    try:
+        run_skillrouter_matrix(plan_path=plan_path, output_path=output_path)
+    except ValueError as exc:
+        assert "prediction file changed" in str(exc)
+    else:
+        raise AssertionError("mutated predictions must fail closed")
+
+
+def test_skillrouter_matrix_fails_when_relevance_changes_after_plan(tmp_path):
+    root, plan_path, output_path = _frozen_fixture_plan(tmp_path)
+    relevance = root / "relevance.json"
+    payload = json.loads(relevance.read_text(encoding="utf-8"))
+    payload["task-single-easy"]["relevance"]["gt/browser-login"] = 2
+    relevance.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+
+    try:
+        run_skillrouter_matrix(plan_path=plan_path, output_path=output_path)
+    except ValueError as exc:
+        assert "adapter provenance changed" in str(exc)
+    else:
+        raise AssertionError("mutated relevance must fail closed")
+
+
+def test_skillrouter_matrix_fails_when_skill_shard_changes_after_plan(tmp_path):
+    root, plan_path, output_path = _frozen_fixture_plan(tmp_path)
+    with gzip.open(root / "easy" / "shard-000.jsonl.gz", "at", encoding="utf-8") as file:
+        file.write(
+            json.dumps(
+                {
+                    "id": "gt/new-distractor",
+                    "name": "New Distractor",
+                    "description": "Changes frozen easy pool",
+                    "body": "This should invalidate the frozen plan.",
+                    "tier": "easy",
+                },
+                sort_keys=True,
+            )
+            + "\n"
+        )
+
+    try:
+        run_skillrouter_matrix(plan_path=plan_path, output_path=output_path)
+    except ValueError as exc:
+        assert "adapter provenance changed" in str(exc)
+    else:
+        raise AssertionError("mutated shard must fail closed")
+
+
+def test_skillrouter_matrix_passes_when_frozen_inputs_are_unchanged(tmp_path):
+    _, plan_path, output_path = _frozen_fixture_plan(tmp_path)
+
+    report = run_skillrouter_matrix(plan_path=plan_path, output_path=output_path)
+
+    assert output_path.exists()
+    assert report["official"]["baseline-minilm__name_only"]["router_id"] == (
+        "baseline-minilm"
+    )
+
+
+def test_skillrouter_matrix_output_must_match_frozen_plan(tmp_path):
+    _, plan_path, _ = _frozen_fixture_plan(tmp_path)
+
+    try:
+        run_skillrouter_matrix(
+            plan_path=plan_path,
+            output_path=tmp_path / "different.json",
+        )
+    except ValueError as exc:
+        assert "matrix output path" in str(exc)
+    else:
+        raise AssertionError("output path mismatch must fail closed")
+
+
+def test_skillrouter_matrix_same_router_field_views_get_distinct_config_ids(tmp_path):
+    plan_path = tmp_path / "plan.json"
+    output_path = tmp_path / "matrix.json"
+    write_skillrouter_matrix_plan(
+        data_root=FIXTURE,
+        output_path=plan_path,
+        upstream_ref="fixture-ref",
+        license_note="fixture-only",
+        run_id="matrix-run",
+        routers=[
+            {
+                "router_id": "baseline-minilm",
+                "field_view": "name_only",
+                "predictions_path": str(PREDICTIONS),
+            },
+            {
+                "router_id": "baseline-minilm",
+                "field_view": "metadata",
+                "predictions_path": str(PREDICTIONS),
+            },
+            {
+                "router_id": "baseline-minilm",
+                "field_view": "full_body",
+                "predictions_path": str(PREDICTIONS),
+            },
+        ],
+        matrix_output_path=output_path,
+        bootstrap_iterations=200,
+    )
+
+    report = run_skillrouter_matrix(plan_path=plan_path, output_path=output_path)
+
+    assert set(report["official"]) == {
+        "baseline-minilm__name_only",
+        "baseline-minilm__metadata",
+        "baseline-minilm__full_body",
+    }
+    for config_id, config_report in report["official"].items():
+        assert config_report["router_id"] == "baseline-minilm"
+        assert config_report["field_view"] in config_id
+
+
+def test_skillrouter_matrix_rejects_duplicate_config_id(tmp_path):
+    try:
+        write_skillrouter_matrix_plan(
+            data_root=FIXTURE,
+            output_path=tmp_path / "plan.json",
+            upstream_ref="fixture-ref",
+            license_note="fixture-only",
+            run_id="matrix-run",
+            routers=[
+                {
+                    "config_id": "duplicate",
+                    "router_id": "baseline-minilm",
+                    "field_view": "name_only",
+                    "predictions_path": str(PREDICTIONS),
+                },
+                {
+                    "config_id": "duplicate",
+                    "router_id": "baseline-minilm",
+                    "field_view": "metadata",
+                    "predictions_path": str(PREDICTIONS),
+                },
+            ],
+        )
+    except ValueError as exc:
+        assert "duplicate config_id" in str(exc)
+    else:
+        raise AssertionError("duplicate config_id must fail closed")
+
+
+def test_skillrouter_matrix_rejects_duplicate_config_id_in_existing_plan(tmp_path):
+    _, plan_path, output_path = _frozen_fixture_plan(tmp_path)
+    plan = json.loads(plan_path.read_text(encoding="utf-8"))
+    duplicate = dict(plan["frozen_routers"][0])
+    duplicate["field_view"] = "metadata"
+    plan["frozen_routers"].append(duplicate)
+    plan_path.write_text(json.dumps(plan, indent=2, sort_keys=True) + "\n")
+
+    try:
+        run_skillrouter_matrix(plan_path=plan_path, output_path=output_path)
+    except ValueError as exc:
+        assert "duplicate config_id" in str(exc)
+    else:
+        raise AssertionError("duplicate config_id in plan must fail closed")
+
+
+def test_skillrouter_matrix_requires_bootstrap_settings_in_existing_plan(tmp_path):
+    _, plan_path, output_path = _frozen_fixture_plan(tmp_path)
+    plan = json.loads(plan_path.read_text(encoding="utf-8"))
+    del plan["bootstrap"]
+    plan_path.write_text(json.dumps(plan, indent=2, sort_keys=True) + "\n")
+
+    try:
+        run_skillrouter_matrix(plan_path=plan_path, output_path=output_path)
+    except ValueError as exc:
+        assert "bootstrap settings" in str(exc)
+    else:
+        raise AssertionError("missing bootstrap settings must fail closed")
+
+
+def test_skillrouter_matrix_default_bootstrap_iterations_are_formal(tmp_path):
+    plan_path = tmp_path / "plan.json"
+    write_skillrouter_matrix_plan(
+        data_root=FIXTURE,
+        output_path=plan_path,
+        upstream_ref="fixture-ref",
+        license_note="fixture-only",
+        run_id="matrix-run",
+        routers=[
+            {
+                "router_id": "baseline-minilm",
+                "field_view": "name_only",
+                "predictions_path": str(PREDICTIONS),
+            }
+        ],
+    )
+
+    plan = json.loads(plan_path.read_text(encoding="utf-8"))
+
+    assert plan["bootstrap"]["iterations"] == 10000
+    assert plan["bootstrap"]["confidence"] == 0.95
 
 
 def test_candidate_subset_includes_gt_before_deterministic_distractors():
@@ -448,6 +666,8 @@ def test_cli_external_plan_and_matrix_write_outputs(tmp_path):
             "1",
             "--stress-candidate-size",
             "3",
+            "--bootstrap-iterations",
+            "200",
         ]
     )
     assert plan_exit == 0
@@ -465,4 +685,32 @@ def test_cli_external_plan_and_matrix_write_outputs(tmp_path):
     assert matrix_exit == 0
 
     report = json.loads(matrix_path.read_text(encoding="utf-8"))
-    assert set(report["official"]) == {"baseline-minilm", "finetuned-embedding"}
+    assert set(report["official"]) == {
+        "baseline-minilm__name_only",
+        "finetuned-embedding__full_body",
+    }
+
+
+def _frozen_fixture_plan(tmp_path: Path) -> tuple[Path, Path, Path]:
+    root = tmp_path / "skillrouter_eval_core"
+    shutil.copytree(FIXTURE, root)
+    plan_path = tmp_path / "plan.json"
+    output_path = tmp_path / "matrix.json"
+    write_skillrouter_matrix_plan(
+        data_root=root,
+        output_path=plan_path,
+        upstream_ref="fixture-ref",
+        license_note="fixture-only",
+        run_id="matrix-run",
+        routers=[
+            {
+                "router_id": "baseline-minilm",
+                "field_view": "name_only",
+                "predictions_path": str(root / "predictions.json"),
+            }
+        ],
+        stress_candidate_sizes=(3,),
+        matrix_output_path=output_path,
+        bootstrap_iterations=200,
+    )
+    return root, plan_path, output_path

--- a/tests/test_external_skillrouter_matrix.py
+++ b/tests/test_external_skillrouter_matrix.py
@@ -1,0 +1,468 @@
+import gzip
+import json
+import shutil
+import math
+from pathlib import Path
+
+from hermes_skilleval.cli import main
+from hermes_skilleval.external.skillrouter import SkillRouterAdapter
+from hermes_skilleval.external.skillrouter_matrix import (
+    build_field_view,
+    candidate_subset,
+    held_out_skill_split,
+    held_out_source_split,
+    overlap_scaffold,
+    paired_bootstrap_ci,
+    run_skillrouter_matrix,
+    write_skillrouter_matrix_plan,
+)
+from hermes_skilleval.external.skillrouter import ExternalTask
+
+
+FIXTURE = Path(__file__).parent / "fixtures" / "external" / "skillrouter_eval_core_tiny"
+PREDICTIONS = FIXTURE / "predictions.json"
+
+
+def test_skillrouter_matrix_plan_freezes_inputs_before_scoring(tmp_path):
+    plan_path = tmp_path / "frozen-plan.json"
+    matrix_output = tmp_path / "matrix.json"
+
+    plan = write_skillrouter_matrix_plan(
+        data_root=FIXTURE,
+        output_path=plan_path,
+        upstream_ref="fixture-ref",
+        license_note="fixture-only",
+        run_id="matrix-fixture-run",
+        routers=[
+            {
+                "router_id": "baseline-minilm",
+                "field_view": "name_only",
+                "predictions_path": str(PREDICTIONS),
+                "version": "frozen-fixture",
+            }
+        ],
+        field_views=("name_only", "metadata", "full_body"),
+        tiers=("easy", "hard"),
+        stress_candidate_sizes=(1, 3, 10),
+        matrix_output_path=matrix_output,
+    )
+
+    assert plan_path.exists()
+    assert not matrix_output.exists()
+    written = json.loads(plan_path.read_text(encoding="utf-8"))
+    assert written == plan
+    assert written["schema_version"] == "v0.3.skillrouter-matrix-plan.v1"
+    assert written["run_id"] == "matrix-fixture-run"
+    assert written["seed"] == 20260625
+    assert written["benchmark_id"] == "skillrouter"
+    assert written["adapter_provenance"]["upstream_ref"] == "fixture-ref"
+    assert written["adapter_provenance"]["license_note"] == "fixture-only"
+    assert written["frozen_routers"][0]["router_id"] == "baseline-minilm"
+    assert written["frozen_routers"][0]["field_view"] == "name_only"
+    assert written["field_views"] == ["name_only", "metadata", "full_body"]
+    assert written["tiers"] == ["easy", "hard"]
+    assert written["stress_candidate_sizes"] == [1, 3, 10]
+    assert written["matrix_output_path"] == str(matrix_output)
+    assert written["git"]["commit"]
+    assert "dirty" in written["git"]
+
+
+def test_skillrouter_field_views_are_deterministic():
+    skill = next(SkillRouterAdapter(data_root=FIXTURE).iter_skills("easy"))
+
+    assert build_field_view(skill, "name_only") == {
+        "schema_version": "v0.3.skillrouter-field-view.v1",
+        "view": "name_only",
+        "builder_version": "v0.3.pr3.field-view.v1",
+        "skill_id": "gt/browser-login",
+        "text": "Browser Login",
+    }
+    assert build_field_view(skill, "metadata")["text"] == (
+        "Browser Login\nSubmit login forms"
+    )
+    assert build_field_view(skill, "full_body")["text"] == (
+        "Browser Login\nSubmit login forms\n"
+        "Use browser automation to fill credentials and submit forms."
+    )
+
+
+def test_skillrouter_matrix_uses_plan_and_separates_official_from_diagnostics(tmp_path):
+    plan_path = tmp_path / "plan.json"
+    output_path = tmp_path / "matrix.json"
+    write_skillrouter_matrix_plan(
+        data_root=FIXTURE,
+        output_path=plan_path,
+        upstream_ref="fixture-ref",
+        license_note="fixture-only",
+        run_id="matrix-run",
+        routers=[
+            {
+                "router_id": "baseline-minilm",
+                "field_view": "name_only",
+                "predictions_path": str(PREDICTIONS),
+                "version": "frozen-fixture",
+            },
+            {
+                "router_id": "finetuned-embedding",
+                "field_view": "full_body",
+                "predictions_path": str(PREDICTIONS),
+                "version": "frozen-fixture",
+            },
+        ],
+        stress_candidate_sizes=(1, 3),
+        matrix_output_path=output_path,
+    )
+
+    report = run_skillrouter_matrix(plan_path=plan_path, output_path=output_path)
+
+    assert output_path.exists()
+    assert report["schema_version"] == "v0.3.skillrouter-matrix-report.v1"
+    assert report["plan_path"] == str(plan_path)
+    assert set(report["official"]) == {"baseline-minilm", "finetuned-embedding"}
+    easy = report["official"]["baseline-minilm"]["by_tier"]["easy"]
+    hard = report["official"]["baseline-minilm"]["by_tier"]["hard"]
+    assert easy["aggregates"]["all"]["task_count"] == 2
+    assert hard["aggregates"]["all"]["task_count"] == 1
+    assert "hermes_diagnostics" in report
+    assert "negative_hit_rate" not in json.dumps(report).lower()
+    assert report["hermes_diagnostics"]["stress_candidate_subsets"]["easy"]["1"][
+        "status"
+    ] == "UNAVAILABLE"
+    assert report["hermes_diagnostics"]["stress_candidate_subsets"]["easy"]["3"][
+        "status"
+    ] == "PASS"
+
+
+def test_skillrouter_matrix_emits_pairwise_ci_for_all_router_pairs(tmp_path):
+    plan_path = tmp_path / "plan.json"
+    output_path = tmp_path / "matrix.json"
+    write_skillrouter_matrix_plan(
+        data_root=FIXTURE,
+        output_path=plan_path,
+        upstream_ref="fixture-ref",
+        license_note="fixture-only",
+        run_id="matrix-run",
+        routers=[
+            {
+                "router_id": "baseline-minilm",
+                "field_view": "name_only",
+                "predictions_path": str(PREDICTIONS),
+                "version": "frozen-fixture",
+            },
+            {
+                "router_id": "finetuned-embedding",
+                "field_view": "metadata",
+                "predictions_path": str(PREDICTIONS),
+                "version": "frozen-fixture",
+            },
+            {
+                "router_id": "lexical-control",
+                "field_view": "full_body",
+                "predictions_path": str(PREDICTIONS),
+                "version": "frozen-fixture",
+            },
+        ],
+        matrix_output_path=output_path,
+    )
+
+    report = run_skillrouter_matrix(plan_path=plan_path, output_path=output_path)
+
+    ci_keys = report["hermes_diagnostics"]["paired_bootstrap_confidence_intervals"]
+    assert {
+        "baseline-minilm__minus__finetuned-embedding__easy__MRR@10",
+        "baseline-minilm__minus__lexical-control__easy__MRR@10",
+        "finetuned-embedding__minus__lexical-control__easy__MRR@10",
+        "baseline-minilm__minus__finetuned-embedding__hard__MRR@10",
+        "baseline-minilm__minus__lexical-control__hard__MRR@10",
+        "finetuned-embedding__minus__lexical-control__hard__MRR@10",
+    } <= set(ci_keys)
+
+
+def test_skillrouter_matrix_refuses_missing_plan(tmp_path):
+    try:
+        run_skillrouter_matrix(
+            plan_path=tmp_path / "missing-plan.json",
+            output_path=tmp_path / "matrix.json",
+        )
+    except ValueError as exc:
+        assert "frozen plan" in str(exc)
+    else:
+        raise AssertionError("missing frozen plan should fail closed")
+
+
+def test_candidate_subset_includes_gt_before_deterministic_distractors():
+    subset = candidate_subset(
+        all_skill_ids=[
+            "distractor/b",
+            "gt/medium-easy",
+            "distractor/a",
+            "gt/browser-login",
+        ],
+        gt_skill_ids=["gt/browser-login", "gt/medium-easy"],
+        target_size=3,
+    )
+
+    assert subset["status"] == "PASS"
+    assert subset["seed"] == 20260625
+    assert subset["selected_skill_ids"][:2] == ["gt/browser-login", "gt/medium-easy"]
+    assert len(subset["selected_skill_ids"]) == 3
+    assert subset["candidate_hash"]
+
+
+def test_candidate_subset_unavailable_when_target_smaller_than_gt_union():
+    subset = candidate_subset(
+        all_skill_ids=["gt/browser-login", "gt/medium-easy"],
+        gt_skill_ids=["gt/browser-login", "gt/medium-easy"],
+        target_size=1,
+    )
+
+    assert subset == {
+        "status": "UNAVAILABLE",
+        "reason": "target_size 1 is smaller than selected GT union 2",
+        "seed": 20260625,
+        "target_size": 1,
+        "required_gt_count": 2,
+    }
+
+
+def test_paired_bootstrap_ci_is_deterministic_over_task_deltas():
+    rows_a = [
+        {"task_id": "t1", "metrics": {"MRR@10": 0.0}},
+        {"task_id": "t2", "metrics": {"MRR@10": 0.5}},
+        {"task_id": "t3", "metrics": {"MRR@10": 1.0}},
+    ]
+    rows_b = [
+        {"task_id": "t1", "metrics": {"MRR@10": 1.0}},
+        {"task_id": "t2", "metrics": {"MRR@10": 0.5}},
+        {"task_id": "t3", "metrics": {"MRR@10": 0.0}},
+    ]
+
+    ci = paired_bootstrap_ci(
+        rows_a,
+        rows_b,
+        metric="MRR@10",
+        iterations=200,
+        seed=20260625,
+    )
+
+    assert ci["schema_version"] == "v0.3.paired-bootstrap-ci.v1"
+    assert ci["paired_task_count"] == 3
+    assert ci["metric"] == "MRR@10"
+    assert math.isclose(ci["point_estimate"], 0.0)
+    assert ci["lower"] <= ci["point_estimate"] <= ci["upper"]
+    assert ci == paired_bootstrap_ci(
+        rows_a,
+        rows_b,
+        metric="MRR@10",
+        iterations=200,
+        seed=20260625,
+    )
+
+
+def test_paired_bootstrap_ci_skips_rows_missing_metric_on_either_side():
+    rows_a = [
+        {"task_id": "t1", "metrics": {"MRR@10": 1.0}},
+        {"task_id": "t2", "metrics": {"MRR@10": 0.5}},
+    ]
+    rows_b = [
+        {"task_id": "t1", "metrics": {}},
+        {"task_id": "t2", "metrics": {"MRR@10": 0.0}},
+    ]
+
+    ci = paired_bootstrap_ci(rows_a, rows_b, metric="MRR@10", iterations=20)
+
+    assert ci["status"] == "PASS"
+    assert ci["paired_task_count"] == 1
+    assert math.isclose(ci["point_estimate"], 0.5)
+
+
+def test_held_out_skill_split_uses_connected_components():
+    tasks = SkillRouterAdapter(data_root=FIXTURE).load_tasks()
+
+    split = held_out_skill_split(tasks)
+
+    assert split["schema_version"] == "v0.3.held-out-skill-split.v1"
+    assert split["status"] == "PASS"
+    components = split["components"]
+    assert len(components) >= 3
+    for component in components:
+        assert component["task_ids"]
+        assert component["skill_ids"] or component["task_type"] == "generic_only"
+        assert component["split"] in {"train", "held_out"}
+    assert split["overlap_assertions"]["task_overlap"] == []
+    assert split["overlap_assertions"]["skill_overlap"] == []
+
+
+def test_held_out_skill_split_uses_selected_gt_not_auxiliary_relevance():
+    tasks = [
+        ExternalTask(
+            benchmark_id="skillrouter",
+            task_id="task-a",
+            query="A",
+            task_type="single_skill",
+            graded_relevance={"gt/a": 3, "degraded/shared": 1},
+            tier="easy",
+            metadata={
+                "core_gt_ids": ["gt/a"],
+                "gt_skill_ids": ["gt/a"],
+                "auxiliary_gt_ids": ["degraded/shared"],
+            },
+        ),
+        ExternalTask(
+            benchmark_id="skillrouter",
+            task_id="task-b",
+            query="B",
+            task_type="single_skill",
+            graded_relevance={"gt/b": 3, "degraded/shared": 1},
+            tier="easy",
+            metadata={
+                "core_gt_ids": ["gt/b"],
+                "gt_skill_ids": ["gt/b"],
+                "auxiliary_gt_ids": ["degraded/shared"],
+            },
+        ),
+    ]
+
+    split = held_out_skill_split(tasks)
+
+    component_skills = [component["skill_ids"] for component in split["components"]]
+    assert ["degraded/shared"] not in component_skills
+    assert sorted(component_skills) == [["gt/a"], ["gt/b"]]
+
+
+def test_held_out_skill_split_uses_adapter_selected_gt_not_auxiliary_gt(tmp_path):
+    root = tmp_path / "skillrouter_eval_core"
+    shutil.copytree(FIXTURE, root)
+    relevance_path = root / "relevance.json"
+    relevance = json.loads(relevance_path.read_text(encoding="utf-8"))
+    relevance["task-single-easy"]["auxiliary_gt_ids"].append("gt/aux-easy")
+    relevance["task-single-easy"]["relevance"]["gt/aux-easy"] = 2
+    relevance_path.write_text(
+        json.dumps(relevance, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    with gzip.open(root / "easy" / "shard-000.jsonl.gz", "at", encoding="utf-8") as file:
+        file.write(
+            json.dumps(
+                {
+                    "id": "gt/aux-easy",
+                    "name": "Auxiliary Easy Skill",
+                    "description": "Auxiliary positive relevance only",
+                    "body": "Should not define held-out-skill component edges.",
+                    "tier": "easy",
+                },
+                sort_keys=True,
+            )
+            + "\n"
+        )
+
+    tasks = SkillRouterAdapter(data_root=root).load_tasks()
+    split = held_out_skill_split(tasks)
+
+    assert "gt/aux-easy" not in {
+        skill_id
+        for component in split["components"]
+        for skill_id in component["skill_ids"]
+    }
+
+
+def test_held_out_source_unavailable_when_metadata_is_insufficient():
+    tasks = SkillRouterAdapter(data_root=FIXTURE).load_tasks()
+
+    result = held_out_source_split(tasks)
+
+    assert result["status"] == "UNAVAILABLE"
+    assert "source metadata" in result["reason"]
+
+
+def test_held_out_source_unavailable_for_single_distinct_source():
+    tasks = [
+        ExternalTask(
+            benchmark_id="skillrouter",
+            task_id="task-a",
+            query="A",
+            task_type="single_skill",
+            graded_relevance={"gt/a": 3},
+            tier="easy",
+            metadata={"source": "one-source"},
+        ),
+        ExternalTask(
+            benchmark_id="skillrouter",
+            task_id="task-b",
+            query="B",
+            task_type="single_skill",
+            graded_relevance={"gt/b": 3},
+            tier="easy",
+            metadata={"source": "one-source"},
+        ),
+    ]
+
+    result = held_out_source_split(tasks)
+
+    assert result["status"] == "UNAVAILABLE"
+    assert "at least two distinct sources" in result["reason"]
+
+
+def test_overlap_scaffold_allows_missing_skillsbench_tasks():
+    tasks = SkillRouterAdapter(data_root=FIXTURE).load_tasks()
+
+    report = overlap_scaffold(skillrouter_tasks=tasks, skillsbench_tasks=None)
+
+    assert report["schema_version"] == "v0.3.skillrouter-skillsbench-overlap.v1"
+    assert report["skillrouter_task_count"] == 4
+    assert report["skillsbench_task_count"] == {
+        "status": "UNAVAILABLE",
+        "reason": "SkillsBench live tasks not selected in PR-3",
+    }
+    assert report["exact_id_overlap"] == []
+    assert report["normalized_text_hash_overlap"] == []
+    assert report["high_similarity_diagnostics"]["status"] == "UNAVAILABLE"
+
+
+def test_cli_external_plan_and_matrix_write_outputs(tmp_path):
+    plan_path = tmp_path / "plan.json"
+    matrix_path = tmp_path / "matrix.json"
+
+    plan_exit = main(
+        [
+            "external-plan",
+            "--benchmark",
+            "skillrouter",
+            "--data-root",
+            str(FIXTURE),
+            "--output",
+            str(plan_path),
+            "--upstream-ref",
+            "fixture-ref",
+            "--license-note",
+            "fixture-only",
+            "--run-id",
+            "cli-matrix-run",
+            "--router-config",
+            f"baseline-minilm:name_only:{PREDICTIONS}",
+            "--router-config",
+            f"finetuned-embedding:full_body:{PREDICTIONS}",
+            "--matrix-output",
+            str(matrix_path),
+            "--stress-candidate-size",
+            "1",
+            "--stress-candidate-size",
+            "3",
+        ]
+    )
+    assert plan_exit == 0
+    matrix_exit = main(
+        [
+            "external-matrix",
+            "--benchmark",
+            "skillrouter",
+            "--plan",
+            str(plan_path),
+            "--output",
+            str(matrix_path),
+        ]
+    )
+    assert matrix_exit == 0
+
+    report = json.loads(matrix_path.read_text(encoding="utf-8"))
+    assert set(report["official"]) == {"baseline-minilm", "finetuned-embedding"}


### PR DESCRIPTION
## Summary
- Add PR-3 OpenSpec change for frozen external matrix generalization.
- Add SkillRouter frozen matrix planning/running on top of PR-1 adapter and PR-2 official scorer.
- Add deterministic field views, candidate stress diagnostics, paired bootstrap CIs, held-out split diagnostics, and SkillRouter/SkillsBench overlap scaffold.

## Scope Boundaries
- No training, threshold tuning, hard-negative mining, model inference, embeddings, rerankers, live-agent runtime, release promotion, or router promotion.
- No Hermes Negative Hit Rate for SkillRouter without explicit negative labels.
- Official SkillRouter Easy/Hard scoring remains delegated to the PR-2 scorer and separated from Hermes diagnostics.

## Test Plan
- [x] `python -m pytest -q tests/test_external_skillrouter_matrix.py tests/test_external_skillrouter_scorer.py tests/test_external_skillrouter_adapter.py tests/test_cli_external_skillrouter.py` -> 55 passed
- [x] `python -m pytest -q` -> 474 passed
- [x] `OPENSPEC_TELEMETRY=0 openspec validate --all --strict` -> 19 passed, 0 failed
- [x] `PYTHONPATH=src python -m hermes_skilleval.cli release-check --phase17-output-dir docs/demo/phase17-calibrated-release-selector --release-output-dir docs/demo/phase18-ci-release-reproducibility` -> PASS
- [x] `git diff --check`
- [x] v0.3 YAML parse check -> parsed 3 files
- [x] CRLF/new-file line-ending check -> LF only in 12 committed text files

## Review Notes
- Internal read-only reviewer initially found split/bootstrap issues; fixed with regression tests.
- Final read-only re-review verdict: Pass.