### PR TITLE
PR-4: add live-agent fake runtime

### DIFF
--- a/docs/human-briefs/2026-06-28-live-agent-runtime-fake.html
+++ b/docs/human-briefs/2026-06-28-live-agent-runtime-fake.html
@@ -1,0 +1,121 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>PR-4 Live-Agent Runtime Fake - Human Brief</title>
+  <style>
+    :root {
+      color-scheme: light;
+      --ink: #1f2933;
+      --muted: #64748b;
+      --line: #d6dde6;
+      --band: #f5f7fa;
+      --accent: #0f766e;
+    }
+    body {
+      margin: 0;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      color: var(--ink);
+      background: #ffffff;
+      line-height: 1.55;
+    }
+    main {
+      max-width: 920px;
+      margin: 0 auto;
+      padding: 36px 24px 48px;
+    }
+    h1 {
+      margin: 0 0 8px;
+      font-size: 30px;
+      letter-spacing: 0;
+    }
+    h2 {
+      margin: 28px 0 10px;
+      font-size: 18px;
+      letter-spacing: 0;
+    }
+    p {
+      margin: 8px 0;
+    }
+    ul {
+      margin: 8px 0 0;
+      padding-left: 22px;
+    }
+    li {
+      margin: 5px 0;
+    }
+    code {
+      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      font-size: 0.94em;
+      background: var(--band);
+      padding: 1px 4px;
+      border-radius: 4px;
+    }
+    .status {
+      display: inline-block;
+      margin: 8px 0 18px;
+      padding: 4px 10px;
+      border: 1px solid var(--line);
+      border-left: 4px solid var(--accent);
+      background: var(--band);
+      font-weight: 600;
+    }
+    .summary {
+      font-size: 18px;
+      border-top: 1px solid var(--line);
+      border-bottom: 1px solid var(--line);
+      padding: 16px 0;
+    }
+    .muted {
+      color: var(--muted);
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>PR-4: Live-Agent Runtime Fake</h1>
+    <div class="status">状态：needs review</div>
+    <p class="summary">本阶段只新增可测试的 <code>live-agent.v1</code> fake runtime contract，没有接入真实 Codex CLI、SkillsBench 或 live agent 执行。</p>
+
+    <h2>本阶段变化</h2>
+    <ul>
+      <li>新增 <code>AgentRunner</code> protocol、请求/结果 dataclass、trace schema 和 fake runner/verifier。</li>
+      <li>新增 <code>no-skill</code>、<code>routed-skill</code>、<code>oracle-skill</code> condition builder，并保持 prompt hash 一致。</li>
+      <li>新增隔离 workspace 准备与 skill mount 记录，包含 workspace reuse fail-closed、碰撞安全的 mount 文件名和 mounted skill SHA-256。</li>
+      <li>将 agent process exit code、timeout 与 verifier pass/fail 分离，task success 只来自 verifier。</li>
+      <li>记录 <code>MOUNTED_ONLY</code>、<code>READ</code>、<code>DECLARED</code>、<code>UNKNOWN</code> skill-use evidence。</li>
+      <li>新增 malformed event、unknown event、trace key/value secret redaction、log truncation、no-skill leakage 的测试覆盖。</li>
+    </ul>
+
+    <h2>关键文件</h2>
+    <ul>
+      <li><code>src/hermes_skilleval/live_agent_runtime.py</code></li>
+      <li><code>tests/test_live_agent_runtime.py</code></li>
+      <li><code>openspec/changes/live-agent-runtime-fake/</code></li>
+      <li><code>docs/v0.3/codex-implementation-guide.md</code></li>
+    </ul>
+
+    <h2>验证</h2>
+    <p class="muted">最终验证结果以命令输出和 PR 描述为准。本 brief 只做人工审阅索引。</p>
+    <ul>
+      <li><code>python -m pytest -q tests/test_live_agent_runtime.py</code></li>
+      <li><code>python -m pytest -q</code></li>
+      <li><code>OPENSPEC_TELEMETRY=0 openspec validate --all --strict</code></li>
+      <li><code>PYTHONPATH=src python -m hermes_skilleval.cli release-check ...</code></li>
+      <li><code>git diff --check</code>、v0.3 YAML parse、CRLF/new-file line-ending check</li>
+    </ul>
+
+    <h2>边界与限制</h2>
+    <ul>
+      <li>没有修改 Phase 10 deterministic offline replay。</li>
+      <li>没有修改 external matrix、SkillRouter scorer、router promotion 或 release gate。</li>
+      <li>没有运行 live agent，也没有集成真实 Codex CLI 或 SkillsBench。</li>
+      <li>usage/cost 在不可得时保持 <code>null</code>，不做估算。</li>
+    </ul>
+
+    <h2>建议下一步</h2>
+    <p>先完成 PR-4 review；真实 Codex CLI runner、SkillsBench 任务和 release-level live evidence 留到后续 PR。</p>
+  </main>
+</body>
+</html>

--- a/docs/human-briefs/2026-06-28-live-agent-runtime-fake.html
+++ b/docs/human-briefs/2026-06-28-live-agent-runtime-fake.html
@@ -82,6 +82,7 @@
     <ul>
       <li>新增 <code>AgentRunner</code> protocol、请求/结果 dataclass、trace schema 和 fake runner/verifier。</li>
       <li>新增 <code>no-skill</code>、<code>routed-skill</code>、<code>oracle-skill</code> condition builder，并保持 prompt hash 一致。</li>
+      <li>请求构造会校验 condition 与 workspace 的 mounted skill ID 有序一致，避免 routed/oracle 或 no-skill workspace 注入错配。</li>
       <li>新增隔离 workspace 准备与 skill mount 记录，包含 workspace reuse fail-closed、碰撞安全的 mount 文件名和 mounted skill SHA-256。</li>
       <li>将 agent process exit code、timeout 与 verifier pass/fail 分离，task success 只来自 verifier。</li>
       <li>记录 <code>MOUNTED_ONLY</code>、<code>READ</code>、<code>DECLARED</code>、<code>UNKNOWN</code> skill-use evidence。</li>
@@ -112,6 +113,7 @@
       <li>没有修改 external matrix、SkillRouter scorer、router promotion 或 release gate。</li>
       <li>没有运行 live agent，也没有集成真实 Codex CLI 或 SkillsBench。</li>
       <li>usage/cost 在不可得时保持 <code>null</code>，不做估算。</li>
+      <li>正式 JSON Schema 校验延后到 PR-5，在真实 Codex trace 进入证据面之前补齐。</li>
     </ul>
 
     <h2>建议下一步</h2>

--- a/docs/v0.3/codex-implementation-guide.md
+++ b/docs/v0.3/codex-implementation-guide.md
@@ -150,6 +150,8 @@ Acceptance:
 Goal: build a testable `live-agent.v1` contract without invoking a real Codex
 or SkillsBench process.
 
+Human brief: `docs/human-briefs/2026-06-28-live-agent-runtime-fake.html`
+
 Expected work:
 
 - Add request/result structures and an `AgentRunner` protocol.

--- a/openspec/changes/live-agent-runtime-fake/.openspec.yaml
+++ b/openspec/changes/live-agent-runtime-fake/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-27

--- a/openspec/changes/live-agent-runtime-fake/design.md
+++ b/openspec/changes/live-agent-runtime-fake/design.md
@@ -1,0 +1,82 @@
+## Context
+
+Phase 10 already has deterministic offline replay artifacts, but v0.3 requires
+a separate live-agent evidence contract before any real agent runner is used.
+PR-4 introduces `live-agent.v1` as a local runtime abstraction with fake
+implementations only. It provides schemas, condition construction, workspace
+isolation, skill mounting, verifier separation, and trace semantics without
+running Codex CLI, SkillsBench, networked services, or live agents.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Define `AgentRunner` protocol and request/result dataclasses for
+  `live-agent.v1`.
+- Build `no-skill`, `routed-skill`, and `oracle-skill` conditions from the same
+  task prompt, changing only skill injection metadata.
+- Prepare fresh isolated workspaces and fail closed on workspace reuse.
+- Mount benchmark skills into workspace-local files with stable hashes.
+- Provide fake runner and fake verifier implementations for CI-only tests.
+- Separate process exit status from verifier pass/fail.
+- Emit trace records that distinguish `MOUNTED_ONLY`, `READ`, `DECLARED`, and
+  `UNKNOWN` skill-use evidence.
+- Redact secrets from trace-visible strings and keep unavailable usage/cost
+  fields as `null`.
+
+**Non-Goals:**
+
+- No real Codex CLI runner, SkillsBench adapter, live-agent execution, network
+  calls, model inference, router promotion, release gate changes, external
+  matrix changes, or Phase 10 replay changes.
+
+## Decisions
+
+1. **New module boundary.** PR-4 adds a new `live_agent_runtime.py` module
+   rather than modifying `agent_loop.py`. This keeps Phase 10 `agent-loop.v1`
+   deterministic replay stable and makes `live-agent.v1` visibly separate.
+
+2. **Fake runner is a protocol implementation.** The fake runner consumes
+   scripted events and returns deterministic process output. It exists only to
+   test schemas, redaction, timeout/error handling, and verifier separation.
+   Real Codex CLI execution belongs to PR-5.
+
+3. **Condition builder freezes prompt equality.** All conditions carry the
+   same prompt text and prompt hash. Skill injection differs only through
+   mounted skill IDs and condition metadata.
+
+4. **Workspace preparation is fail-closed.** A run workspace must be absent
+   before preparation. Reusing an existing workspace raises an error so final
+   evidence cannot accidentally share state. Mounted skill filenames include a
+   stable skill-ID hash suffix so sanitized IDs such as `skill/a` and
+   `skill_a` cannot collide. Duplicate skill IDs are rejected before any run
+   workspace is created.
+
+5. **Observable skill-use states only.** Mounted skills start as
+   `MOUNTED_ONLY`. A fake read event moves them to `READ`; a declaration event
+   moves them to `DECLARED`; malformed or unrecognized evidence is `UNKNOWN`.
+   The runtime does not infer real use from model text.
+
+## Risks / Trade-offs
+
+- **Risk: fake runner is mistaken for live evidence.** → Mitigation: schema and
+  docs state fake runner only; no real CLI integration or live task execution.
+- **Risk: Phase 10 replay semantics drift.** → Mitigation: avoid editing Phase
+  10 modules and add tests only under the new live-agent runtime surface.
+- **Risk: secrets enter traces.** → Mitigation: central redaction helper covers
+  request text, verifier details, event text, stdout/stderr, and final messages
+  in fake traces, including trace-visible object keys.
+- **Risk: local paths enter portable evidence.** → Mitigation: trace
+  serialization records the workspace name by default rather than the absolute
+  temporary directory path.
+
+## Migration Plan
+
+PR-4 is additive. Existing CLI, release, router, external matrix, and Phase 10
+paths remain unchanged. Rollback is removing the new live-agent module, tests,
+OpenSpec change, and Human Brief.
+
+## Open Questions
+
+- Real Codex CLI event parsing, sandbox flags, SkillsBench task selection, and
+  evidence-pack validation are explicitly deferred to later PRs.

--- a/openspec/changes/live-agent-runtime-fake/design.md
+++ b/openspec/changes/live-agent-runtime-fake/design.md
@@ -15,6 +15,8 @@ running Codex CLI, SkillsBench, networked services, or live agents.
   `live-agent.v1`.
 - Build `no-skill`, `routed-skill`, and `oracle-skill` conditions from the same
   task prompt, changing only skill injection metadata.
+- Fail closed when a request is built from a condition and workspace whose
+  mounted skill IDs differ in content or order.
 - Prepare fresh isolated workspaces and fail closed on workspace reuse.
 - Mount benchmark skills into workspace-local files with stable hashes.
 - Provide fake runner and fake verifier implementations for CI-only tests.
@@ -43,7 +45,9 @@ running Codex CLI, SkillsBench, networked services, or live agents.
 
 3. **Condition builder freezes prompt equality.** All conditions carry the
    same prompt text and prompt hash. Skill injection differs only through
-   mounted skill IDs and condition metadata.
+   mounted skill IDs and condition metadata. Request construction also checks
+   ordered condition/workspace mounted skill IDs so routed top-k order remains
+   auditable.
 
 4. **Workspace preparation is fail-closed.** A run workspace must be absent
    before preparation. Reusing an existing workspace raises an error so final
@@ -65,10 +69,13 @@ running Codex CLI, SkillsBench, networked services, or live agents.
   10 modules and add tests only under the new live-agent runtime surface.
 - **Risk: secrets enter traces.** → Mitigation: central redaction helper covers
   request text, verifier details, event text, stdout/stderr, and final messages
-  in fake traces, including trace-visible object keys.
+  in fake traces, including nested trace-visible object keys.
 - **Risk: local paths enter portable evidence.** → Mitigation: trace
   serialization records the workspace name by default rather than the absolute
   temporary directory path.
+- **Risk: fake schema hardens too early.** → Mitigation: formal JSON Schema
+  validation is deferred to PR-5 before real Codex traces are produced; PR-4
+  keeps the trace shape deterministic and unit-tested.
 
 ## Migration Plan
 
@@ -80,3 +87,5 @@ OpenSpec change, and Human Brief.
 
 - Real Codex CLI event parsing, sandbox flags, SkillsBench task selection, and
   evidence-pack validation are explicitly deferred to later PRs.
+- Formal JSON Schema validation for real Codex trace artifacts is deferred to
+  PR-5 before any real live-agent traces are accepted.

--- a/openspec/changes/live-agent-runtime-fake/proposal.md
+++ b/openspec/changes/live-agent-runtime-fake/proposal.md
@@ -1,0 +1,51 @@
+## Why
+
+v0.3 needs a live-agent evidence contract before any real Codex CLI or
+SkillsBench integration can be trusted. PR-4 creates a local, fake-runner
+`live-agent.v1` runtime abstraction that is testable in CI while keeping Phase
+10 deterministic offline replay unchanged.
+
+## What Changes
+
+- Add `live-agent.v1` request/result/trace structures and an `AgentRunner`
+  protocol.
+- Add condition builders for `no-skill`, `routed-skill`, and `oracle-skill`
+  while keeping the task prompt identical across conditions.
+- Add isolated workspace preparation and benchmark skill mounting helpers.
+- Add fake agent runner and fake verifier implementations for deterministic
+  tests only.
+- Separate agent process exit status from deterministic verifier pass/fail.
+- Track skill-use evidence as `READ`, `DECLARED`, `MOUNTED_ONLY`, or
+  `UNKNOWN` from observable fake events.
+- Keep usage and cost fields `null` when unavailable.
+- Add tests for success, verifier failure, process failure, timeout, malformed
+  event input, unknown events, secret redaction, skill leakage, and workspace
+  reuse.
+- Do not integrate real Codex CLI, SkillsBench, live-agent execution,
+  external matrix/scorer changes, router promotion, or release gate logic.
+
+## Capabilities
+
+### New Capabilities
+
+- `live-agent-runtime`: Defines the `live-agent.v1` runtime contract, fake
+  runner/verifier, condition builders, workspace and skill mounting behavior,
+  trace schema, redaction, and deterministic tests.
+
+### Modified Capabilities
+
+- None.
+
+## Impact
+
+- Affected code: new live-agent runtime module(s) and optional scoped CLI/test
+  helpers if needed.
+- Affected tests: new fake-runner live-agent runtime tests covering trace
+  schema, conditions, isolation, verifier/process separation, evidence, errors,
+  redaction, leakage, and workspace reuse.
+- Affected docs/OpenSpec: PR-4 OpenSpec artifacts and a concise Human Brief.
+- Stable boundaries: Phase 10 `agent-loop.v1` replay remains unchanged; PR-3
+  external matrix/scorer paths remain untouched.
+- Out of scope: real Codex CLI runner, SkillsBench adapter, live-agent runs,
+  router promotion, release gates, training, model inference, network access,
+  or committing raw live traces.

--- a/openspec/changes/live-agent-runtime-fake/specs/live-agent-runtime/spec.md
+++ b/openspec/changes/live-agent-runtime-fake/specs/live-agent-runtime/spec.md
@@ -1,0 +1,119 @@
+## ADDED Requirements
+
+### Requirement: Define live-agent runtime contract
+
+The system SHALL define a `live-agent.v1` runtime contract without invoking a
+real Codex CLI or SkillsBench process.
+
+#### Scenario: Construct request and result records
+
+- **WHEN** a caller builds a live-agent request
+- **THEN** the request MUST include task ID, prompt, condition, workspace path,
+  mounted skills, timeout, and metadata
+- **AND** the result MUST include process exit code, timeout status, verifier
+  outcome, trace schema version, usage, and cost
+- **AND** usage and cost MUST be `null` when unavailable
+
+### Requirement: Build skill-injection conditions
+
+The system SHALL build `no-skill`, `routed-skill`, and `oracle-skill`
+conditions while preserving prompt equality.
+
+#### Scenario: Build comparable conditions
+
+- **WHEN** conditions are built for the same task prompt
+- **THEN** all conditions MUST have the same prompt hash
+- **AND** `no-skill` MUST mount no benchmark skills
+- **AND** `routed-skill` MUST mount only routed skill IDs
+- **AND** `oracle-skill` MUST mount only oracle skill IDs
+
+### Requirement: Prepare isolated workspaces and mount skills
+
+The system SHALL prepare a fresh workspace for each live-agent run and mount
+benchmark skills locally.
+
+#### Scenario: Prepare workspace
+
+- **WHEN** a workspace is prepared for a run
+- **THEN** the workspace path MUST NOT already exist
+- **AND** mounted skills MUST be written under a workspace-local skill
+  directory
+- **AND** each mounted skill MUST record ID, relative path, and SHA-256
+- **AND** mounted skill filenames MUST be collision-resistant
+
+#### Scenario: Reject workspace reuse
+
+- **WHEN** the requested run workspace already exists
+- **THEN** workspace preparation MUST fail closed
+
+#### Scenario: Reject duplicate mounted skill IDs
+
+- **WHEN** mounted skills contain duplicate skill IDs
+- **THEN** workspace preparation MUST fail closed before creating or writing the
+  run workspace
+
+### Requirement: Execute fake runner and verifier
+
+The system SHALL provide fake runner and fake verifier implementations for
+deterministic tests.
+
+#### Scenario: Separate process and verifier outcomes
+
+- **WHEN** the fake runner returns process output
+- **THEN** process exit code MUST be recorded separately from deterministic
+  verifier pass/fail
+- **AND** task success MUST be derived from verifier pass/fail, not process
+  exit code alone
+
+#### Scenario: Handle timeout and process failure
+
+- **WHEN** the fake runner reports timeout or non-zero process exit
+- **THEN** the trace MUST record that process state
+- **AND** verifier outcome MUST still be represented separately
+
+### Requirement: Emit live-agent trace schema
+
+The system SHALL emit a deterministic `live-agent.v1` trace record.
+
+#### Scenario: Trace successful fake run
+
+- **WHEN** a fake live-agent run completes
+- **THEN** the trace MUST include schema version, request, result, mounted
+  skills, skill-use evidence, redacted events, stdout, stderr, and final
+  message
+- **AND** secrets MUST be redacted from trace-visible text
+- **AND** secrets MUST be redacted from trace-visible object keys and values
+- **AND** trace serialization MUST NOT expose absolute workspace paths by
+  default
+
+#### Scenario: Handle malformed and unknown events
+
+- **WHEN** fake runner events are malformed
+- **THEN** the run MUST fail closed with a malformed-event error
+- **WHEN** fake runner events have unknown types
+- **THEN** the trace MUST preserve a redacted unknown-event record without
+  crashing
+
+### Requirement: Track observable skill-use evidence
+
+The system SHALL classify skill-use evidence only from observable events.
+
+#### Scenario: Classify mounted and read skills
+
+- **WHEN** a skill is mounted but has no read or declaration event
+- **THEN** its evidence state MUST be `MOUNTED_ONLY`
+- **WHEN** a skill read event is observed
+- **THEN** its evidence state MUST be `READ`
+- **WHEN** a skill declaration event is observed
+- **THEN** its evidence state MUST be `DECLARED`
+- **WHEN** evidence cannot be interpreted
+- **THEN** its evidence state MUST be `UNKNOWN`
+
+### Requirement: Prevent no-skill leakage
+
+The system SHALL fail closed when no-skill conditions receive benchmark skills.
+
+#### Scenario: Reject no-skill leakage
+
+- **WHEN** a `no-skill` condition includes mounted benchmark skills
+- **THEN** request construction or execution MUST fail closed

--- a/openspec/changes/live-agent-runtime-fake/specs/live-agent-runtime/spec.md
+++ b/openspec/changes/live-agent-runtime-fake/specs/live-agent-runtime/spec.md
@@ -14,6 +14,13 @@ real Codex CLI or SkillsBench process.
   outcome, trace schema version, usage, and cost
 - **AND** usage and cost MUST be `null` when unavailable
 
+#### Scenario: Reject condition and workspace mismatch
+
+- **WHEN** a request is built from a condition and prepared workspace
+- **THEN** the ordered condition mounted skill IDs MUST match the ordered
+  workspace mounted skill IDs
+- **AND** request construction MUST fail closed when they differ
+
 ### Requirement: Build skill-injection conditions
 
 The system SHALL build `no-skill`, `routed-skill`, and `oracle-skill`

--- a/openspec/changes/live-agent-runtime-fake/tasks.md
+++ b/openspec/changes/live-agent-runtime-fake/tasks.md
@@ -1,0 +1,60 @@
+## 1. OpenSpec And Scope
+
+- [x] 1.1 Create change `live-agent-runtime-fake` with proposal, design,
+  tasks, and `live-agent-runtime` spec.
+- [x] 1.2 Keep PR-4 limited to fake `live-agent.v1` runtime abstraction; do
+  not modify Phase 10 replay, external matrix, scorer, router promotion, or
+  release gate logic.
+
+## 2. Runtime Contract And Conditions
+
+- [x] 2.1 Add RED tests for `AgentRunner` protocol, request/result dataclasses,
+  and `live-agent.v1` trace schema fields.
+- [x] 2.2 Implement live-agent runtime dataclasses, protocol, schema constants,
+  and serialization helpers.
+- [x] 2.3 Add RED tests for `no-skill`, `routed-skill`, and `oracle-skill`
+  condition builders preserving prompt hashes.
+- [x] 2.4 Implement condition builders and no-skill leakage validation.
+
+## 3. Workspace And Skill Mounting
+
+- [x] 3.1 Add RED tests for fresh workspace preparation, workspace reuse
+  failure, and workspace-local skill mounting.
+- [x] 3.2 Implement isolated workspace preparation and mounted skill hash
+  records.
+
+## 4. Fake Runner, Verifier, And Trace
+
+- [x] 4.1 Add RED tests for fake-runner success, verifier failure, process
+  failure, and timeout.
+- [x] 4.2 Implement fake runner, fake verifier, and execution orchestration.
+- [x] 4.3 Add RED tests that process exit code is separate from verifier
+  pass/fail and task success derives from verifier outcome.
+- [x] 4.4 Add RED tests for `MOUNTED_ONLY`, `READ`, `DECLARED`, and `UNKNOWN`
+  skill-use evidence.
+- [x] 4.5 Implement live-agent trace rendering with usage/cost `null` when
+  unavailable.
+
+## 5. Error Handling And Redaction
+
+- [x] 5.1 Add RED tests for malformed event fail-closed behavior.
+- [x] 5.2 Add RED tests for unknown event preservation without crashing.
+- [x] 5.3 Add RED tests for secret redaction and log truncation.
+- [x] 5.4 Implement event parsing, unknown-event preservation, redaction, and
+  log truncation.
+
+## 6. Documentation And Human Brief
+
+- [x] 6.1 Add concise Chinese Human Brief for PR-4 with scope, changed files,
+  verification, limits, and next step.
+- [x] 6.2 Link PR-4 Human Brief from v0.3 implementation guide only if needed.
+
+## 7. Validation
+
+- [x] 7.1 Run focused live-agent runtime tests.
+- [x] 7.2 Run `python -m pytest -q`.
+- [x] 7.3 Run `OPENSPEC_TELEMETRY=0 openspec validate --all --strict`.
+- [x] 7.4 Run `PYTHONPATH=src python -m hermes_skilleval.cli release-check --phase17-output-dir docs/demo/phase17-calibrated-release-selector --release-output-dir docs/demo/phase18-ci-release-reproducibility`.
+- [x] 7.5 Run `git diff --check`.
+- [x] 7.6 Run v0.3 YAML parse check.
+- [x] 7.7 Run CRLF/new-file line-ending check.

--- a/src/hermes_skilleval/live_agent_runtime.py
+++ b/src/hermes_skilleval/live_agent_runtime.py
@@ -1,0 +1,456 @@
+from __future__ import annotations
+
+import hashlib
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Protocol, runtime_checkable
+
+from hermes_skilleval.release_manifest import sha256_file
+
+
+TRACE_SCHEMA_VERSION = "live-agent.v1"
+SKILL_USE_STATES = {"MOUNTED_ONLY", "READ", "DECLARED", "UNKNOWN"}
+SECRET_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(
+        r"-----BEGIN [^-]*PRIVATE KEY-----.*?-----END [^-]*PRIVATE KEY-----",
+        re.IGNORECASE | re.DOTALL,
+    ),
+    re.compile(r"AKIA[A-Z0-9]{12,}", re.IGNORECASE),
+    re.compile(r"BEGIN (?:OPENSSH|RSA|DSA|EC )?PRIVATE KEY", re.IGNORECASE),
+    re.compile(r"PRIVATE KEY", re.IGNORECASE),
+    re.compile(r"ssh-(?:ed25519|rsa)\s+[A-Za-z0-9+/=._-]+", re.IGNORECASE),
+    re.compile(
+        r"(?:api[_-]?key|access[_-]?token|auth[_-]?token|token|password)"
+        r"\b\s*[:=]\s*[^\s,;\"']+",
+        re.IGNORECASE,
+    ),
+    re.compile(r"bearer\s+[A-Za-z0-9._-]+", re.IGNORECASE),
+    re.compile(r"\bsk-[A-Za-z0-9_-]{8,}\b", re.IGNORECASE),
+    re.compile(
+        r"\b(?:25[0-5]|2[0-4]\d|1?\d?\d)"
+        r"(?:\.(?:25[0-5]|2[0-4]\d|1?\d?\d)){3}\b"
+    ),
+    re.compile(r"/root(?:/[^\s,;\"']*)?", re.IGNORECASE),
+)
+
+
+@dataclass(frozen=True)
+class LiveAgentSkill:
+    skill_id: str
+    name: str
+    body: str
+
+
+@dataclass(frozen=True)
+class AgentCondition:
+    task_id: str
+    prompt: str
+    condition: str
+    prompt_hash: str
+    mounted_skills: list[LiveAgentSkill]
+
+
+@dataclass(frozen=True)
+class WorkspaceState:
+    workspace_path: Path
+    skill_dir: Path
+    mounted_skills: list[dict[str, Any]]
+
+
+@dataclass(frozen=True)
+class AgentRequest:
+    run_id: str
+    task_id: str
+    prompt: str
+    condition: str
+    prompt_hash: str
+    workspace_path: Path
+    mounted_skills: list[dict[str, Any]]
+    timeout_seconds: int
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_condition(
+        cls,
+        *,
+        run_id: str,
+        condition: AgentCondition,
+        workspace: WorkspaceState,
+        timeout_seconds: int,
+        metadata: dict[str, Any] | None = None,
+    ) -> "AgentRequest":
+        return cls(
+            run_id=run_id,
+            task_id=condition.task_id,
+            prompt=condition.prompt,
+            condition=condition.condition,
+            prompt_hash=condition.prompt_hash,
+            workspace_path=workspace.workspace_path,
+            mounted_skills=workspace.mounted_skills,
+            timeout_seconds=timeout_seconds,
+            metadata=metadata or {},
+        )
+
+    def to_dict(
+        self,
+        *,
+        include_absolute_paths: bool = False,
+        redact_secrets: bool = False,
+    ) -> dict[str, Any]:
+        workspace_path = (
+            str(self.workspace_path)
+            if include_absolute_paths
+            else self.workspace_path.name
+        )
+        data = {
+            "run_id": self.run_id,
+            "task_id": self.task_id,
+            "prompt": self.prompt,
+            "condition": self.condition,
+            "prompt_hash": self.prompt_hash,
+            "workspace_path": workspace_path,
+            "mounted_skills": self.mounted_skills,
+            "timeout_seconds": self.timeout_seconds,
+            "metadata": self.metadata,
+        }
+        if redact_secrets:
+            return _redact_value(data)
+        return data
+
+
+@dataclass(frozen=True)
+class RunnerOutput:
+    exit_code: int | None
+    timed_out: bool
+    stdout: str
+    stderr: str
+    events: list[Any]
+
+
+@dataclass(frozen=True)
+class VerifierResult:
+    passed: bool
+    details: dict[str, Any]
+
+
+@runtime_checkable
+class AgentRunner(Protocol):
+    def run(self, request: AgentRequest) -> RunnerOutput:
+        ...
+
+
+@runtime_checkable
+class AgentVerifier(Protocol):
+    def verify(self, request: AgentRequest, output: RunnerOutput) -> VerifierResult:
+        ...
+
+
+class FakeAgentRunner:
+    def __init__(
+        self,
+        *,
+        exit_code: int | None = 0,
+        timed_out: bool = False,
+        stdout: str = "",
+        stderr: str = "",
+        events: list[Any] | None = None,
+    ) -> None:
+        self.exit_code = exit_code
+        self.timed_out = timed_out
+        self.stdout = stdout
+        self.stderr = stderr
+        self.events = events or []
+
+    def run(self, request: AgentRequest) -> RunnerOutput:
+        return RunnerOutput(
+            exit_code=self.exit_code,
+            timed_out=self.timed_out,
+            stdout=self.stdout,
+            stderr=self.stderr,
+            events=self.events,
+        )
+
+
+class FakeVerifier:
+    def __init__(
+        self,
+        *,
+        pass_: bool,
+        details: dict[str, Any] | None = None,
+    ) -> None:
+        self.pass_ = pass_
+        self.details = details or {}
+
+    def verify(self, request: AgentRequest, output: RunnerOutput) -> VerifierResult:
+        return VerifierResult(passed=self.pass_, details=self.details)
+
+
+@dataclass(frozen=True)
+class AgentResult:
+    request: AgentRequest
+    process_exit_code: int | None
+    timed_out: bool
+    verifier_passed: bool
+    verifier_details: dict[str, Any]
+    task_success: bool
+    stdout: str
+    stderr: str
+    stdout_truncated: bool
+    stderr_truncated: bool
+    events: list[dict[str, Any]]
+    skill_use: dict[str, dict[str, str]]
+    final_message: str | None
+    usage: dict[str, Any] | None = None
+    cost: dict[str, Any] | None = None
+
+    def to_trace(self) -> dict[str, Any]:
+        return {
+            "schema_version": TRACE_SCHEMA_VERSION,
+            "request": self.request.to_dict(redact_secrets=True),
+            "result": {
+                "process_exit_code": self.process_exit_code,
+                "timed_out": self.timed_out,
+                "verifier": {
+                    "passed": self.verifier_passed,
+                    "details": _redact_value(self.verifier_details),
+                },
+                "task_success": self.task_success,
+                "usage": self.usage,
+                "cost": self.cost,
+                "stdout": self.stdout,
+                "stderr": self.stderr,
+                "stdout_truncated": self.stdout_truncated,
+                "stderr_truncated": self.stderr_truncated,
+                "final_message": self.final_message,
+            },
+            "mounted_skills": _redact_value(self.request.mounted_skills),
+            "skill_use": _redact_mapping_keys(self.skill_use),
+            "events": _redact_value(self.events),
+        }
+
+
+def build_condition(
+    *,
+    task_id: str,
+    prompt: str,
+    condition: str,
+    routed_skills: list[LiveAgentSkill] | None = None,
+    oracle_skills: list[LiveAgentSkill] | None = None,
+) -> AgentCondition:
+    routed = routed_skills or []
+    oracle = oracle_skills or []
+    if condition == "no-skill":
+        if routed or oracle:
+            raise ValueError("no-skill condition must not receive benchmark skills")
+        mounted: list[LiveAgentSkill] = []
+    elif condition == "routed-skill":
+        mounted = routed
+    elif condition == "oracle-skill":
+        mounted = oracle
+    else:
+        raise ValueError(f"unsupported live-agent condition: {condition}")
+    return AgentCondition(
+        task_id=_non_empty(task_id, "task_id"),
+        prompt=_non_empty(prompt, "prompt"),
+        condition=condition,
+        prompt_hash=_sha256_text(prompt),
+        mounted_skills=mounted,
+    )
+
+
+def prepare_live_agent_workspace(
+    *,
+    base_dir: Path | str,
+    run_id: str,
+    mounted_skills: list[LiveAgentSkill],
+) -> WorkspaceState:
+    root = Path(base_dir) / _safe_path_part(run_id)
+    if root.exists():
+        raise ValueError(f"workspace already exists: {root}")
+    records = _mounted_skill_records(mounted_skills)
+    skill_dir = root / "skills"
+    skill_dir.mkdir(parents=True)
+    for skill, record in zip(mounted_skills, records, strict=True):
+        path = root / record["relative_path"]
+        path.write_text(skill.body, encoding="utf-8")
+        record["sha256"] = sha256_file(path)
+    return WorkspaceState(
+        workspace_path=root,
+        skill_dir=skill_dir,
+        mounted_skills=records,
+    )
+
+
+def _mounted_skill_records(
+    mounted_skills: list[LiveAgentSkill],
+) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    seen_skill_ids: set[str] = set()
+    seen_relative_paths: set[str] = set()
+    for skill in mounted_skills:
+        if skill.skill_id in seen_skill_ids:
+            raise ValueError(f"duplicate skill_id in mounted skills: {skill.skill_id}")
+        seen_skill_ids.add(skill.skill_id)
+        relative_path = Path("skills") / _skill_mount_filename(skill)
+        relative_path_text = relative_path.as_posix()
+        if relative_path_text in seen_relative_paths:
+            raise ValueError(f"duplicate mounted skill path: {relative_path_text}")
+        seen_relative_paths.add(relative_path_text)
+        records.append(
+            {
+                "skill_id": skill.skill_id,
+                "name": skill.name,
+                "relative_path": relative_path_text,
+                "sha256": "",
+            }
+        )
+    return records
+
+
+def execute_live_agent(
+    *,
+    request: AgentRequest,
+    runner: AgentRunner,
+    verifier: AgentVerifier,
+    max_log_chars: int = 4000,
+) -> AgentResult:
+    if request.condition == "no-skill" and request.mounted_skills:
+        raise ValueError("no-skill condition leaked mounted skills")
+    output = runner.run(request)
+    events, skill_use, final_message = _parse_events(output.events, request)
+    verification = verifier.verify(request, output)
+    stdout, stdout_truncated = _truncate(_redact(output.stdout), max_log_chars)
+    stderr, stderr_truncated = _truncate(_redact(output.stderr), max_log_chars)
+    return AgentResult(
+        request=request,
+        process_exit_code=output.exit_code,
+        timed_out=output.timed_out,
+        verifier_passed=verification.passed,
+        verifier_details=verification.details,
+        task_success=verification.passed,
+        stdout=stdout,
+        stderr=stderr,
+        stdout_truncated=stdout_truncated,
+        stderr_truncated=stderr_truncated,
+        events=events,
+        skill_use=skill_use,
+        final_message=final_message,
+        usage=None,
+        cost=None,
+    )
+
+
+def _parse_events(
+    raw_events: list[Any],
+    request: AgentRequest,
+) -> tuple[list[dict[str, Any]], dict[str, dict[str, str]], str | None]:
+    mounted = {record["skill_id"] for record in request.mounted_skills}
+    skill_use = {
+        skill_id: {"state": "MOUNTED_ONLY"}
+        for skill_id in sorted(mounted)
+    }
+    events = []
+    final_message = None
+    for raw in raw_events:
+        if not isinstance(raw, dict):
+            raise ValueError("malformed event: expected object")
+        event_type = raw.get("type")
+        if not isinstance(event_type, str):
+            raise ValueError("malformed event: missing type")
+        if event_type == "skill_read":
+            skill_id = _event_skill_id(raw)
+            _set_skill_state(skill_use, mounted, skill_id, "READ")
+            events.append({"type": "skill_read", "skill_id": skill_id})
+        elif event_type == "skill_declared":
+            skill_id = _event_skill_id(raw)
+            _set_skill_state(skill_use, mounted, skill_id, "DECLARED")
+            events.append({"type": "skill_declared", "skill_id": skill_id})
+        elif event_type == "final":
+            message = _redact(str(raw.get("message", "")))
+            final_message = message
+            events.append({"type": "final", "message": message})
+        else:
+            events.append(
+                {
+                    "type": "unknown",
+                    "original_type": event_type,
+                    "payload": _redact_value(raw),
+                }
+            )
+    return events, skill_use, final_message
+
+
+def _set_skill_state(
+    skill_use: dict[str, dict[str, str]],
+    mounted: set[str],
+    skill_id: str,
+    state: str,
+) -> None:
+    if state not in SKILL_USE_STATES:
+        raise ValueError(f"unsupported skill use state: {state}")
+    if skill_id not in mounted:
+        skill_use[skill_id] = {"state": "UNKNOWN"}
+        return
+    current = skill_use[skill_id]["state"]
+    if current == "DECLARED":
+        return
+    skill_use[skill_id] = {"state": state}
+
+
+def _event_skill_id(event: dict[str, Any]) -> str:
+    value = event.get("skill_id")
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError("malformed event: skill_id must be non-empty")
+    return value
+
+
+def _redact_value(value: Any) -> Any:
+    if isinstance(value, str):
+        return _redact(value)
+    if isinstance(value, dict):
+        return {key: _redact_value(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_redact_value(item) for item in value]
+    return value
+
+
+def _redact_mapping_keys(value: dict[str, Any]) -> dict[str, Any]:
+    return {
+        _redact(str(key)): _redact_value(item)
+        for key, item in value.items()
+    }
+
+
+def _redact(text: str) -> str:
+    redacted = text
+    for pattern in SECRET_PATTERNS:
+        redacted = pattern.sub("[REDACTED]", redacted)
+    return redacted
+
+
+def _truncate(text: str, max_chars: int) -> tuple[str, bool]:
+    if len(text) <= max_chars:
+        return text, False
+    return text[:max_chars], True
+
+
+def _safe_path_part(value: str) -> str:
+    text = _non_empty(value, "path part").replace("/", "_")
+    return re.sub(r"[^A-Za-z0-9_.-]", "_", text)
+
+
+def _skill_mount_filename(skill: LiveAgentSkill) -> str:
+    base = _safe_path_part(skill.skill_id)
+    digest = _sha256_text(skill.skill_id)[:12]
+    return f"{base}--{digest}.md"
+
+
+def _non_empty(value: str, field: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{field} must be a non-empty string")
+    return value
+
+
+def _sha256_text(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()

--- a/src/hermes_skilleval/live_agent_runtime.py
+++ b/src/hermes_skilleval/live_agent_runtime.py
@@ -80,6 +80,7 @@ class AgentRequest:
         timeout_seconds: int,
         metadata: dict[str, Any] | None = None,
     ) -> "AgentRequest":
+        _validate_workspace_matches_condition(condition, workspace)
         return cls(
             run_id=run_id,
             task_id=condition.task_id,
@@ -282,6 +283,23 @@ def prepare_live_agent_workspace(
     )
 
 
+def _validate_workspace_matches_condition(
+    condition: AgentCondition,
+    workspace: WorkspaceState,
+) -> None:
+    condition_skill_ids = [skill.skill_id for skill in condition.mounted_skills]
+    workspace_skill_ids = [
+        str(record.get("skill_id", ""))
+        for record in workspace.mounted_skills
+    ]
+    if condition_skill_ids != workspace_skill_ids:
+        raise ValueError(
+            "workspace mounted skill IDs must match condition mounted skill IDs "
+            f"in order: condition={condition_skill_ids!r}, "
+            f"workspace={workspace_skill_ids!r}"
+        )
+
+
 def _mounted_skill_records(
     mounted_skills: list[LiveAgentSkill],
 ) -> list[dict[str, Any]]:
@@ -409,7 +427,10 @@ def _redact_value(value: Any) -> Any:
     if isinstance(value, str):
         return _redact(value)
     if isinstance(value, dict):
-        return {key: _redact_value(item) for key, item in value.items()}
+        return {
+            _redact(str(key)): _redact_value(item)
+            for key, item in value.items()
+        }
     if isinstance(value, list):
         return [_redact_value(item) for item in value]
     return value

--- a/tests/test_live_agent_runtime.py
+++ b/tests/test_live_agent_runtime.py
@@ -1,0 +1,419 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from hermes_skilleval.live_agent_runtime import (
+    AgentRequest,
+    AgentRunner,
+    AgentVerifier,
+    FakeAgentRunner,
+    FakeVerifier,
+    LiveAgentSkill,
+    build_condition,
+    execute_live_agent,
+    prepare_live_agent_workspace,
+)
+
+
+def _skill(skill_id: str = "skill/browser-login") -> LiveAgentSkill:
+    return LiveAgentSkill(
+        skill_id=skill_id,
+        name="Browser Login",
+        body="Use browser automation. token=SECRET123",
+    )
+
+
+def test_live_agent_request_and_result_serialize_schema(tmp_path):
+    condition = build_condition(
+        task_id="task-1",
+        prompt="Do the task",
+        condition="routed-skill",
+        routed_skills=[_skill()],
+    )
+    workspace = prepare_live_agent_workspace(
+        base_dir=tmp_path,
+        run_id="run-1",
+        mounted_skills=condition.mounted_skills,
+    )
+    request = AgentRequest(
+        run_id="run-1",
+        task_id="task-1",
+        prompt=condition.prompt,
+        condition=condition.condition,
+        prompt_hash=condition.prompt_hash,
+        workspace_path=workspace.workspace_path,
+        mounted_skills=workspace.mounted_skills,
+        timeout_seconds=30,
+    )
+
+    result = execute_live_agent(
+        request=request,
+        runner=FakeAgentRunner(events=[{"type": "final", "message": "done"}]),
+        verifier=FakeVerifier(pass_=True, details={"checked": True}),
+    )
+    trace = result.to_trace()
+
+    assert isinstance(FakeAgentRunner(), AgentRunner)
+    assert isinstance(FakeVerifier(pass_=True), AgentVerifier)
+    assert trace["schema_version"] == "live-agent.v1"
+    assert trace["request"]["task_id"] == "task-1"
+    assert trace["result"]["process_exit_code"] == 0
+    assert trace["result"]["verifier"]["passed"] is True
+    assert trace["result"]["task_success"] is True
+    assert trace["result"]["usage"] is None
+    assert trace["result"]["cost"] is None
+    json.dumps(trace)
+
+
+def test_condition_builders_preserve_prompt_hash_and_skill_injection():
+    prompt = "Complete the same task."
+    no_skill = build_condition(task_id="t", prompt=prompt, condition="no-skill")
+    routed = build_condition(
+        task_id="t",
+        prompt=prompt,
+        condition="routed-skill",
+        routed_skills=[_skill("skill/routed")],
+    )
+    oracle = build_condition(
+        task_id="t",
+        prompt=prompt,
+        condition="oracle-skill",
+        oracle_skills=[_skill("skill/oracle")],
+    )
+
+    assert no_skill.prompt_hash == routed.prompt_hash == oracle.prompt_hash
+    assert no_skill.mounted_skills == []
+    assert [skill.skill_id for skill in routed.mounted_skills] == ["skill/routed"]
+    assert [skill.skill_id for skill in oracle.mounted_skills] == ["skill/oracle"]
+
+
+def test_no_skill_condition_rejects_skill_leakage():
+    with pytest.raises(ValueError, match="no-skill"):
+        build_condition(
+            task_id="t",
+            prompt="Do it",
+            condition="no-skill",
+            routed_skills=[_skill()],
+        )
+
+
+def test_workspace_preparation_mounts_skills_and_rejects_reuse(tmp_path):
+    skill = _skill()
+    workspace = prepare_live_agent_workspace(
+        base_dir=tmp_path,
+        run_id="run-1",
+        mounted_skills=[skill],
+    )
+
+    assert workspace.workspace_path.exists()
+    assert workspace.skill_dir.exists()
+    mounted = workspace.mounted_skills[0]
+    assert mounted["skill_id"] == "skill/browser-login"
+    assert mounted["sha256"]
+    assert (workspace.workspace_path / mounted["relative_path"]).read_text(
+        encoding="utf-8"
+    ) == skill.body
+
+    with pytest.raises(ValueError, match="already exists"):
+        prepare_live_agent_workspace(
+            base_dir=tmp_path,
+            run_id="run-1",
+            mounted_skills=[skill],
+        )
+
+
+def test_workspace_mount_filenames_are_collision_resistant(tmp_path):
+    workspace = prepare_live_agent_workspace(
+        base_dir=tmp_path,
+        run_id="run-collision",
+        mounted_skills=[
+            _skill("skill/a"),
+            _skill("skill_a"),
+        ],
+    )
+
+    paths = [record["relative_path"] for record in workspace.mounted_skills]
+    assert len(paths) == len(set(paths))
+    assert all((workspace.workspace_path / path).is_file() for path in paths)
+
+    with pytest.raises(ValueError, match="duplicate skill_id"):
+        prepare_live_agent_workspace(
+            base_dir=tmp_path,
+            run_id="run-duplicate",
+            mounted_skills=[_skill("skill/a"), _skill("skill/a")],
+        )
+    assert not (tmp_path / "run-duplicate").exists()
+
+
+def test_fake_runner_separates_process_exit_from_verifier_result(tmp_path):
+    condition = build_condition(
+        task_id="task-1",
+        prompt="Do the task",
+        condition="routed-skill",
+        routed_skills=[_skill()],
+    )
+    workspace = prepare_live_agent_workspace(
+        base_dir=tmp_path,
+        run_id="run-2",
+        mounted_skills=condition.mounted_skills,
+    )
+    request = AgentRequest.from_condition(
+        run_id="run-2",
+        condition=condition,
+        workspace=workspace,
+        timeout_seconds=10,
+    )
+
+    result = execute_live_agent(
+        request=request,
+        runner=FakeAgentRunner(exit_code=0, events=[{"type": "final", "message": "ok"}]),
+        verifier=FakeVerifier(pass_=False, details={"reason": "wrong output"}),
+    )
+
+    assert result.process_exit_code == 0
+    assert result.verifier_passed is False
+    assert result.task_success is False
+
+
+def test_fake_runner_process_failure_is_not_verifier_failure(tmp_path):
+    request = _request(tmp_path, run_id="run-process-fail")
+
+    result = execute_live_agent(
+        request=request,
+        runner=FakeAgentRunner(exit_code=7, stderr="process failed"),
+        verifier=FakeVerifier(pass_=True),
+    )
+
+    assert result.process_exit_code == 7
+    assert result.verifier_passed is True
+    assert result.task_success is True
+    assert result.stderr == "process failed"
+
+
+def test_fake_runner_timeout_records_process_state(tmp_path):
+    request = _request(tmp_path, run_id="run-timeout")
+
+    result = execute_live_agent(
+        request=request,
+        runner=FakeAgentRunner(timed_out=True, exit_code=None),
+        verifier=FakeVerifier(pass_=False),
+    )
+
+    assert result.timed_out is True
+    assert result.process_exit_code is None
+    assert result.task_success is False
+
+
+def test_skill_use_evidence_tracks_mounted_read_declared_and_unknown(tmp_path):
+    skill = _skill("skill/a")
+    condition = build_condition(
+        task_id="task-1",
+        prompt="Do the task",
+        condition="routed-skill",
+        routed_skills=[skill, _skill("skill/b"), _skill("skill/c")],
+    )
+    workspace = prepare_live_agent_workspace(
+        base_dir=tmp_path,
+        run_id="run-evidence",
+        mounted_skills=condition.mounted_skills,
+    )
+    request = AgentRequest.from_condition(
+        run_id="run-evidence",
+        condition=condition,
+        workspace=workspace,
+        timeout_seconds=10,
+    )
+
+    result = execute_live_agent(
+        request=request,
+        runner=FakeAgentRunner(
+            events=[
+                {"type": "skill_read", "skill_id": "skill/a"},
+                {"type": "skill_declared", "skill_id": "skill/b"},
+                {"type": "skill_read", "skill_id": "skill/not-mounted"},
+            ]
+        ),
+        verifier=FakeVerifier(pass_=True),
+    )
+
+    assert result.skill_use["skill/a"]["state"] == "READ"
+    assert result.skill_use["skill/b"]["state"] == "DECLARED"
+    assert result.skill_use["skill/c"]["state"] == "MOUNTED_ONLY"
+    assert result.skill_use["skill/not-mounted"]["state"] == "UNKNOWN"
+
+
+def test_malformed_event_fails_closed(tmp_path):
+    request = _request(tmp_path, run_id="run-malformed")
+
+    with pytest.raises(ValueError, match="malformed event"):
+        execute_live_agent(
+            request=request,
+            runner=FakeAgentRunner(events=["not-an-object"]),
+            verifier=FakeVerifier(pass_=True),
+        )
+
+
+def test_unknown_events_are_preserved_without_crashing(tmp_path):
+    request = _request(tmp_path, run_id="run-unknown")
+
+    result = execute_live_agent(
+        request=request,
+        runner=FakeAgentRunner(events=[{"type": "future_event", "payload": "x"}]),
+        verifier=FakeVerifier(pass_=True),
+    )
+
+    assert result.events[0]["type"] == "unknown"
+    assert result.events[0]["original_type"] == "future_event"
+
+
+def test_secret_redaction_and_log_truncation(tmp_path):
+    request = _request(
+        tmp_path,
+        run_id="run-redact",
+        prompt="Do the task with token=PROMPTSECRET",
+        metadata={"note": "password=METASECRET"},
+    )
+    secret_text = "token=SECRET123 password=hunter2 " + ("x" * 200)
+
+    result = execute_live_agent(
+        request=request,
+        runner=FakeAgentRunner(
+            stdout=secret_text,
+            stderr="api_key=abc123",
+            events=[{"type": "final", "message": secret_text}],
+        ),
+        verifier=FakeVerifier(pass_=True, details={"note": "api_key=VERIFYSECRET"}),
+        max_log_chars=80,
+    )
+    trace = result.to_trace()
+    serialized = json.dumps(trace)
+
+    assert "SECRET123" not in serialized
+    assert "hunter2" not in serialized
+    assert "abc123" not in serialized
+    assert "PROMPTSECRET" not in serialized
+    assert "METASECRET" not in serialized
+    assert "VERIFYSECRET" not in serialized
+    assert str(tmp_path) not in serialized
+    assert "[REDACTED]" in serialized
+    assert trace["result"]["stdout_truncated"] is True
+    assert len(trace["result"]["stdout"]) <= 80
+
+
+def test_release_sensitive_patterns_are_redacted_from_trace(tmp_path):
+    request = _request(
+        tmp_path,
+        run_id="run-sensitive",
+        prompt=(
+            "Bearer bearer-secret sk-1234567890abcdef "
+            "BEGIN OPENSSH PRIVATE KEY /root/private-cache 10.0.0.1"
+        ),
+        metadata={
+            "aws": "AKIA1234567890ABCDEF",
+            "ssh": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIexample",
+        },
+    )
+
+    result = execute_live_agent(
+        request=request,
+        runner=FakeAgentRunner(
+            stdout="access_token: value-123 auth-token=secret-value",
+            stderr="PRIVATE KEY 192.168.0.10",
+            events=[
+                {"type": "final", "message": "api-key=secret 172.16.0.5"},
+                {
+                    "type": "future_event",
+                    "payload": "Bearer event-secret /root/event-cache",
+                },
+            ],
+        ),
+        verifier=FakeVerifier(
+            pass_=True,
+            details={"path": "/root/verifier", "secret": "sk-verifier123456"},
+        ),
+    )
+
+    serialized = json.dumps(result.to_trace())
+    for leaked in [
+        "bearer-secret",
+        "sk-1234567890abcdef",
+        "PRIVATE KEY",
+        "/root/private-cache",
+        "10.0.0.1",
+        "AKIA1234567890ABCDEF",
+        "ssh-ed25519",
+        "value-123",
+        "secret-value",
+        "192.168.0.10",
+        "172.16.0.5",
+        "event-secret",
+        "/root/verifier",
+        "sk-verifier123456",
+    ]:
+        assert leaked not in serialized
+    assert serialized.count("[REDACTED]") >= 8
+
+
+def test_sensitive_skill_ids_are_redacted_from_trace_events_and_skill_use(tmp_path):
+    skill_id = "sk-1234567890abcdef"
+    condition = build_condition(
+        task_id="task-1",
+        prompt="Do the task",
+        condition="routed-skill",
+        routed_skills=[_skill(skill_id)],
+    )
+    workspace = prepare_live_agent_workspace(
+        base_dir=tmp_path,
+        run_id="run-sensitive-skill-id",
+        mounted_skills=condition.mounted_skills,
+    )
+    request = AgentRequest.from_condition(
+        run_id="run-sensitive-skill-id",
+        condition=condition,
+        workspace=workspace,
+        timeout_seconds=10,
+    )
+
+    result = execute_live_agent(
+        request=request,
+        runner=FakeAgentRunner(
+            events=[
+                {"type": "skill_read", "skill_id": skill_id},
+                {"type": "skill_declared", "skill_id": "Bearer leaked-token"},
+            ]
+        ),
+        verifier=FakeVerifier(pass_=True),
+    )
+
+    serialized = json.dumps(result.to_trace())
+    assert skill_id not in serialized
+    assert "leaked-token" not in serialized
+    assert "[REDACTED]" in serialized
+
+
+def _request(
+    tmp_path: Path,
+    *,
+    run_id: str,
+    prompt: str = "Do the task",
+    metadata: dict[str, str] | None = None,
+) -> AgentRequest:
+    condition = build_condition(
+        task_id="task-1",
+        prompt=prompt,
+        condition="routed-skill",
+        routed_skills=[_skill()],
+    )
+    workspace = prepare_live_agent_workspace(
+        base_dir=tmp_path,
+        run_id=run_id,
+        mounted_skills=condition.mounted_skills,
+    )
+    return AgentRequest.from_condition(
+        run_id=run_id,
+        condition=condition,
+        workspace=workspace,
+        timeout_seconds=10,
+        metadata=metadata,
+    )

--- a/tests/test_live_agent_runtime.py
+++ b/tests/test_live_agent_runtime.py
@@ -98,6 +98,116 @@ def test_no_skill_condition_rejects_skill_leakage():
         )
 
 
+def test_routed_condition_rejects_oracle_workspace(tmp_path):
+    routed = build_condition(
+        task_id="task-1",
+        prompt="Do the task",
+        condition="routed-skill",
+        routed_skills=[_skill("skill/routed")],
+    )
+    oracle = build_condition(
+        task_id="task-1",
+        prompt="Do the task",
+        condition="oracle-skill",
+        oracle_skills=[_skill("skill/oracle")],
+    )
+    workspace = prepare_live_agent_workspace(
+        base_dir=tmp_path,
+        run_id="run-routed-oracle-mismatch",
+        mounted_skills=oracle.mounted_skills,
+    )
+
+    with pytest.raises(ValueError, match="mounted skill IDs"):
+        AgentRequest.from_condition(
+            run_id="run-routed-oracle-mismatch",
+            condition=routed,
+            workspace=workspace,
+            timeout_seconds=10,
+        )
+
+
+def test_oracle_condition_rejects_routed_workspace(tmp_path):
+    routed = build_condition(
+        task_id="task-1",
+        prompt="Do the task",
+        condition="routed-skill",
+        routed_skills=[_skill("skill/routed")],
+    )
+    oracle = build_condition(
+        task_id="task-1",
+        prompt="Do the task",
+        condition="oracle-skill",
+        oracle_skills=[_skill("skill/oracle")],
+    )
+    workspace = prepare_live_agent_workspace(
+        base_dir=tmp_path,
+        run_id="run-oracle-routed-mismatch",
+        mounted_skills=routed.mounted_skills,
+    )
+
+    with pytest.raises(ValueError, match="mounted skill IDs"):
+        AgentRequest.from_condition(
+            run_id="run-oracle-routed-mismatch",
+            condition=oracle,
+            workspace=workspace,
+            timeout_seconds=10,
+        )
+
+
+def test_no_skill_condition_rejects_non_empty_workspace_before_execution(tmp_path):
+    condition = build_condition(
+        task_id="task-1",
+        prompt="Do the task",
+        condition="no-skill",
+    )
+    workspace = prepare_live_agent_workspace(
+        base_dir=tmp_path,
+        run_id="run-no-skill-workspace-leak",
+        mounted_skills=[_skill("skill/leaked")],
+    )
+
+    with pytest.raises(ValueError, match="mounted skill IDs"):
+        AgentRequest.from_condition(
+            run_id="run-no-skill-workspace-leak",
+            condition=condition,
+            workspace=workspace,
+            timeout_seconds=10,
+        )
+
+
+def test_matching_condition_workspace_builds_and_executes(tmp_path):
+    condition = build_condition(
+        task_id="task-1",
+        prompt="Do the task",
+        condition="routed-skill",
+        routed_skills=[_skill("skill/a"), _skill("skill/b")],
+    )
+    workspace = prepare_live_agent_workspace(
+        base_dir=tmp_path,
+        run_id="run-match",
+        mounted_skills=condition.mounted_skills,
+    )
+
+    request = AgentRequest.from_condition(
+        run_id="run-match",
+        condition=condition,
+        workspace=workspace,
+        timeout_seconds=10,
+    )
+    result = execute_live_agent(
+        request=request,
+        runner=FakeAgentRunner(events=[{"type": "final", "message": "ok"}]),
+        verifier=FakeVerifier(pass_=True),
+    )
+
+    assert [record["skill_id"] for record in request.mounted_skills] == [
+        "skill/a",
+        "skill/b",
+    ]
+    assert result.task_success is True
+    assert condition.prompt_hash == request.prompt_hash
+
+
 def test_workspace_preparation_mounts_skills_and_rejects_reuse(tmp_path):
     skill = _skill()
     workspace = prepare_live_agent_workspace(
@@ -389,6 +499,48 @@ def test_sensitive_skill_ids_are_redacted_from_trace_events_and_skill_use(tmp_pa
     serialized = json.dumps(result.to_trace())
     assert skill_id not in serialized
     assert "leaked-token" not in serialized
+    assert "[REDACTED]" in serialized
+
+
+def test_secret_like_dict_keys_are_recursively_redacted_from_trace(tmp_path):
+    request = _request(
+        tmp_path,
+        run_id="run-secret-keys",
+        metadata={
+            "sk-1234567890abcdef": "metadata-key",
+            "nested": {"password=SECRET": "nested-key"},
+        },
+    )
+
+    result = execute_live_agent(
+        request=request,
+        runner=FakeAgentRunner(
+            events=[
+                {
+                    "type": "future_event",
+                    "Bearer leaked-token": {
+                        "password=SECRET": "event-key",
+                    },
+                }
+            ]
+        ),
+        verifier=FakeVerifier(
+            pass_=True,
+            details={
+                "api_key=VERIFYSECRET": "verifier-key",
+                "nested": {"password=SECRET": "verifier-nested-key"},
+            },
+        ),
+    )
+
+    serialized = json.dumps(result.to_trace())
+    for leaked in [
+        "sk-1234567890abcdef",
+        "api_key=VERIFYSECRET",
+        "Bearer leaked-token",
+        "password=SECRET",
+    ]:
+        assert leaked not in serialized
     assert "[REDACTED]" in serialized
 
 


### PR DESCRIPTION
## Summary

- Add additive `live-agent.v1` fake runtime contract with `AgentRunner` / `AgentVerifier` protocols, request/result dataclasses, and deterministic trace serialization.
- Add `no-skill`, `routed-skill`, and `oracle-skill` condition builders with prompt-hash parity and no-skill leakage checks.
- Add condition/workspace mounted-skill ID parity checks so request construction fails closed on routed/oracle/no-skill workspace injection mismatch.
- Add isolated workspace prep with collision-resistant mounted skill filenames, duplicate-skill fail-closed behavior, mounted skill SHA-256 records, fake runner/verifier, skill-use evidence states, timeout/process/verifier separation, recursive key/value redaction, and malformed/unknown event handling.
- Add PR-4 OpenSpec artifacts and Chinese Human Brief.

## Scope Boundaries

- Does not integrate real Codex CLI.
- Does not integrate SkillsBench.
- Does not run live agents.
- Does not modify Phase 10 deterministic offline replay.
- Does not modify external matrix, SkillRouter scorer, router promotion, or release gate logic.
- Usage/cost remain `null` when unavailable.
- Formal JSON Schema validation is documented as deferred to PR-5 before real Codex traces are accepted.

## Validation

- `python -m pytest -q tests/test_live_agent_runtime.py` -> 19 passed
- `python -m pytest -q` -> 503 passed
- `OPENSPEC_TELEMETRY=0 openspec validate --all --strict` -> 20 passed, 0 failed
- `PYTHONPATH=src python -m hermes_skilleval.cli release-check --phase17-output-dir docs/demo/phase17-calibrated-release-selector --release-output-dir docs/demo/phase18-ci-release-reproducibility` -> PASS
- `git diff --check` -> PASS
- v0.3 YAML parse check -> parsed 3 v0.3 YAML files
- CRLF/new-file line-ending check -> LF only in 5 changed/new text files

## Review Notes

Latest request-changes pass fixed two blocking live-agent evidence contract issues:

- `AgentRequest.from_condition(...)` now fails closed unless ordered condition mounted skill IDs match ordered workspace mounted skill IDs. Regression tests cover routed condition + oracle workspace, oracle condition + routed workspace, no-skill condition + non-empty workspace before runner execution, and matching condition/workspace execution.
- `_redact_value(...)` now recursively redacts dict keys as well as values. Regression tests cover secret-like metadata keys, verifier detail keys, unknown event keys, nested keys, event skill IDs, skill_use keys, mounted skill records, stdout/stderr, and final messages.
