### PR TITLE
PR-5: add Codex CLI runner isolation

### DIFF
--- a/docs/human-briefs/2026-06-28-codex-cli-runner-isolation.html
+++ b/docs/human-briefs/2026-06-28-codex-cli-runner-isolation.html
@@ -82,8 +82,10 @@
     <ul>
       <li>新增 <code>CodexCliRunnerConfig</code> 和 <code>CodexCliRunner</code>，保持 PR-4 <code>AgentRunner</code> / verifier contract。</li>
       <li>默认使用 isolated <code>CODEX_HOME</code>、<code>--json</code>、<code>--ephemeral</code>、<code>--ignore-user-config</code>、<code>--ignore-rules</code>、<code>--sandbox workspace-write</code>、<code>--output-last-message</code>。</li>
-      <li>继承 <code>CODEX_HOME</code> 只允许 smoke-only metadata，并 fail-closed 检测 global skills/plugins/MCP/config leakage。</li>
-      <li>拒绝 <code>danger-full-access</code>、dangerous bypass flags、<code>--yolo</code>、runner control flag override 和 <code>CODEX_HOME</code> override。</li>
+      <li>benchmark skills 挂载到 <code>.agents/skills/&lt;safe-skill-id&gt;/SKILL.md</code>，每个文件包含 Codex skill <code>name</code> / <code>description</code> metadata。</li>
+      <li>final-evidence isolated mode 同时隔离 <code>HOME</code>，并记录 user/admin/workspace-parent/bundled skill inventory；继承 <code>CODEX_HOME</code> 只允许 smoke-only metadata。</li>
+      <li>拒绝 <code>danger-full-access</code>、dangerous bypass flags、<code>--yolo</code>、runner control flag override、<code>--flag=value</code> control forms 和 <code>CODEX_HOME</code> override。</li>
+      <li><code>--skip-git-repo-check</code> 只能由 runner 在 help 显示支持时受控加入，不能通过用户 <code>extra_args</code> 注入。</li>
       <li>用 fake executable 覆盖 success、timeout process-group cleanup、JSONL parsing、malformed/unknown events、skill evidence、redaction、truncation。</li>
       <li>新增并收紧 <code>schemas/live-agent-trace.schema.json</code>，验证 fake 和 Codex runner trace 以及非法 skill state。</li>
     </ul>

--- a/docs/human-briefs/2026-06-28-codex-cli-runner-isolation.html
+++ b/docs/human-briefs/2026-06-28-codex-cli-runner-isolation.html
@@ -84,7 +84,8 @@
       <li>默认使用 isolated <code>CODEX_HOME</code>、<code>--json</code>、<code>--ephemeral</code>、<code>--ignore-user-config</code>、<code>--ignore-rules</code>、<code>--sandbox workspace-write</code>、<code>--output-last-message</code>。</li>
       <li>benchmark skills 挂载到 <code>.agents/skills/&lt;safe-skill-id&gt;/SKILL.md</code>，每个文件包含 Codex skill <code>name</code> / <code>description</code> metadata。</li>
       <li>final-evidence isolated mode 同时隔离 <code>HOME</code>，并记录 user/admin/workspace-parent/bundled skill inventory；继承 <code>CODEX_HOME</code> 只允许 smoke-only metadata。</li>
-      <li>拒绝 <code>danger-full-access</code>、dangerous bypass flags、<code>--yolo</code>、runner control flag override、<code>--flag=value</code> control forms 和 <code>CODEX_HOME</code> override。</li>
+      <li>拒绝 <code>danger-full-access</code>、dangerous bypass flags、<code>--yolo</code>、runner control flag override、<code>--flag=value</code> control forms，以及 <code>CODEX_HOME</code> / <code>HOME</code> / XDG 等 runner-controlled env override。</li>
+      <li>dot-prefixed skill directories 如果包含 <code>SKILL.md</code>，也按可能的 skill leakage 计数。</li>
       <li><code>--skip-git-repo-check</code> 只能由 runner 在 help 显示支持时受控加入，不能通过用户 <code>extra_args</code> 注入。</li>
       <li>用 fake executable 覆盖 success、timeout process-group cleanup、JSONL parsing、malformed/unknown events、skill evidence、redaction、truncation。</li>
       <li>新增并收紧 <code>schemas/live-agent-trace.schema.json</code>，验证 fake 和 Codex runner trace 以及非法 skill state。</li>

--- a/docs/human-briefs/2026-06-28-codex-cli-runner-isolation.html
+++ b/docs/human-briefs/2026-06-28-codex-cli-runner-isolation.html
@@ -1,0 +1,122 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>PR-5 Codex CLI Runner Isolation - Human Brief</title>
+  <style>
+    :root {
+      color-scheme: light;
+      --ink: #1f2933;
+      --muted: #64748b;
+      --line: #d6dde6;
+      --band: #f5f7fa;
+      --accent: #0f766e;
+    }
+    body {
+      margin: 0;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      color: var(--ink);
+      background: #fff;
+      line-height: 1.55;
+    }
+    main {
+      max-width: 920px;
+      margin: 0 auto;
+      padding: 36px 24px 48px;
+    }
+    h1 {
+      margin: 0 0 8px;
+      font-size: 30px;
+      letter-spacing: 0;
+    }
+    h2 {
+      margin: 28px 0 10px;
+      font-size: 18px;
+      letter-spacing: 0;
+    }
+    p {
+      margin: 8px 0;
+    }
+    ul {
+      margin: 8px 0 0;
+      padding-left: 22px;
+    }
+    li {
+      margin: 5px 0;
+    }
+    code {
+      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      font-size: 0.94em;
+      background: var(--band);
+      padding: 1px 4px;
+      border-radius: 4px;
+    }
+    .status {
+      display: inline-block;
+      margin: 8px 0 18px;
+      padding: 4px 10px;
+      border: 1px solid var(--line);
+      border-left: 4px solid var(--accent);
+      background: var(--band);
+      font-weight: 600;
+    }
+    .summary {
+      font-size: 18px;
+      border-top: 1px solid var(--line);
+      border-bottom: 1px solid var(--line);
+      padding: 16px 0;
+    }
+    .muted {
+      color: var(--muted);
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>PR-5: Codex CLI Runner Isolation</h1>
+    <div class="status">状态：needs review</div>
+    <p class="summary">本阶段只新增 <code>CodexCliRunner</code> 隔离执行层，用 fake Codex executable 测试真实 subprocess 语义，不运行 SkillsBench 或 live-agent benchmark。</p>
+
+    <h2>本阶段变化</h2>
+    <ul>
+      <li>新增 <code>CodexCliRunnerConfig</code> 和 <code>CodexCliRunner</code>，保持 PR-4 <code>AgentRunner</code> / verifier contract。</li>
+      <li>默认使用 isolated <code>CODEX_HOME</code>、<code>--json</code>、<code>--ephemeral</code>、<code>--ignore-user-config</code>、<code>--ignore-rules</code>、<code>--sandbox workspace-write</code>、<code>--output-last-message</code>。</li>
+      <li>继承 <code>CODEX_HOME</code> 只允许 smoke-only metadata，并 fail-closed 检测 global skills/plugins/MCP/config leakage。</li>
+      <li>拒绝 <code>danger-full-access</code>、dangerous bypass flags、<code>--yolo</code>、runner control flag override 和 <code>CODEX_HOME</code> override。</li>
+      <li>用 fake executable 覆盖 success、timeout process-group cleanup、JSONL parsing、malformed/unknown events、skill evidence、redaction、truncation。</li>
+      <li>新增并收紧 <code>schemas/live-agent-trace.schema.json</code>，验证 fake 和 Codex runner trace 以及非法 skill state。</li>
+    </ul>
+
+    <h2>关键文件</h2>
+    <ul>
+      <li><code>src/hermes_skilleval/live_agent_runtime.py</code></li>
+      <li><code>tests/test_codex_cli_runner.py</code></li>
+      <li><code>schemas/live-agent-trace.schema.json</code></li>
+      <li><code>openspec/changes/codex-cli-runner-isolation/</code></li>
+    </ul>
+
+    <h2>验证</h2>
+    <p class="muted">最终验证结果以 PR 描述和命令输出为准。本 brief 只做人工审阅索引。</p>
+    <ul>
+      <li><code>python -m pytest -q tests/test_codex_cli_runner.py</code></li>
+      <li><code>python -m pytest -q tests/test_live_agent_runtime.py</code></li>
+      <li><code>python -m pytest -q</code></li>
+      <li><code>OPENSPEC_TELEMETRY=0 openspec validate --all --strict</code></li>
+      <li><code>release-check</code>、<code>git diff --check</code>、v0.3 YAML parse、CRLF/new-file check</li>
+    </ul>
+
+    <h2>边界与限制</h2>
+    <ul>
+      <li>没有接入 SkillsBench，没有运行 full live-agent benchmark。</li>
+      <li>没有修改 Phase 10 deterministic offline replay。</li>
+      <li>没有修改 external matrix、SkillRouter scorer、router promotion 或 release gate。</li>
+      <li>agent process exit code 只作为过程状态，task success 仍来自 verifier。</li>
+      <li>usage/cost 在没有可靠 token usage 时保持 <code>null</code>。</li>
+    </ul>
+
+    <h2>建议下一步</h2>
+    <p>先完成 PR-5 review；SkillsBench adapter、task freezing 和 live matrix 留到 PR-6。</p>
+  </main>
+</body>
+</html>

--- a/docs/v0.3/codex-implementation-guide.md
+++ b/docs/v0.3/codex-implementation-guide.md
@@ -190,10 +190,14 @@ Expected work:
   when supported by the installed CLI.
 - Never use `--yolo` or danger-full-access for benchmark evidence.
 - Support isolated and inherited `CODEX_HOME` modes; final evidence defaults
-  to isolated mode.
-- Preflight global skills, plugins, MCP, and config leakage.
-- Mount benchmark skills under a workspace-local skill directory.
+  to isolated mode with run-local empty `HOME`.
+- Preflight user HOME, admin, workspace-parent, bundled skill inventory,
+  global skills, plugins, MCP, and config leakage.
+- Mount benchmark skills under
+  `.agents/skills/<safe-skill-id>/SKILL.md` with Codex skill metadata.
 - Keep `no-skill` free of benchmark/global skills.
+- Reject runner-control `extra_args` in both split and `--flag=value` forms;
+  only the runner may add `--skip-git-repo-check` after help confirms support.
 - Parse JSONL events for tool calls, file reads, `SKILL.md` reads, final
   messages, token usage when reliable, and unknown event types.
 - Kill the full process group on timeout.

--- a/docs/v0.3/codex-implementation-guide.md
+++ b/docs/v0.3/codex-implementation-guide.md
@@ -180,6 +180,8 @@ Acceptance:
 Goal: implement a real Codex CLI runner with strict isolation, redaction, and
 trace parsing.
 
+Human brief: `docs/human-briefs/2026-06-28-codex-cli-runner-isolation.html`
+
 Expected work:
 
 - Read the local `codex exec --help` and record the actual supported flags.

--- a/docs/v0.3/codex-implementation-guide.md
+++ b/docs/v0.3/codex-implementation-guide.md
@@ -198,6 +198,9 @@ Expected work:
 - Keep `no-skill` free of benchmark/global skills.
 - Reject runner-control `extra_args` in both split and `--flag=value` forms;
   only the runner may add `--skip-git-repo-check` after help confirms support.
+- Reject `extra_env` overrides for runner-controlled home/config keys,
+  including `CODEX_HOME`, `HOME`, Windows home/config keys, and XDG
+  config/data/cache keys.
 - Parse JSONL events for tool calls, file reads, `SKILL.md` reads, final
   messages, token usage when reliable, and unknown event types.
 - Kill the full process group on timeout.

--- a/openspec/changes/codex-cli-runner-isolation/.openspec.yaml
+++ b/openspec/changes/codex-cli-runner-isolation/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-27

--- a/openspec/changes/codex-cli-runner-isolation/design.md
+++ b/openspec/changes/codex-cli-runner-isolation/design.md
@@ -1,0 +1,85 @@
+# Design: Codex CLI Runner Isolation
+
+## Context
+
+PR-4 introduced an offline fake `live-agent.v1` contract. PR-5 is the first
+real process runner layer, but it is still infrastructure only: no SkillsBench
+tasks, no full live-agent benchmark, and no promotion logic. The runner must
+make real Codex subprocess behavior observable without letting process success
+replace verifier success.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Implement a `CodexCliRunner` that satisfies `AgentRunner`.
+- Use `codex exec` in non-interactive JSONL mode.
+- Default to isolated `CODEX_HOME`; allow inherit mode only for explicit smoke
+  tests.
+- Use workspace-write sandbox and approval policy never.
+- Fail closed on unsupported or unsafe CLI flags, `danger-full-access`, bypass
+  flags, inherited global skill/plugin/MCP/config leakage, and no-skill skill
+  injection.
+- Preserve PR-4 condition/workspace mounted-skill ordering and verifier source
+  of truth.
+- Parse JSONL defensively and retain unknown events without crashing.
+- Kill the process group on timeout.
+- Redact and truncate stdout/stderr and trace-visible event data.
+- Provide a JSON Schema for `live-agent.v1` traces before real Codex traces are
+  accepted.
+
+**Non-Goals:**
+
+- No SkillsBench integration, live benchmark matrix, router training/tuning,
+  external matrix/scorer edits, release promotion, or Phase 10 replay changes.
+
+## Decisions
+
+1. **Runner is additive.** `CodexCliRunner` is added beside the fake runner and
+   reuses `AgentRequest`, `RunnerOutput`, `execute_live_agent`, and verifier
+   semantics. The fake API remains stable.
+
+2. **Isolated mode is default.** By default the runner creates a run-local
+   `CODEX_HOME` with no user config. Inherit mode exists for smoke tests only
+   and is marked as not final evidence.
+
+3. **Command construction is explicit.** The default invocation uses
+   `codex exec --json --ephemeral --ignore-user-config --ignore-rules
+   --sandbox workspace-write --cd <workspace> --output-last-message <file>`.
+   Dangerous bypass flags, `danger-full-access`, control-flag overrides, and
+   `CODEX_HOME` environment overrides are rejected before running. Prompt text
+   is passed after `--` so prompt text beginning with flags is not parsed as
+   runner configuration.
+
+4. **Preflight happens before subprocess execution.** Preflight records Codex
+   version/help, checks supported flags, scans inherited `CODEX_HOME` surfaces
+   when inheritance is requested, and rejects no-skill mounted skills.
+
+5. **JSONL parsing is defensive.** Malformed JSONL lines are preserved as
+   unknown events rather than crashing the runner. Unknown event types are
+   preserved and can mark skill activation `UNKNOWN`.
+
+6. **Verifier remains authoritative.** The subprocess exit code is reported,
+   but task success remains verifier pass/fail through PR-4
+   `execute_live_agent`.
+
+## Risks / Trade-offs
+
+- **Risk: real CLI flags drift.** Mitigation: preflight reads `codex exec
+  --help` and records version/help support in metadata.
+- **Risk: global config leaks into evidence.** Mitigation: isolated
+  `CODEX_HOME` is default; inherit mode is explicitly smoke-only and scanned.
+- **Risk: process hangs.** Mitigation: timeout sends process-group `SIGTERM`
+  and then bounded `SIGKILL` fallback, not only parent-process cleanup.
+- **Risk: runner output leaks before trace serialization.** Mitigation:
+  runner-level events, final messages, stdout, and stderr are redacted and
+  size-bounded before returning `RunnerOutput`.
+- **Risk: schema hardens incorrectly.** Mitigation: schema covers the stable
+  PR-4 trace envelope and is validated by tests against fake and CLI-runner
+  traces.
+
+## Migration Plan
+
+PR-5 is additive. Existing fake runner tests and Phase 10 deterministic replay
+remain unchanged. Rollback is removing `CodexCliRunner`, schema, tests, PR-5
+OpenSpec artifacts, and the Human Brief.

--- a/openspec/changes/codex-cli-runner-isolation/design.md
+++ b/openspec/changes/codex-cli-runner-isolation/design.md
@@ -16,10 +16,14 @@ replace verifier success.
 - Use `codex exec` in non-interactive JSONL mode.
 - Default to isolated `CODEX_HOME`; allow inherit mode only for explicit smoke
   tests.
+- Set `HOME` to a run-local empty home in isolated final-evidence mode and
+  inventory all known skill surfaces before subprocess execution.
 - Use workspace-write sandbox and approval policy never.
 - Fail closed on unsupported or unsafe CLI flags, `danger-full-access`, bypass
-  flags, inherited global skill/plugin/MCP/config leakage, and no-skill skill
-  injection.
+  flags, `--flag=value` control-flag forms, global skill/plugin/MCP/config
+  leakage, and no-skill skill injection.
+- Mount benchmark skills in Codex-discoverable repo skill format under
+  `.agents/skills/<safe-skill-id>/SKILL.md`.
 - Preserve PR-4 condition/workspace mounted-skill ordering and verifier source
   of truth.
 - Parse JSONL defensively and retain unknown events without crashing.
@@ -40,26 +44,33 @@ replace verifier success.
    semantics. The fake API remains stable.
 
 2. **Isolated mode is default.** By default the runner creates a run-local
-   `CODEX_HOME` with no user config. Inherit mode exists for smoke tests only
-   and is marked as not final evidence.
+   `CODEX_HOME` and a run-local empty `HOME`. Inherit mode exists for smoke
+   tests only and is marked as not final evidence.
 
 3. **Command construction is explicit.** The default invocation uses
    `codex exec --json --ephemeral --ignore-user-config --ignore-rules
    --sandbox workspace-write --cd <workspace> --output-last-message <file>`.
    Dangerous bypass flags, `danger-full-access`, control-flag overrides, and
-   `CODEX_HOME` environment overrides are rejected before running. Prompt text
-   is passed after `--` so prompt text beginning with flags is not parsed as
-   runner configuration.
+   `CODEX_HOME` environment overrides are rejected before running. Rejection
+   normalizes `--flag=value` to `--flag`, and runner-controlled
+   `--skip-git-repo-check` is added only when supported by help output. Prompt
+   text is passed after `--` so prompt text beginning with flags is not parsed
+   as runner configuration.
 
 4. **Preflight happens before subprocess execution.** Preflight records Codex
    version/help, checks supported flags, scans inherited `CODEX_HOME` surfaces
-   when inheritance is requested, and rejects no-skill mounted skills.
+   when inheritance is requested, inventories user/admin/workspace-parent skill
+   surfaces, and rejects no-skill mounted skills.
 
-5. **JSONL parsing is defensive.** Malformed JSONL lines are preserved as
+5. **Benchmark skill mounts use Codex skill layout.** Mounted records point to
+   `.agents/skills/<safe-skill-id>/SKILL.md`; each file includes `name` and
+   `description` frontmatter so the repo skill is discoverable by Codex.
+
+6. **JSONL parsing is defensive.** Malformed JSONL lines are preserved as
    unknown events rather than crashing the runner. Unknown event types are
    preserved and can mark skill activation `UNKNOWN`.
 
-6. **Verifier remains authoritative.** The subprocess exit code is reported,
+7. **Verifier remains authoritative.** The subprocess exit code is reported,
    but task success remains verifier pass/fail through PR-4
    `execute_live_agent`.
 
@@ -68,7 +79,9 @@ replace verifier success.
 - **Risk: real CLI flags drift.** Mitigation: preflight reads `codex exec
   --help` and records version/help support in metadata.
 - **Risk: global config leaks into evidence.** Mitigation: isolated
-  `CODEX_HOME` is default; inherit mode is explicitly smoke-only and scanned.
+  `CODEX_HOME` and isolated `HOME` are default; preflight scans user, admin,
+  and workspace-parent skill surfaces, and inherit mode is explicitly
+  smoke-only.
 - **Risk: process hangs.** Mitigation: timeout sends process-group `SIGTERM`
   and then bounded `SIGKILL` fallback, not only parent-process cleanup.
 - **Risk: runner output leaks before trace serialization.** Mitigation:

--- a/openspec/changes/codex-cli-runner-isolation/design.md
+++ b/openspec/changes/codex-cli-runner-isolation/design.md
@@ -21,7 +21,8 @@ replace verifier success.
 - Use workspace-write sandbox and approval policy never.
 - Fail closed on unsupported or unsafe CLI flags, `danger-full-access`, bypass
   flags, `--flag=value` control-flag forms, global skill/plugin/MCP/config
-  leakage, and no-skill skill injection.
+  leakage, runner-controlled environment overrides, and no-skill skill
+  injection.
 - Mount benchmark skills in Codex-discoverable repo skill format under
   `.agents/skills/<safe-skill-id>/SKILL.md`.
 - Preserve PR-4 condition/workspace mounted-skill ordering and verifier source
@@ -51,16 +52,18 @@ replace verifier success.
    `codex exec --json --ephemeral --ignore-user-config --ignore-rules
    --sandbox workspace-write --cd <workspace> --output-last-message <file>`.
    Dangerous bypass flags, `danger-full-access`, control-flag overrides, and
-   `CODEX_HOME` environment overrides are rejected before running. Rejection
-   normalizes `--flag=value` to `--flag`, and runner-controlled
-   `--skip-git-repo-check` is added only when supported by help output. Prompt
-   text is passed after `--` so prompt text beginning with flags is not parsed
-   as runner configuration.
+   runner-controlled environment overrides are rejected before running.
+   Rejection normalizes `--flag=value` to `--flag`, rejects `extra_env`
+   overrides for `CODEX_HOME`, `HOME`, Windows home/config keys, and XDG
+   config/data/cache keys, and adds runner-controlled `--skip-git-repo-check`
+   only when supported by help output. Prompt text is passed after `--` so
+   prompt text beginning with flags is not parsed as runner configuration.
 
 4. **Preflight happens before subprocess execution.** Preflight records Codex
    version/help, checks supported flags, scans inherited `CODEX_HOME` surfaces
    when inheritance is requested, inventories user/admin/workspace-parent skill
-   surfaces, and rejects no-skill mounted skills.
+   surfaces including dot-prefixed directories that contain `SKILL.md`, and
+   rejects no-skill mounted skills.
 
 5. **Benchmark skill mounts use Codex skill layout.** Mounted records point to
    `.agents/skills/<safe-skill-id>/SKILL.md`; each file includes `name` and

--- a/openspec/changes/codex-cli-runner-isolation/proposal.md
+++ b/openspec/changes/codex-cli-runner-isolation/proposal.md
@@ -1,0 +1,58 @@
+# Proposal: Codex CLI Runner Isolation
+
+## Why
+
+PR-4 defined the `live-agent.v1` fake runtime contract. PR-5 needs a real
+`CodexCliRunner` implementation that can invoke `codex exec` under strict local
+isolation while preserving the PR-4 request/result/verifier semantics. This
+must happen before any SkillsBench integration or benchmark-scale live-agent
+evidence is accepted.
+
+Local `codex exec --help` on 2026-06-28 confirms support for:
+
+- `--sandbox read-only|workspace-write|danger-full-access`
+- `--ephemeral`
+- `--ignore-user-config`
+- `--ignore-rules`
+- `--json`
+- `--output-last-message <FILE>`
+- `--cd <DIR>`
+- `--config <key=value>`
+
+It also exposes dangerous bypass flags. PR-5 must reject those for evidence
+runs.
+
+## What Changes
+
+- Add `CodexCliRunner` implementing the PR-4 `AgentRunner` protocol.
+- Add subprocess execution for `codex exec` with non-interactive JSONL mode,
+  workspace-write sandbox, approval policy never, isolated `CODEX_HOME` by
+  default, and process-group cleanup on timeout.
+- Add explicit preflight checks for Codex version/help support, forbidden
+  sandbox flags, global skill/plugin/MCP/config leakage, and no-skill leakage.
+- Mount benchmark skills into a Codex-compatible workspace-local skills path
+  while preserving PR-4 condition/workspace skill semantics.
+- Parse JSONL events defensively, preserving unknown event types and marking
+  skill activation `UNKNOWN` when needed.
+- Add stdout/stderr size limits and reuse PR-4 redaction behavior.
+- Add `schemas/live-agent-trace.schema.json` and validate real Codex traces in
+  tests.
+- Keep usage/cost `null` unless reliable token usage is available.
+
+## Out Of Scope
+
+- No SkillsBench adapter or live-agent benchmark matrix.
+- No router training, threshold tuning, or model inference.
+- No external SkillRouter matrix/scorer changes.
+- No router promotion or release gate changes.
+- No Phase 10 deterministic offline replay changes.
+- No `--yolo`, `danger-full-access`, or dangerous bypass flags.
+
+## Impact
+
+- Affected code: PR-4 live-agent runtime module, if needed for additive runner
+  classes/helpers only.
+- Affected tests: new Codex CLI runner tests using fake local executable
+  scripts, not the real live benchmark.
+- Affected docs/OpenSpec: PR-5 OpenSpec artifacts, trace schema, and concise
+  Human Brief.

--- a/openspec/changes/codex-cli-runner-isolation/specs/live-agent-runtime/spec.md
+++ b/openspec/changes/codex-cli-runner-isolation/specs/live-agent-runtime/spec.md
@@ -1,0 +1,120 @@
+## MODIFIED Requirements
+
+### Requirement: Define live-agent runtime contract
+
+The system SHALL define a `live-agent.v1` runtime contract without invoking a
+real Codex CLI or SkillsBench process.
+
+#### Scenario: Construct request and result records
+
+- **WHEN** a caller builds a live-agent request
+- **THEN** the request MUST include task ID, prompt, condition, workspace path,
+  mounted skills, timeout, and metadata
+- **AND** the result MUST include process exit code, timeout status, verifier
+  outcome, trace schema version, usage, and cost
+- **AND** usage and cost MUST be `null` when unavailable
+
+#### Scenario: Reject condition and workspace mismatch
+
+- **WHEN** a request is built from a condition and prepared workspace
+- **THEN** the ordered condition mounted skill IDs MUST match the ordered
+  workspace mounted skill IDs
+- **AND** request construction MUST fail closed when they differ
+
+#### Scenario: Validate trace schema
+
+- **WHEN** a real Codex CLI runner emits a `live-agent.v1` trace
+- **THEN** the trace MUST validate against
+  `schemas/live-agent-trace.schema.json`
+
+## ADDED Requirements
+
+### Requirement: Run Codex CLI with isolated execution
+
+The system SHALL provide a `CodexCliRunner` that invokes `codex exec`
+non-interactively without using live benchmark tasks.
+
+#### Scenario: Build safe default command
+
+- **WHEN** the runner is configured in default isolated mode
+- **THEN** it MUST use an isolated run-local `CODEX_HOME`
+- **AND** it MUST invoke `codex exec` with JSONL output, ephemeral session,
+  workspace-write sandbox, ignored user config, ignored rules, and output-last
+  message capture
+- **AND** it MUST NOT use `--yolo`, `danger-full-access`, or dangerous bypass
+  flags
+- **AND** it MUST reject runner-control flag overrides and `CODEX_HOME`
+  overrides
+- **AND** prompt text MUST NOT be parsed as runner flags
+
+#### Scenario: Allow inherited mode only for smoke tests
+
+- **WHEN** the runner is configured to inherit `CODEX_HOME`
+- **THEN** the run metadata MUST mark inherited mode as smoke-only
+- **AND** final evidence MUST still default to isolated mode
+
+### Requirement: Preflight Codex CLI safety
+
+The system SHALL fail closed before subprocess execution when preflight detects
+unsafe or unsupported Codex CLI conditions.
+
+#### Scenario: Check version and help support
+
+- **WHEN** preflight runs
+- **THEN** it MUST collect Codex version and `codex exec --help`
+- **AND** it MUST fail closed if required flags are unsupported
+
+#### Scenario: Reject leakage surfaces
+
+- **WHEN** global skills, plugins, MCP config, or inherited user config would be
+  consumed by a final evidence run
+- **THEN** preflight MUST fail closed
+
+#### Scenario: Reject no-skill leakage
+
+- **WHEN** the request condition is `no-skill`
+- **AND** mounted benchmark skills are present
+- **THEN** preflight MUST fail closed before subprocess execution
+
+### Requirement: Parse Codex JSONL defensively
+
+The system SHALL parse Codex JSONL events without trusting every emitted line.
+
+#### Scenario: Preserve unknown events
+
+- **WHEN** the CLI emits an unknown event type
+- **THEN** the runner MUST preserve a redacted unknown-event record
+- **AND** the runner MUST NOT crash solely because of the unknown type
+
+#### Scenario: Preserve malformed JSONL as unknown
+
+- **WHEN** the CLI emits malformed JSONL
+- **THEN** the runner MUST preserve a redacted malformed-event record
+- **AND** the runner MUST NOT crash solely because of that malformed line
+
+#### Scenario: Track skill activation evidence
+
+- **WHEN** JSONL events show mounted skill reads or declarations
+- **THEN** the resulting trace MUST classify them as `READ` or `DECLARED`
+- **AND** unrecognized skill activation evidence MUST be classified as
+  `UNKNOWN`
+
+### Requirement: Manage Codex subprocess lifecycle
+
+The system SHALL bound Codex subprocess runtime and logs.
+
+#### Scenario: Timeout cleanup
+
+- **WHEN** the Codex subprocess exceeds the request timeout
+- **THEN** the runner MUST kill the subprocess process group
+- **AND** the runner MUST use a bounded kill fallback when the process group
+  ignores termination
+- **AND** the result MUST record timeout with no verifier-derived task success
+
+#### Scenario: Redact and truncate logs
+
+- **WHEN** stdout or stderr contains sensitive strings or exceeds configured
+  size limits
+- **THEN** trace-visible logs MUST be redacted and truncated
+- **AND** runner-returned events and final messages MUST also be redacted and
+  size-bounded

--- a/openspec/changes/codex-cli-runner-isolation/specs/live-agent-runtime/spec.md
+++ b/openspec/changes/codex-cli-runner-isolation/specs/live-agent-runtime/spec.md
@@ -45,7 +45,11 @@ non-interactively without using live benchmark tasks.
 - **AND** it MUST NOT use `--yolo`, `danger-full-access`, or dangerous bypass
   flags
 - **AND** it MUST reject runner-control flag overrides, including
-  `--flag=value` forms, and `CODEX_HOME` overrides
+  `--flag=value` forms
+- **AND** it MUST reject `extra_env` overrides for runner-controlled home and
+  config environment variables such as `CODEX_HOME`, `HOME`, `USERPROFILE`,
+  `APPDATA`, `LOCALAPPDATA`, `XDG_CONFIG_HOME`, `XDG_DATA_HOME`, and
+  `XDG_CACHE_HOME`
 - **AND** it MAY add runner-controlled `--skip-git-repo-check` only when
   `codex exec --help` advertises support
 - **AND** prompt text MUST NOT be parsed as runner flags
@@ -74,6 +78,8 @@ unsafe or unsupported Codex CLI conditions.
 - **THEN** preflight MUST fail closed
 - **AND** isolated final-evidence preflight MUST inventory user, admin,
   workspace-parent, and bundled skill surfaces
+- **AND** dot-prefixed skill directories containing `SKILL.md` MUST count as
+  possible skill leakage
 - **AND** benchmark skills MUST be mounted only under
   `.agents/skills/<safe-skill-id>/SKILL.md` with Codex skill metadata
 

--- a/openspec/changes/codex-cli-runner-isolation/specs/live-agent-runtime/spec.md
+++ b/openspec/changes/codex-cli-runner-isolation/specs/live-agent-runtime/spec.md
@@ -38,13 +38,16 @@ non-interactively without using live benchmark tasks.
 
 - **WHEN** the runner is configured in default isolated mode
 - **THEN** it MUST use an isolated run-local `CODEX_HOME`
+- **AND** it MUST set `HOME` to a run-local empty home for final evidence
 - **AND** it MUST invoke `codex exec` with JSONL output, ephemeral session,
   workspace-write sandbox, ignored user config, ignored rules, and output-last
   message capture
 - **AND** it MUST NOT use `--yolo`, `danger-full-access`, or dangerous bypass
   flags
-- **AND** it MUST reject runner-control flag overrides and `CODEX_HOME`
-  overrides
+- **AND** it MUST reject runner-control flag overrides, including
+  `--flag=value` forms, and `CODEX_HOME` overrides
+- **AND** it MAY add runner-controlled `--skip-git-repo-check` only when
+  `codex exec --help` advertises support
 - **AND** prompt text MUST NOT be parsed as runner flags
 
 #### Scenario: Allow inherited mode only for smoke tests
@@ -69,6 +72,10 @@ unsafe or unsupported Codex CLI conditions.
 - **WHEN** global skills, plugins, MCP config, or inherited user config would be
   consumed by a final evidence run
 - **THEN** preflight MUST fail closed
+- **AND** isolated final-evidence preflight MUST inventory user, admin,
+  workspace-parent, and bundled skill surfaces
+- **AND** benchmark skills MUST be mounted only under
+  `.agents/skills/<safe-skill-id>/SKILL.md` with Codex skill metadata
 
 #### Scenario: Reject no-skill leakage
 

--- a/openspec/changes/codex-cli-runner-isolation/tasks.md
+++ b/openspec/changes/codex-cli-runner-isolation/tasks.md
@@ -1,0 +1,61 @@
+## 1. OpenSpec And Scope
+
+- [x] 1.1 Create change `codex-cli-runner-isolation` with proposal, design,
+  tasks, and `live-agent-runtime` spec delta.
+- [x] 1.2 Keep PR-5 limited to `CodexCliRunner`; do not modify Phase 10,
+  SkillsBench, external matrix/scorer, router promotion, or release gate logic.
+- [x] 1.3 Record local `codex exec --help` supported flags in the design
+  context.
+
+## 2. Schema
+
+- [x] 2.1 Add `schemas/live-agent-trace.schema.json`.
+- [x] 2.2 Add tests validating fake and Codex runner traces against the schema.
+
+## 3. Runner Configuration And Preflight
+
+- [x] 3.1 Add RED tests for safe default command construction: `--json`,
+  `--ephemeral`, `--ignore-user-config`, `--ignore-rules`,
+  `--sandbox workspace-write`, `--cd`, and `--output-last-message`.
+- [x] 3.2 Add RED tests rejecting `danger-full-access`, dangerous bypass flags,
+  and `--yolo`.
+- [x] 3.3 Add RED tests for isolated `CODEX_HOME` default and inherited
+  smoke-only metadata.
+- [x] 3.4 Add RED tests for version/help preflight and unsupported required
+  flags.
+- [x] 3.5 Add RED tests for global skill/plugin/MCP/config leakage and
+  no-skill leakage.
+- [x] 3.6 Implement `CodexCliRunner` configuration and preflight.
+
+## 4. Subprocess Execution
+
+- [x] 4.1 Add RED tests using fake Codex executable scripts for success,
+  non-zero exit, timeout, process-group cleanup, and output-last-message.
+- [x] 4.2 Implement non-interactive subprocess execution and process-group
+  timeout cleanup.
+- [x] 4.3 Ensure process exit code is never treated as task success.
+
+## 5. JSONL Parsing And Evidence
+
+- [x] 5.1 Add RED tests for JSONL event parsing, malformed JSONL preservation,
+  unknown event preservation, final messages, skill reads/declarations, and
+  UNKNOWN skill activation evidence.
+- [x] 5.2 Implement defensive JSONL parsing into PR-4-compatible events.
+- [x] 5.3 Keep usage/cost `null` unless reliable token usage is available.
+
+## 6. Redaction, Logs, Docs
+
+- [x] 6.1 Add RED tests for stdout/stderr size limits and redaction.
+- [x] 6.2 Implement log truncation/redaction.
+- [x] 6.3 Add concise Chinese Human Brief for PR-5.
+- [x] 6.4 Link PR-5 Human Brief from v0.3 implementation guide.
+
+## 7. Validation
+
+- [x] 7.1 Run focused Codex CLI runner tests.
+- [x] 7.2 Run `python -m pytest -q`.
+- [x] 7.3 Run `OPENSPEC_TELEMETRY=0 openspec validate --all --strict`.
+- [x] 7.4 Run `PYTHONPATH=src python -m hermes_skilleval.cli release-check --phase17-output-dir docs/demo/phase17-calibrated-release-selector --release-output-dir docs/demo/phase18-ci-release-reproducibility`.
+- [x] 7.5 Run `git diff --check`.
+- [x] 7.6 Run v0.3 YAML parse check.
+- [x] 7.7 Run CRLF/new-file line-ending check.

--- a/openspec/changes/codex-cli-runner-isolation/tasks.md
+++ b/openspec/changes/codex-cli-runner-isolation/tasks.md
@@ -33,6 +33,9 @@
   admin, and workspace-parent skill surfaces.
 - [x] 3.9 Reject runner control flags in both split and `--flag=value` forms,
   and add runner-controlled `--skip-git-repo-check` only when supported.
+- [x] 3.10 Reject `extra_env` overrides for runner-controlled home/config
+  environment keys and count dot-prefixed `SKILL.md` directories as possible
+  skill leakage.
 
 ## 4. Subprocess Execution
 

--- a/openspec/changes/codex-cli-runner-isolation/tasks.md
+++ b/openspec/changes/codex-cli-runner-isolation/tasks.md
@@ -26,6 +26,13 @@
 - [x] 3.5 Add RED tests for global skill/plugin/MCP/config leakage and
   no-skill leakage.
 - [x] 3.6 Implement `CodexCliRunner` configuration and preflight.
+- [x] 3.7 Mount benchmark skills under
+  `.agents/skills/<safe-skill-id>/SKILL.md` with `name` and `description`
+  metadata.
+- [x] 3.8 Add final-evidence inventory and fail-closed checks for user HOME,
+  admin, and workspace-parent skill surfaces.
+- [x] 3.9 Reject runner control flags in both split and `--flag=value` forms,
+  and add runner-controlled `--skip-git-repo-check` only when supported.
 
 ## 4. Subprocess Execution
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
   "pytest>=8.0.0",
+  "jsonschema>=4.0.0",
   "types-PyYAML>=6.0.12",
 ]
 embedding = [

--- a/schemas/live-agent-trace.schema.json
+++ b/schemas/live-agent-trace.schema.json
@@ -1,0 +1,122 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.invalid/hermes-skilleval/live-agent-trace.schema.json",
+  "title": "Hermes SkillEval live-agent.v1 trace",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "request",
+    "result",
+    "mounted_skills",
+    "skill_use",
+    "events"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "live-agent.v1"
+    },
+    "request": {
+      "type": "object",
+      "required": [
+        "run_id",
+        "task_id",
+        "prompt",
+        "condition",
+        "prompt_hash",
+        "workspace_path",
+        "mounted_skills",
+        "timeout_seconds",
+        "metadata"
+      ],
+      "properties": {
+        "run_id": {"type": "string"},
+        "task_id": {"type": "string"},
+        "prompt": {"type": "string"},
+        "condition": {"enum": ["no-skill", "routed-skill", "oracle-skill"]},
+        "prompt_hash": {"type": "string"},
+        "workspace_path": {"type": "string"},
+        "mounted_skills": {"type": "array"},
+        "timeout_seconds": {"type": "integer"},
+        "metadata": {"type": "object"}
+      },
+      "additionalProperties": true
+    },
+    "result": {
+      "type": "object",
+      "required": [
+        "process_exit_code",
+        "timed_out",
+        "verifier",
+        "task_success",
+        "usage",
+        "cost",
+        "stdout",
+        "stderr",
+        "stdout_truncated",
+        "stderr_truncated",
+        "final_message"
+      ],
+      "properties": {
+        "process_exit_code": {"type": ["integer", "null"]},
+        "timed_out": {"type": "boolean"},
+        "verifier": {
+          "type": "object",
+          "required": ["passed", "details"],
+          "properties": {
+            "passed": {"type": "boolean"},
+            "details": {"type": "object"}
+          },
+          "additionalProperties": true
+        },
+        "task_success": {"type": "boolean"},
+        "usage": {"type": ["object", "null"]},
+        "cost": {"type": ["object", "null"]},
+        "stdout": {"type": "string"},
+        "stderr": {"type": "string"},
+        "stdout_truncated": {"type": "boolean"},
+        "stderr_truncated": {"type": "boolean"},
+        "final_message": {"type": ["string", "null"]}
+      },
+      "additionalProperties": true
+    },
+    "mounted_skills": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["skill_id", "name", "relative_path", "sha256"],
+        "properties": {
+          "skill_id": {"type": "string"},
+          "name": {"type": "string"},
+          "relative_path": {"type": "string"},
+          "sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"}
+        },
+        "additionalProperties": true
+      }
+    },
+    "skill_use": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "required": ["state"],
+        "properties": {
+          "state": {
+            "enum": ["MOUNTED_ONLY", "READ", "DECLARED", "UNKNOWN"]
+          }
+        },
+        "additionalProperties": true
+      }
+    },
+    "events": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["type"],
+        "properties": {
+          "type": {"type": "string"}
+        },
+        "additionalProperties": true
+      }
+    }
+  },
+  "additionalProperties": true
+}

--- a/src/hermes_skilleval/live_agent_runtime.py
+++ b/src/hermes_skilleval/live_agent_runtime.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
 import hashlib
+import json
+import os
 import re
+import signal
+import subprocess
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Protocol, runtime_checkable
@@ -185,6 +189,305 @@ class FakeVerifier:
 
     def verify(self, request: AgentRequest, output: RunnerOutput) -> VerifierResult:
         return VerifierResult(passed=self.pass_, details=self.details)
+
+
+@dataclass(frozen=True)
+class CodexCliRunnerConfig:
+    codex_binary: Path | str = "codex"
+    codex_home_mode: str = "isolated"
+    codex_home_base: Path | str | None = None
+    inherited_codex_home: Path | str | None = None
+    allow_inherit_for_smoke: bool = False
+    sandbox: str = "workspace-write"
+    approval_policy: str = "never"
+    extra_args: list[str] = field(default_factory=list)
+    max_stdout_chars: int = 4000
+    max_stderr_chars: int = 4000
+    max_event_chars: int = 4000
+    terminate_grace_seconds: float = 2.0
+
+
+class CodexCliRunner:
+    REQUIRED_EXEC_FLAGS = (
+        "--json",
+        "--ephemeral",
+        "--ignore-user-config",
+        "--ignore-rules",
+        "--sandbox",
+        "--cd",
+        "--output-last-message",
+    )
+    FORBIDDEN_ARGS = {
+        "--yolo",
+        "--dangerously-bypass-approvals-and-sandbox",
+        "--dangerously-bypass-hook-trust",
+    }
+    CONTROL_ARGS = {
+        "--json",
+        "--ephemeral",
+        "--ignore-user-config",
+        "--ignore-rules",
+        "--sandbox",
+        "-s",
+        "--cd",
+        "-C",
+        "--output-last-message",
+        "-o",
+        "--config",
+        "-c",
+        "--add-dir",
+        "--profile",
+        "-p",
+    }
+
+    def __init__(self, config: CodexCliRunnerConfig | None = None) -> None:
+        self.config = config or CodexCliRunnerConfig()
+
+    def run(
+        self,
+        request: AgentRequest,
+        *,
+        extra_env: dict[str, str] | None = None,
+    ) -> RunnerOutput:
+        self._validate_extra_env(extra_env)
+        preflight = self._preflight(request)
+        command, output_path = self._command(request)
+        env = self._env(request, extra_env=extra_env)
+        process: subprocess.Popen[str] | None = None
+        try:
+            process = subprocess.Popen(
+                command,
+                cwd=request.workspace_path,
+                env=env,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                start_new_session=True,
+            )
+            stdout_raw, stderr_raw = process.communicate(timeout=request.timeout_seconds)
+            stdout, stdout_truncated = _truncate(
+                _redact(stdout_raw),
+                self.config.max_stdout_chars,
+            )
+            stderr, stderr_truncated = _truncate(
+                _redact(stderr_raw),
+                self.config.max_stderr_chars,
+            )
+            events = [
+                preflight,
+                *self._parse_jsonl_events(stdout_raw),
+                {
+                    "type": "codex_process",
+                    "stdout_truncated": stdout_truncated,
+                    "stderr_truncated": stderr_truncated,
+                },
+                *self._final_message_event(output_path),
+            ]
+            return RunnerOutput(
+                exit_code=process.returncode,
+                timed_out=False,
+                stdout=stdout,
+                stderr=stderr,
+                events=events,
+            )
+        except subprocess.TimeoutExpired as exc:
+            if process is not None:
+                stdout_raw, stderr_raw = self._terminate_process_group(process)
+            else:
+                stdout_raw = _decode_timeout_output(exc.stdout)
+                stderr_raw = _decode_timeout_output(exc.stderr)
+            stdout, _ = _truncate(
+                _redact(stdout_raw),
+                self.config.max_stdout_chars,
+            )
+            stderr, _ = _truncate(
+                _redact(stderr_raw),
+                self.config.max_stderr_chars,
+            )
+            return RunnerOutput(
+                exit_code=None,
+                timed_out=True,
+                stdout=stdout,
+                stderr=stderr,
+                events=[preflight, {"type": "codex_timeout"}],
+            )
+
+    def _preflight(self, request: AgentRequest) -> dict[str, Any]:
+        self._validate_config(request)
+        version = self._check_output((str(self.config.codex_binary), "--version"))
+        help_text = self._check_output((str(self.config.codex_binary), "exec", "--help"))
+        missing = [flag for flag in self.REQUIRED_EXEC_FLAGS if flag not in help_text]
+        if missing:
+            raise ValueError(
+                "unsupported codex exec flags: " + ", ".join(sorted(missing))
+            )
+        self._check_global_leakage()
+        return {
+            "type": "preflight",
+            "codex_version": _redact(version.strip()),
+            "codex_home_mode": self.config.codex_home_mode,
+            "evidence_mode": (
+                "smoke-only"
+                if self.config.codex_home_mode == "inherit"
+                else "final-evidence"
+            ),
+            "sandbox": self.config.sandbox,
+            "approval_policy": self.config.approval_policy,
+        }
+
+    def _validate_config(self, request: AgentRequest) -> None:
+        if request.condition == "no-skill" and request.mounted_skills:
+            raise ValueError("no-skill condition leaked mounted skills")
+        if self.config.sandbox == "danger-full-access":
+            raise ValueError("danger-full-access is not allowed for live-agent evidence")
+        if self.config.sandbox != "workspace-write":
+            raise ValueError("CodexCliRunner requires workspace-write sandbox")
+        if self.config.approval_policy != "never":
+            raise ValueError("CodexCliRunner requires approval policy never")
+        if self.config.codex_home_mode not in {"isolated", "inherit"}:
+            raise ValueError("codex_home_mode must be isolated or inherit")
+        if (
+            self.config.codex_home_mode == "inherit"
+            and not self.config.allow_inherit_for_smoke
+        ):
+            raise ValueError("inherited CODEX_HOME is smoke-only")
+        for arg in self.config.extra_args:
+            if arg in self.CONTROL_ARGS:
+                raise ValueError(f"forbidden Codex CLI control argument: {arg}")
+            if arg in self.FORBIDDEN_ARGS or "dangerously-bypass" in arg:
+                raise ValueError(f"forbidden Codex CLI argument: {arg}")
+            if arg == "danger-full-access":
+                raise ValueError("danger-full-access is not allowed")
+
+    def _validate_extra_env(self, extra_env: dict[str, str] | None) -> None:
+        if extra_env and "CODEX_HOME" in extra_env:
+            raise ValueError("extra_env must not override CODEX_HOME")
+
+    def _check_global_leakage(self) -> None:
+        if self.config.codex_home_mode != "inherit":
+            return
+        home = self._inherited_home()
+        leakage_names = ("skills", "plugins", "mcp.json", "config.toml")
+        leaked = [name for name in leakage_names if (home / name).exists()]
+        if leaked:
+            raise ValueError("global Codex leakage detected: " + ", ".join(leaked))
+
+    def _command(self, request: AgentRequest) -> tuple[list[str], Path]:
+        output_path = request.workspace_path / ".hermes-runner" / "codex-last-message.txt"
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        command = [
+            str(self.config.codex_binary),
+            "exec",
+            "--json",
+            "--ephemeral",
+            "--ignore-user-config",
+            "--ignore-rules",
+            "--sandbox",
+            self.config.sandbox,
+            "--config",
+            "approval_policy=\"never\"",
+            "--cd",
+            str(request.workspace_path),
+            "--output-last-message",
+            str(output_path),
+            *self.config.extra_args,
+            "--",
+            request.prompt,
+        ]
+        return command, output_path
+
+    def _env(
+        self,
+        request: AgentRequest,
+        *,
+        extra_env: dict[str, str] | None = None,
+    ) -> dict[str, str]:
+        env = os.environ.copy()
+        if self.config.codex_home_mode == "isolated":
+            base = (
+                Path(self.config.codex_home_base)
+                if self.config.codex_home_base is not None
+                else request.workspace_path / ".codex-home"
+            )
+            home = base / _safe_path_part(request.run_id)
+            home.mkdir(parents=True, exist_ok=True)
+            env["CODEX_HOME"] = str(home)
+        else:
+            env["CODEX_HOME"] = str(self._inherited_home())
+        if extra_env:
+            env.update(extra_env)
+        return env
+
+    def _inherited_home(self) -> Path:
+        if self.config.inherited_codex_home is not None:
+            return Path(self.config.inherited_codex_home)
+        return Path(os.environ.get("CODEX_HOME", Path.home() / ".codex"))
+
+    def _parse_jsonl_events(self, stdout: str) -> list[dict[str, Any]]:
+        events = []
+        for line in stdout.splitlines():
+            if not line.strip():
+                continue
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                payload, _ = _truncate(_redact(line), self.config.max_event_chars)
+                events.append(
+                    {
+                        "type": "unknown",
+                        "original_type": "malformed_jsonl",
+                        "payload": payload,
+                    }
+                )
+                continue
+            if not isinstance(event, dict):
+                payload = self._redact_event_payload(event)
+                events.append(
+                    {
+                        "type": "unknown",
+                        "original_type": "non_object_jsonl",
+                        "payload": payload,
+                    }
+                )
+                continue
+            events.append(self._redact_event_payload(event))
+        return events
+
+    def _final_message_event(self, path: Path) -> list[dict[str, Any]]:
+        if not path.exists():
+            return []
+        message, _ = _truncate(
+            _redact(path.read_text(encoding="utf-8")),
+            self.config.max_event_chars,
+        )
+        return [{"type": "final", "message": message}]
+
+    def _redact_event_payload(self, value: Any) -> Any:
+        redacted = _redact_value(value)
+        return _truncate_strings(redacted, self.config.max_event_chars)
+
+    def _check_output(self, command: tuple[str, ...]) -> str:
+        try:
+            return subprocess.check_output(command, text=True, stderr=subprocess.STDOUT)
+        except (OSError, subprocess.CalledProcessError) as exc:
+            raise ValueError(f"Codex CLI preflight failed: {command}") from exc
+
+    def _terminate_process_group(
+        self,
+        process: subprocess.Popen[str],
+    ) -> tuple[str, str]:
+        try:
+            os.killpg(process.pid, signal.SIGTERM)
+        except ProcessLookupError:
+            return process.communicate()
+        try:
+            return process.communicate(timeout=self.config.terminate_grace_seconds)
+        except subprocess.TimeoutExpired:
+            try:
+                os.killpg(process.pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+            return process.communicate()
 
 
 @dataclass(frozen=True)
@@ -389,10 +692,13 @@ def _parse_events(
             final_message = message
             events.append({"type": "final", "message": message})
         else:
+            skill_id = raw.get("skill_id")
+            if isinstance(skill_id, str) and skill_id.strip():
+                _set_skill_state(skill_use, mounted, skill_id, "UNKNOWN")
             events.append(
                 {
                     "type": "unknown",
-                    "original_type": event_type,
+                    "original_type": raw.get("original_type", event_type),
                     "payload": _redact_value(raw),
                 }
             )
@@ -456,6 +762,20 @@ def _truncate(text: str, max_chars: int) -> tuple[str, bool]:
     return text[:max_chars], True
 
 
+def _truncate_strings(value: Any, max_chars: int) -> Any:
+    if isinstance(value, str):
+        truncated, _ = _truncate(value, max_chars)
+        return truncated
+    if isinstance(value, dict):
+        return {
+            _truncate_strings(key, max_chars): _truncate_strings(item, max_chars)
+            for key, item in value.items()
+        }
+    if isinstance(value, list):
+        return [_truncate_strings(item, max_chars) for item in value]
+    return value
+
+
 def _safe_path_part(value: str) -> str:
     text = _non_empty(value, "path part").replace("/", "_")
     return re.sub(r"[^A-Za-z0-9_.-]", "_", text)
@@ -475,3 +795,11 @@ def _non_empty(value: str, field: str) -> str:
 
 def _sha256_text(value: str) -> str:
     return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _decode_timeout_output(value: str | bytes | None) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    return value

--- a/src/hermes_skilleval/live_agent_runtime.py
+++ b/src/hermes_skilleval/live_agent_runtime.py
@@ -254,6 +254,16 @@ class CodexCliRunner:
         "--oss",
         "--skip-git-repo-check",
     }
+    RUNNER_CONTROLLED_ENV_KEYS = {
+        "CODEX_HOME",
+        "HOME",
+        "USERPROFILE",
+        "APPDATA",
+        "LOCALAPPDATA",
+        "XDG_CONFIG_HOME",
+        "XDG_DATA_HOME",
+        "XDG_CACHE_HOME",
+    }
 
     def __init__(self, config: CodexCliRunnerConfig | None = None) -> None:
         self.config = config or CodexCliRunnerConfig()
@@ -383,8 +393,14 @@ class CodexCliRunner:
                 raise ValueError(f"unsupported Codex CLI extra argument: {flag}")
 
     def _validate_extra_env(self, extra_env: dict[str, str] | None) -> None:
-        if extra_env and "CODEX_HOME" in extra_env:
-            raise ValueError("extra_env must not override CODEX_HOME")
+        if not extra_env:
+            return
+        overridden = sorted(set(extra_env) & self.RUNNER_CONTROLLED_ENV_KEYS)
+        if overridden:
+            raise ValueError(
+                "extra_env must not override runner-controlled environment keys: "
+                + ", ".join(overridden)
+            )
 
     def _check_global_leakage(self) -> None:
         if self.config.codex_home_mode != "inherit":
@@ -508,6 +524,8 @@ class CodexCliRunner:
         extra_env: dict[str, str] | None = None,
     ) -> dict[str, str]:
         env = os.environ.copy()
+        if extra_env:
+            env.update(extra_env)
         if self.config.codex_home_mode == "isolated":
             base = (
                 Path(self.config.codex_home_base)
@@ -523,8 +541,6 @@ class CodexCliRunner:
                 env["HOME"] = str(isolated_home)
         else:
             env["CODEX_HOME"] = str(self._inherited_home())
-        if extra_env:
-            env.update(extra_env)
         return env
 
     def _inherited_home(self) -> Path:
@@ -928,11 +944,20 @@ def _allowed_workspace_skill_dirs(
 def _visible_child_names(path: Path) -> list[str]:
     if not path.exists():
         return []
-    return sorted(child.name for child in path.iterdir() if not child.name.startswith("."))
+    names = []
+    for child in path.iterdir():
+        if child.name.startswith(".") and not _looks_like_skill_dir(child):
+            continue
+        names.append(child.name)
+    return sorted(names)
 
 
 def _visible_child_count(path: Path) -> int:
     return len(_visible_child_names(path))
+
+
+def _looks_like_skill_dir(path: Path) -> bool:
+    return path.is_dir() and (path / "SKILL.md").is_file()
 
 
 def _non_empty(value: str, field: str) -> str:

--- a/src/hermes_skilleval/live_agent_runtime.py
+++ b/src/hermes_skilleval/live_agent_runtime.py
@@ -44,6 +44,7 @@ class LiveAgentSkill:
     skill_id: str
     name: str
     body: str
+    description: str | None = None
 
 
 @dataclass(frozen=True)
@@ -198,9 +199,14 @@ class CodexCliRunnerConfig:
     codex_home_base: Path | str | None = None
     inherited_codex_home: Path | str | None = None
     allow_inherit_for_smoke: bool = False
+    isolate_home: bool = True
+    admin_skill_paths: list[Path | str] = field(
+        default_factory=lambda: [Path("/etc/codex/skills")]
+    )
     sandbox: str = "workspace-write"
     approval_policy: str = "never"
     extra_args: list[str] = field(default_factory=list)
+    skip_git_repo_check: bool = True
     max_stdout_chars: int = 4000
     max_stderr_chars: int = 4000
     max_event_chars: int = 4000
@@ -238,6 +244,15 @@ class CodexCliRunner:
         "--add-dir",
         "--profile",
         "-p",
+        "--remote",
+        "--remote-auth-token-env",
+        "--search",
+        "--enable",
+        "--disable",
+        "--image",
+        "-i",
+        "--oss",
+        "--skip-git-repo-check",
     }
 
     def __init__(self, config: CodexCliRunnerConfig | None = None) -> None:
@@ -251,7 +266,7 @@ class CodexCliRunner:
     ) -> RunnerOutput:
         self._validate_extra_env(extra_env)
         preflight = self._preflight(request)
-        command, output_path = self._command(request)
+        command, output_path = self._command(request, preflight)
         env = self._env(request, extra_env=extra_env)
         process: subprocess.Popen[str] | None = None
         try:
@@ -314,6 +329,7 @@ class CodexCliRunner:
 
     def _preflight(self, request: AgentRequest) -> dict[str, Any]:
         self._validate_config(request)
+        inventory = self._global_capability_inventory(request)
         version = self._check_output((str(self.config.codex_binary), "--version"))
         help_text = self._check_output((str(self.config.codex_binary), "exec", "--help"))
         missing = [flag for flag in self.REQUIRED_EXEC_FLAGS if flag not in help_text]
@@ -322,6 +338,7 @@ class CodexCliRunner:
                 "unsupported codex exec flags: " + ", ".join(sorted(missing))
             )
         self._check_global_leakage()
+        supports_skip_git_repo_check = "--skip-git-repo-check" in help_text
         return {
             "type": "preflight",
             "codex_version": _redact(version.strip()),
@@ -333,6 +350,9 @@ class CodexCliRunner:
             ),
             "sandbox": self.config.sandbox,
             "approval_policy": self.config.approval_policy,
+            "supports_skip_git_repo_check": supports_skip_git_repo_check,
+            "global_capability_inventory": inventory,
+            "skill_inventory": inventory,
         }
 
     def _validate_config(self, request: AgentRequest) -> None:
@@ -352,12 +372,15 @@ class CodexCliRunner:
         ):
             raise ValueError("inherited CODEX_HOME is smoke-only")
         for arg in self.config.extra_args:
-            if arg in self.CONTROL_ARGS:
-                raise ValueError(f"forbidden Codex CLI control argument: {arg}")
-            if arg in self.FORBIDDEN_ARGS or "dangerously-bypass" in arg:
-                raise ValueError(f"forbidden Codex CLI argument: {arg}")
+            flag = arg.split("=", 1)[0]
+            if flag in self.CONTROL_ARGS:
+                raise ValueError(f"forbidden Codex CLI control argument: {flag}")
+            if flag in self.FORBIDDEN_ARGS or "dangerously-bypass" in arg:
+                raise ValueError(f"forbidden Codex CLI argument: {flag}")
             if arg == "danger-full-access":
                 raise ValueError("danger-full-access is not allowed")
+            if arg.startswith("-"):
+                raise ValueError(f"unsupported Codex CLI extra argument: {flag}")
 
     def _validate_extra_env(self, extra_env: dict[str, str] | None) -> None:
         if extra_env and "CODEX_HOME" in extra_env:
@@ -372,8 +395,79 @@ class CodexCliRunner:
         if leaked:
             raise ValueError("global Codex leakage detected: " + ", ".join(leaked))
 
-    def _command(self, request: AgentRequest) -> tuple[list[str], Path]:
-        output_path = request.workspace_path / ".hermes-runner" / "codex-last-message.txt"
+    def _global_capability_inventory(self, request: AgentRequest) -> dict[str, Any]:
+        user_skill_dir = Path(os.environ.get("HOME", Path.home())) / ".agents" / "skills"
+        home_isolated = (
+            self.config.codex_home_mode == "isolated" and self.config.isolate_home
+        )
+        if home_isolated:
+            user_status = "ISOLATED_HOME"
+            user_entries = 0
+        elif self.config.codex_home_mode == "inherit":
+            user_entries = _visible_child_count(user_skill_dir)
+            user_status = "SMOKE_ONLY"
+        else:
+            user_entries = _visible_child_count(user_skill_dir)
+            if user_entries:
+                raise ValueError("user skill leakage detected under HOME/.agents/skills")
+            user_status = "CLEAR" if user_skill_dir.exists() else "ABSENT"
+
+        admin_inventory = []
+        for path_value in self.config.admin_skill_paths:
+            path = Path(path_value)
+            entry_count = _visible_child_count(path)
+            if entry_count:
+                raise ValueError("admin skill leakage detected under admin skill path")
+            admin_inventory.append(
+                {
+                    "status": "CLEAR" if path.exists() else "ABSENT",
+                    "entry_count": entry_count,
+                }
+            )
+
+        workspace_inventory = self._workspace_skill_inventory(request)
+        return {
+            "home_isolated": home_isolated,
+            "user_skill_dir": {
+                "status": user_status,
+                "entry_count": user_entries,
+            },
+            "admin_skill_dirs": admin_inventory,
+            "workspace_skill_dirs": workspace_inventory,
+            "bundled_skills": {"status": "SYSTEM_MANAGED_UNKNOWN"},
+        }
+
+    def _workspace_skill_inventory(self, request: AgentRequest) -> dict[str, Any]:
+        workspace_skill_dir = request.workspace_path / ".agents" / "skills"
+        allowed = _allowed_workspace_skill_dirs(request.mounted_skills)
+        workspace_children = _visible_child_names(workspace_skill_dir)
+        unexpected = sorted(set(workspace_children) - allowed)
+        if unexpected:
+            raise ValueError(
+                "workspace skill leakage detected under run workspace .agents/skills"
+            )
+
+        parent_leak_count = 0
+        for parent in request.workspace_path.parents:
+            parent_skill_dir = parent / ".agents" / "skills"
+            if not parent_skill_dir.exists():
+                continue
+            if _visible_child_count(parent_skill_dir):
+                raise ValueError("workspace parent skill leakage detected")
+            parent_leak_count += 1
+        return {
+            "workspace_status": "CLEAR" if workspace_skill_dir.exists() else "ABSENT",
+            "mounted_entry_count": len(workspace_children),
+            "parent_skill_dirs_checked": len(request.workspace_path.parents),
+            "empty_parent_skill_dirs": parent_leak_count,
+        }
+
+    def _command(
+        self,
+        request: AgentRequest,
+        preflight: dict[str, Any],
+    ) -> tuple[list[str], Path]:
+        output_path = self._runner_output_dir(request) / "codex-last-message.txt"
         output_path.parent.mkdir(parents=True, exist_ok=True)
         command = [
             str(self.config.codex_binary),
@@ -390,11 +484,22 @@ class CodexCliRunner:
             str(request.workspace_path),
             "--output-last-message",
             str(output_path),
-            *self.config.extra_args,
-            "--",
-            request.prompt,
         ]
+        if (
+            self.config.skip_git_repo_check
+            and preflight.get("supports_skip_git_repo_check") is True
+        ):
+            command.append("--skip-git-repo-check")
+        command.extend([*self.config.extra_args, "--", request.prompt])
         return command, output_path
+
+    def _runner_output_dir(self, request: AgentRequest) -> Path:
+        base = (
+            Path(self.config.codex_home_base)
+            if self.config.codex_home_base is not None
+            else request.workspace_path.parent / ".hermes-runner"
+        )
+        return base / _safe_path_part(request.run_id) / "runner-output"
 
     def _env(
         self,
@@ -412,6 +517,10 @@ class CodexCliRunner:
             home = base / _safe_path_part(request.run_id)
             home.mkdir(parents=True, exist_ok=True)
             env["CODEX_HOME"] = str(home)
+            if self.config.isolate_home:
+                isolated_home = home / "home"
+                isolated_home.mkdir(parents=True, exist_ok=True)
+                env["HOME"] = str(isolated_home)
         else:
             env["CODEX_HOME"] = str(self._inherited_home())
         if extra_env:
@@ -573,11 +682,12 @@ def prepare_live_agent_workspace(
     if root.exists():
         raise ValueError(f"workspace already exists: {root}")
     records = _mounted_skill_records(mounted_skills)
-    skill_dir = root / "skills"
-    skill_dir.mkdir(parents=True)
+    root.mkdir(parents=True)
+    skill_dir = root / ".agents" / "skills"
     for skill, record in zip(mounted_skills, records, strict=True):
         path = root / record["relative_path"]
-        path.write_text(skill.body, encoding="utf-8")
+        path.parent.mkdir(parents=True, exist_ok=False)
+        path.write_text(_codex_skill_text(skill), encoding="utf-8")
         record["sha256"] = sha256_file(path)
     return WorkspaceState(
         workspace_path=root,
@@ -608,12 +718,16 @@ def _mounted_skill_records(
 ) -> list[dict[str, Any]]:
     records: list[dict[str, Any]] = []
     seen_skill_ids: set[str] = set()
+    seen_skill_names: set[str] = set()
     seen_relative_paths: set[str] = set()
     for skill in mounted_skills:
         if skill.skill_id in seen_skill_ids:
             raise ValueError(f"duplicate skill_id in mounted skills: {skill.skill_id}")
         seen_skill_ids.add(skill.skill_id)
-        relative_path = Path("skills") / _skill_mount_filename(skill)
+        if skill.name in seen_skill_names:
+            raise ValueError(f"duplicate skill name in mounted skills: {skill.name}")
+        seen_skill_names.add(skill.name)
+        relative_path = Path(".agents") / "skills" / _skill_mount_dirname(skill) / "SKILL.md"
         relative_path_text = relative_path.as_posix()
         if relative_path_text in seen_relative_paths:
             raise ValueError(f"duplicate mounted skill path: {relative_path_text}")
@@ -781,10 +895,44 @@ def _safe_path_part(value: str) -> str:
     return re.sub(r"[^A-Za-z0-9_.-]", "_", text)
 
 
-def _skill_mount_filename(skill: LiveAgentSkill) -> str:
+def _skill_mount_dirname(skill: LiveAgentSkill) -> str:
     base = _safe_path_part(skill.skill_id)
     digest = _sha256_text(skill.skill_id)[:12]
-    return f"{base}--{digest}.md"
+    return f"{base}--{digest}"
+
+
+def _codex_skill_text(skill: LiveAgentSkill) -> str:
+    name = _skill_metadata_value(skill.name)
+    description = _skill_metadata_value(
+        skill.description or f"Benchmark skill {skill.skill_id}"
+    )
+    return f"---\nname: {name}\ndescription: {description}\n---\n{skill.body}"
+
+
+def _skill_metadata_value(value: str) -> str:
+    text = _non_empty(value, "skill metadata").replace("\r", " ").replace("\n", " ")
+    return json.dumps(text)
+
+
+def _allowed_workspace_skill_dirs(
+    mounted_skills: list[dict[str, Any]],
+) -> set[str]:
+    allowed: set[str] = set()
+    for record in mounted_skills:
+        parts = Path(str(record.get("relative_path", ""))).parts
+        if len(parts) == 4 and parts[0] == ".agents" and parts[1] == "skills":
+            allowed.add(parts[2])
+    return allowed
+
+
+def _visible_child_names(path: Path) -> list[str]:
+    if not path.exists():
+        return []
+    return sorted(child.name for child in path.iterdir() if not child.name.startswith("."))
+
+
+def _visible_child_count(path: Path) -> int:
+    return len(_visible_child_names(path))
 
 
 def _non_empty(value: str, field: str) -> str:

--- a/tests/test_codex_cli_runner.py
+++ b/tests/test_codex_cli_runner.py
@@ -1,0 +1,483 @@
+import json
+import os
+import stat
+import sys
+import textwrap
+from pathlib import Path
+
+import jsonschema
+import pytest
+
+from hermes_skilleval.live_agent_runtime import (
+    AgentRequest,
+    CodexCliRunner,
+    CodexCliRunnerConfig,
+    FakeAgentRunner,
+    FakeVerifier,
+    LiveAgentSkill,
+    build_condition,
+    execute_live_agent,
+    prepare_live_agent_workspace,
+)
+
+
+def _skill(skill_id: str = "skill/browser") -> LiveAgentSkill:
+    return LiveAgentSkill(skill_id=skill_id, name="Browser", body="Skill body")
+
+
+def _request(tmp_path: Path, *, condition_name: str = "routed-skill") -> AgentRequest:
+    skills = [_skill()] if condition_name != "no-skill" else []
+    condition = build_condition(
+        task_id="task-1",
+        prompt="Do the task",
+        condition=condition_name,
+        routed_skills=skills,
+    )
+    workspace = prepare_live_agent_workspace(
+        base_dir=tmp_path,
+        run_id=f"run-{condition_name}",
+        mounted_skills=condition.mounted_skills,
+    )
+    return AgentRequest.from_condition(
+        run_id=f"run-{condition_name}",
+        condition=condition,
+        workspace=workspace,
+        timeout_seconds=5,
+    )
+
+
+def _fake_codex(tmp_path: Path, body: str) -> Path:
+    path = tmp_path / "fake-codex.py"
+    path.write_text(
+        "#!/usr/bin/env python3\n"
+        "import json, os, signal, sys, time\n"
+        + textwrap.dedent(body).lstrip(),
+        encoding="utf-8",
+    )
+    path.chmod(path.stat().st_mode | stat.S_IXUSR)
+    return path
+
+
+def _runner(tmp_path: Path, codex: Path, **kwargs) -> CodexCliRunner:
+    return CodexCliRunner(
+        CodexCliRunnerConfig(
+            codex_binary=codex,
+            codex_home_base=tmp_path / "codex-home",
+            **kwargs,
+        )
+    )
+
+
+def test_codex_cli_runner_builds_safe_default_command_and_isolated_home(tmp_path):
+    codex = _fake_codex(
+        tmp_path,
+        """
+        if sys.argv[1:] == ["--version"]:
+            print("codex 1.2.3")
+            raise SystemExit(0)
+        if sys.argv[1:3] == ["exec", "--help"]:
+            print("--json --ephemeral --ignore-user-config --ignore-rules --sandbox --cd --output-last-message")
+            raise SystemExit(0)
+        record = {"argv": sys.argv[1:], "env": {"CODEX_HOME": os.environ.get("CODEX_HOME")}}
+        out = os.environ["FAKE_CODEX_RECORD"]
+        open(out, "w", encoding="utf-8").write(json.dumps(record))
+        output_file = sys.argv[sys.argv.index("--output-last-message") + 1]
+        open(output_file, "w", encoding="utf-8").write("done")
+        print(json.dumps({"type": "final", "message": "done"}))
+        """,
+    )
+    record_path = tmp_path / "record.json"
+    request = _request(tmp_path)
+    runner = _runner(tmp_path, codex)
+    env = {"FAKE_CODEX_RECORD": str(record_path)}
+
+    output = runner.run(request, extra_env=env)
+    record = json.loads(record_path.read_text(encoding="utf-8"))
+
+    assert output.exit_code == 0
+    assert output.timed_out is False
+    assert record["argv"][:2] == ["exec", "--json"]
+    for flag in [
+        "--ephemeral",
+        "--ignore-user-config",
+        "--ignore-rules",
+        "--sandbox",
+        "workspace-write",
+        "--cd",
+        str(request.workspace_path),
+        "--output-last-message",
+    ]:
+        assert flag in record["argv"]
+    assert record["env"]["CODEX_HOME"].startswith(str(tmp_path / "codex-home"))
+    assert record["env"]["CODEX_HOME"] != os.environ.get("CODEX_HOME")
+    assert output.events[-1]["type"] == "final"
+    assert output.events[-1]["message"] == "done"
+
+
+def test_codex_cli_runner_rejects_codex_home_extra_env_override(tmp_path):
+    codex = _fake_codex(tmp_path, "print('should not run')\n")
+
+    with pytest.raises(ValueError, match="CODEX_HOME"):
+        _runner(tmp_path, codex).run(
+            _request(tmp_path),
+            extra_env={"CODEX_HOME": str(tmp_path / "attacker-home")},
+        )
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "match"),
+    [
+        ({"sandbox": "danger-full-access"}, "danger-full-access"),
+        ({"extra_args": ["--dangerously-bypass-approvals-and-sandbox"]}, "dangerously"),
+        ({"extra_args": ["--yolo"]}, "--yolo"),
+        ({"extra_args": ["--sandbox", "read-only"]}, "--sandbox"),
+        ({"extra_args": ["--cd", "/tmp"]}, "--cd"),
+        ({"extra_args": ["--output-last-message", "/tmp/out"]}, "--output-last-message"),
+        ({"extra_args": ["--config", "approval_policy=\"on-request\""]}, "--config"),
+    ],
+)
+def test_codex_cli_runner_rejects_unsafe_flags(tmp_path, kwargs, match):
+    codex = _fake_codex(tmp_path, "print('should not run')\n")
+    runner = _runner(tmp_path, codex, **kwargs)
+
+    with pytest.raises(ValueError, match=match):
+        runner.run(_request(tmp_path))
+
+
+def test_codex_cli_runner_passes_flag_like_prompt_after_delimiter(tmp_path):
+    codex = _fake_codex(
+        tmp_path,
+        """
+        if sys.argv[1:] == ["--version"]:
+            print("codex 1.2.3")
+            raise SystemExit(0)
+        if sys.argv[1:3] == ["exec", "--help"]:
+            print("--json --ephemeral --ignore-user-config --ignore-rules --sandbox --cd --output-last-message")
+            raise SystemExit(0)
+        out = os.environ["FAKE_CODEX_RECORD"]
+        open(out, "w", encoding="utf-8").write(json.dumps({"argv": sys.argv[1:]}))
+        """,
+    )
+    condition = build_condition(
+        task_id="task-1",
+        prompt="--yolo --sandbox danger-full-access",
+        condition="routed-skill",
+        routed_skills=[_skill()],
+    )
+    workspace = prepare_live_agent_workspace(
+        base_dir=tmp_path,
+        run_id="run-flag-prompt",
+        mounted_skills=condition.mounted_skills,
+    )
+    request = AgentRequest.from_condition(
+        run_id="run-flag-prompt",
+        condition=condition,
+        workspace=workspace,
+        timeout_seconds=5,
+    )
+    record = tmp_path / "record.json"
+
+    _runner(tmp_path, codex).run(request, extra_env={"FAKE_CODEX_RECORD": str(record)})
+    argv = json.loads(record.read_text(encoding="utf-8"))["argv"]
+
+    assert "--" in argv
+    assert argv[-2:] == ["--", "--yolo --sandbox danger-full-access"]
+
+
+def test_codex_cli_runner_inherit_home_is_smoke_only_metadata(tmp_path, monkeypatch):
+    codex = _fake_codex(
+        tmp_path,
+        """
+        if sys.argv[1:] == ["--version"]:
+            print("codex 1.2.3")
+            raise SystemExit(0)
+        if sys.argv[1:3] == ["exec", "--help"]:
+            print("--json --ephemeral --ignore-user-config --ignore-rules --sandbox --cd --output-last-message")
+            raise SystemExit(0)
+        print(json.dumps({"type": "final", "message": "done"}))
+        """,
+    )
+    inherited_home = tmp_path / "inherited-codex-home"
+    inherited_home.mkdir()
+    monkeypatch.setenv("CODEX_HOME", str(inherited_home))
+
+    runner = _runner(tmp_path, codex, codex_home_mode="inherit", allow_inherit_for_smoke=True)
+    output = runner.run(_request(tmp_path))
+
+    assert output.events[0]["type"] == "preflight"
+    assert output.events[0]["codex_home_mode"] == "inherit"
+    assert output.events[0]["evidence_mode"] == "smoke-only"
+
+
+def test_codex_cli_runner_preflight_rejects_missing_required_flags(tmp_path):
+    codex = _fake_codex(
+        tmp_path,
+        """
+        if sys.argv[1:] == ["--version"]:
+            print("codex 1.2.3")
+            raise SystemExit(0)
+        if sys.argv[1:3] == ["exec", "--help"]:
+            print("--json --sandbox")
+            raise SystemExit(0)
+        raise SystemExit(0)
+        """,
+    )
+
+    with pytest.raises(ValueError, match="unsupported codex exec flags"):
+        _runner(tmp_path, codex).run(_request(tmp_path))
+
+
+def test_codex_cli_runner_preflight_rejects_global_leakage_in_inherit_mode(tmp_path):
+    codex = _fake_codex(
+        tmp_path,
+        """
+        if sys.argv[1:] == ["--version"]:
+            print("codex 1.2.3")
+            raise SystemExit(0)
+        if sys.argv[1:3] == ["exec", "--help"]:
+            print("--json --ephemeral --ignore-user-config --ignore-rules --sandbox --cd --output-last-message")
+            raise SystemExit(0)
+        print(json.dumps({"type": "final", "message": "done"}))
+        """,
+    )
+    home = tmp_path / "leaky-home"
+    (home / "skills").mkdir(parents=True)
+
+    runner = _runner(
+        tmp_path,
+        codex,
+        codex_home_mode="inherit",
+        allow_inherit_for_smoke=True,
+        inherited_codex_home=home,
+    )
+
+    with pytest.raises(ValueError, match="global Codex leakage"):
+        runner.run(_request(tmp_path))
+
+
+def test_codex_cli_runner_rejects_no_skill_leakage_before_subprocess(tmp_path):
+    codex = _fake_codex(tmp_path, "raise SystemExit('should not run')\n")
+    request = AgentRequest(
+        run_id="run-leak",
+        task_id="task-1",
+        prompt="Do it",
+        condition="no-skill",
+        prompt_hash="hash",
+        workspace_path=tmp_path / "workspace",
+        mounted_skills=[{"skill_id": "skill/leaked"}],
+        timeout_seconds=5,
+    )
+
+    with pytest.raises(ValueError, match="no-skill"):
+        _runner(tmp_path, codex).run(request)
+
+
+def test_codex_cli_runner_timeout_kills_process_group(tmp_path):
+    marker = tmp_path / "terminated.txt"
+    codex = _fake_codex(
+        tmp_path,
+        f"""
+        if sys.argv[1:] == ["--version"]:
+            print("codex 1.2.3")
+            raise SystemExit(0)
+        if sys.argv[1:3] == ["exec", "--help"]:
+            print("--json --ephemeral --ignore-user-config --ignore-rules --sandbox --cd --output-last-message")
+            raise SystemExit(0)
+        def handler(signum, frame):
+            open({str(marker)!r}, "w", encoding="utf-8").write(str(signum))
+            raise SystemExit(124)
+        signal.signal(signal.SIGTERM, handler)
+        time.sleep(10)
+        """,
+    )
+    request = _request(tmp_path)
+    request = AgentRequest(
+        **{**request.to_dict(include_absolute_paths=True), "workspace_path": request.workspace_path},
+    )
+    object.__setattr__(request, "timeout_seconds", 1)
+
+    output = _runner(tmp_path, codex).run(request)
+
+    assert output.exit_code is None
+    assert output.timed_out is True
+    assert marker.exists()
+
+
+def test_codex_cli_runner_timeout_kill_fallback_for_ignored_sigterm(tmp_path):
+    codex = _fake_codex(
+        tmp_path,
+        """
+        if sys.argv[1:] == ["--version"]:
+            print("codex 1.2.3")
+            raise SystemExit(0)
+        if sys.argv[1:3] == ["exec", "--help"]:
+            print("--json --ephemeral --ignore-user-config --ignore-rules --sandbox --cd --output-last-message")
+            raise SystemExit(0)
+        signal.signal(signal.SIGTERM, signal.SIG_IGN)
+        time.sleep(10)
+        """,
+    )
+    request = _request(tmp_path)
+    object.__setattr__(request, "timeout_seconds", 1)
+
+    output = _runner(tmp_path, codex).run(request)
+
+    assert output.exit_code is None
+    assert output.timed_out is True
+
+
+def test_codex_cli_runner_nonzero_exit_does_not_define_task_success(tmp_path):
+    codex = _fake_codex(
+        tmp_path,
+        """
+        if sys.argv[1:] == ["--version"]:
+            print("codex 1.2.3")
+            raise SystemExit(0)
+        if sys.argv[1:3] == ["exec", "--help"]:
+            print("--json --ephemeral --ignore-user-config --ignore-rules --sandbox --cd --output-last-message")
+            raise SystemExit(0)
+        print(json.dumps({"type": "final", "message": "done"}))
+        raise SystemExit(7)
+        """,
+    )
+
+    result = execute_live_agent(
+        request=_request(tmp_path),
+        runner=_runner(tmp_path, codex),
+        verifier=FakeVerifier(pass_=False),
+    )
+
+    assert result.process_exit_code == 7
+    assert result.verifier_passed is False
+    assert result.task_success is False
+
+
+def test_codex_cli_runner_parses_jsonl_unknown_malformed_and_skill_events(tmp_path):
+    codex = _fake_codex(
+        tmp_path,
+        """
+        if sys.argv[1:] == ["--version"]:
+            print("codex 1.2.3")
+            raise SystemExit(0)
+        if sys.argv[1:3] == ["exec", "--help"]:
+            print("--json --ephemeral --ignore-user-config --ignore-rules --sandbox --cd --output-last-message")
+            raise SystemExit(0)
+        print(json.dumps({"type": "skill_read", "skill_id": "skill/browser"}))
+        print("{not-json")
+        print(json.dumps({"type": "future_event", "skill_id": "skill/unknown", "token": "sk-secret123456"}))
+        print(json.dumps({"type": "final", "message": "done"}))
+        """,
+    )
+
+    result = execute_live_agent(
+        request=_request(tmp_path),
+        runner=_runner(tmp_path, codex),
+        verifier=FakeVerifier(pass_=False),
+    )
+    trace = result.to_trace()
+    serialized = json.dumps(trace)
+
+    assert result.process_exit_code == 0
+    assert result.verifier_passed is False
+    assert result.task_success is False
+    assert trace["skill_use"]["skill/browser"]["state"] == "READ"
+    assert any(event["type"] == "unknown" for event in trace["events"])
+    assert any(event.get("original_type") == "malformed_jsonl" for event in trace["events"])
+    assert "sk-secret123456" not in serialized
+
+
+def test_codex_cli_runner_redacts_and_truncates_stdout_stderr(tmp_path):
+    codex = _fake_codex(
+        tmp_path,
+        """
+        if sys.argv[1:] == ["--version"]:
+            print("codex 1.2.3")
+            raise SystemExit(0)
+        if sys.argv[1:3] == ["exec", "--help"]:
+            print("--json --ephemeral --ignore-user-config --ignore-rules --sandbox --cd --output-last-message")
+            raise SystemExit(0)
+        print("token=SECRET123 " + ("x" * 200))
+        print("api_key=ERRSECRET", file=sys.stderr)
+        """,
+    )
+
+    output = _runner(tmp_path, codex, max_stdout_chars=40, max_stderr_chars=40).run(
+        _request(tmp_path)
+    )
+
+    assert "SECRET123" not in output.stdout
+    assert "ERRSECRET" not in output.stderr
+    assert len(output.stdout) <= 40
+    assert len(output.stderr) <= 40
+
+
+def test_codex_cli_runner_redacts_runner_events_and_final_message(tmp_path):
+    codex = _fake_codex(
+        tmp_path,
+        """
+        if sys.argv[1:] == ["--version"]:
+            print("codex 1.2.3")
+            raise SystemExit(0)
+        if sys.argv[1:3] == ["exec", "--help"]:
+            print("--json --ephemeral --ignore-user-config --ignore-rules --sandbox --cd --output-last-message")
+            raise SystemExit(0)
+        output_file = sys.argv[sys.argv.index("--output-last-message") + 1]
+        open(output_file, "w", encoding="utf-8").write("token=FINALSECRET " + ("z" * 200))
+        print(json.dumps({"type": "future_event", "payload": "api_key=EVENTSECRET " + ("x" * 200)}))
+        """,
+    )
+
+    output = _runner(tmp_path, codex, max_event_chars=50).run(_request(tmp_path))
+    serialized = json.dumps(output.events)
+
+    assert "FINALSECRET" not in serialized
+    assert "EVENTSECRET" not in serialized
+    assert len(output.events[-1]["message"]) <= 50
+    assert len(output.events[1]["payload"]) <= 50
+
+
+def test_live_agent_trace_schema_validates_fake_and_codex_traces(tmp_path):
+    schema = json.loads(
+        Path("schemas/live-agent-trace.schema.json").read_text(encoding="utf-8")
+    )
+    codex = _fake_codex(
+        tmp_path,
+        """
+        if sys.argv[1:] == ["--version"]:
+            print("codex 1.2.3")
+            raise SystemExit(0)
+        if sys.argv[1:3] == ["exec", "--help"]:
+            print("--json --ephemeral --ignore-user-config --ignore-rules --sandbox --cd --output-last-message")
+            raise SystemExit(0)
+        print(json.dumps({"type": "final", "message": "done"}))
+        """,
+    )
+
+    codex_trace = execute_live_agent(
+        request=_request(tmp_path),
+        runner=_runner(tmp_path, codex),
+        verifier=FakeVerifier(pass_=True),
+    ).to_trace()
+    jsonschema.validate(codex_trace, schema)
+
+    fake_trace = execute_live_agent(
+        request=_request(tmp_path / "fake", condition_name="routed-skill"),
+        runner=FakeAgentRunner(events=[{"type": "final", "message": "done"}]),
+        verifier=FakeVerifier(pass_=True),
+    ).to_trace()
+    jsonschema.validate(fake_trace, schema)
+
+
+def test_live_agent_trace_schema_rejects_malformed_skill_state(tmp_path):
+    schema = json.loads(
+        Path("schemas/live-agent-trace.schema.json").read_text(encoding="utf-8")
+    )
+    trace = execute_live_agent(
+        request=_request(tmp_path),
+        runner=FakeAgentRunner(events=[{"type": "final", "message": "done"}]),
+        verifier=FakeVerifier(pass_=True),
+    ).to_trace()
+    trace["skill_use"]["skill/browser"]["state"] = "USED_MAYBE"
+
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(trace, schema)

--- a/tests/test_codex_cli_runner.py
+++ b/tests/test_codex_cli_runner.py
@@ -133,6 +133,24 @@ def test_codex_cli_runner_rejects_codex_home_extra_env_override(tmp_path):
         )
 
 
+@pytest.mark.parametrize("env_key", ["HOME", "USERPROFILE", "XDG_CONFIG_HOME"])
+def test_codex_cli_runner_rejects_runner_controlled_extra_env_override(
+    tmp_path,
+    env_key,
+):
+    codex = _fake_codex(tmp_path, "print('should not run')\n")
+    host_home = tmp_path / "host-home"
+    (host_home / ".agents" / "skills" / "global" / "SKILL.md").parent.mkdir(
+        parents=True
+    )
+
+    with pytest.raises(ValueError, match=env_key):
+        _runner(tmp_path, codex).run(
+            _request(tmp_path),
+            extra_env={env_key: str(host_home)},
+        )
+
+
 @pytest.mark.parametrize(
     ("kwargs", "match"),
     [
@@ -320,6 +338,21 @@ def test_codex_cli_runner_rejects_preexisting_parent_repo_skills(tmp_path):
     codex = _fake_codex(tmp_path, "print('should not run')\n")
     repo = tmp_path / "repo"
     (repo / ".agents" / "skills" / "global").mkdir(parents=True)
+    request = _request(repo / "workspaces")
+
+    with pytest.raises(ValueError, match="workspace parent skill leakage"):
+        _runner(tmp_path, codex).run(request)
+
+
+def test_codex_cli_runner_rejects_dot_prefixed_skill_leakage(tmp_path):
+    codex = _fake_codex(tmp_path, "print('should not run')\n")
+    repo = tmp_path / "repo"
+    hidden_skill = repo / ".agents" / "skills" / ".hidden-skill"
+    hidden_skill.mkdir(parents=True)
+    (hidden_skill / "SKILL.md").write_text(
+        "---\nname: hidden\ndescription: hidden\n---\nbody\n",
+        encoding="utf-8",
+    )
     request = _request(repo / "workspaces")
 
     with pytest.raises(ValueError, match="workspace parent skill leakage"):

--- a/tests/test_codex_cli_runner.py
+++ b/tests/test_codex_cli_runner.py
@@ -76,9 +76,15 @@ def test_codex_cli_runner_builds_safe_default_command_and_isolated_home(tmp_path
             print("codex 1.2.3")
             raise SystemExit(0)
         if sys.argv[1:3] == ["exec", "--help"]:
-            print("--json --ephemeral --ignore-user-config --ignore-rules --sandbox --cd --output-last-message")
+            print("--json --ephemeral --ignore-user-config --ignore-rules --sandbox --cd --output-last-message --skip-git-repo-check")
             raise SystemExit(0)
-        record = {"argv": sys.argv[1:], "env": {"CODEX_HOME": os.environ.get("CODEX_HOME")}}
+        record = {
+            "argv": sys.argv[1:],
+            "env": {
+                "CODEX_HOME": os.environ.get("CODEX_HOME"),
+                "HOME": os.environ.get("HOME"),
+            },
+        }
         out = os.environ["FAKE_CODEX_RECORD"]
         open(out, "w", encoding="utf-8").write(json.dumps(record))
         output_file = sys.argv[sys.argv.index("--output-last-message") + 1]
@@ -106,10 +112,13 @@ def test_codex_cli_runner_builds_safe_default_command_and_isolated_home(tmp_path
         "--cd",
         str(request.workspace_path),
         "--output-last-message",
+        "--skip-git-repo-check",
     ]:
         assert flag in record["argv"]
     assert record["env"]["CODEX_HOME"].startswith(str(tmp_path / "codex-home"))
     assert record["env"]["CODEX_HOME"] != os.environ.get("CODEX_HOME")
+    assert record["env"]["HOME"].startswith(record["env"]["CODEX_HOME"])
+    assert record["env"]["HOME"] != os.environ.get("HOME")
     assert output.events[-1]["type"] == "final"
     assert output.events[-1]["message"] == "done"
 
@@ -134,6 +143,12 @@ def test_codex_cli_runner_rejects_codex_home_extra_env_override(tmp_path):
         ({"extra_args": ["--cd", "/tmp"]}, "--cd"),
         ({"extra_args": ["--output-last-message", "/tmp/out"]}, "--output-last-message"),
         ({"extra_args": ["--config", "approval_policy=\"on-request\""]}, "--config"),
+        ({"extra_args": ["--sandbox=danger-full-access"]}, "--sandbox"),
+        ({"extra_args": ["--config=approval_policy=\"on-request\""]}, "--config"),
+        ({"extra_args": ["-c=approval_policy=\"on-request\""]}, "-c"),
+        ({"extra_args": ["--add-dir=/"]}, "--add-dir"),
+        ({"extra_args": ["--yolo=true"]}, "--yolo"),
+        ({"extra_args": ["--profile=unsafe"]}, "--profile"),
     ],
 )
 def test_codex_cli_runner_rejects_unsafe_flags(tmp_path, kwargs, match):
@@ -253,6 +268,62 @@ def test_codex_cli_runner_preflight_rejects_global_leakage_in_inherit_mode(tmp_p
 
     with pytest.raises(ValueError, match="global Codex leakage"):
         runner.run(_request(tmp_path))
+
+
+def test_codex_cli_runner_isolated_clean_home_passes(tmp_path, monkeypatch):
+    codex = _fake_codex(
+        tmp_path,
+        """
+        if sys.argv[1:] == ["--version"]:
+            print("codex 1.2.3")
+            raise SystemExit(0)
+        if sys.argv[1:3] == ["exec", "--help"]:
+            print("--json --ephemeral --ignore-user-config --ignore-rules --sandbox --cd --output-last-message")
+            raise SystemExit(0)
+        print(json.dumps({"type": "final", "message": "done"}))
+        """,
+    )
+    host_home = tmp_path / "host-home"
+    host_home.mkdir()
+    monkeypatch.setenv("HOME", str(host_home))
+
+    output = _runner(tmp_path, codex).run(_request(tmp_path))
+
+    inventory = output.events[0]["global_capability_inventory"]
+    assert inventory["home_isolated"] is True
+    assert inventory["user_skill_dir"]["status"] == "ISOLATED_HOME"
+
+
+def test_codex_cli_runner_rejects_user_home_skill_leakage_when_not_isolating_home(
+    tmp_path,
+    monkeypatch,
+):
+    codex = _fake_codex(tmp_path, "print('should not run')\n")
+    host_home = tmp_path / "host-home"
+    (host_home / ".agents" / "skills" / "global").mkdir(parents=True)
+    monkeypatch.setenv("HOME", str(host_home))
+
+    with pytest.raises(ValueError, match="user skill leakage"):
+        _runner(tmp_path, codex, isolate_home=False).run(_request(tmp_path))
+
+
+def test_codex_cli_runner_rejects_admin_skill_leakage(tmp_path):
+    codex = _fake_codex(tmp_path, "print('should not run')\n")
+    admin_skills = tmp_path / "etc-codex-skills"
+    (admin_skills / "admin").mkdir(parents=True)
+
+    with pytest.raises(ValueError, match="admin skill leakage"):
+        _runner(tmp_path, codex, admin_skill_paths=[admin_skills]).run(_request(tmp_path))
+
+
+def test_codex_cli_runner_rejects_preexisting_parent_repo_skills(tmp_path):
+    codex = _fake_codex(tmp_path, "print('should not run')\n")
+    repo = tmp_path / "repo"
+    (repo / ".agents" / "skills" / "global").mkdir(parents=True)
+    request = _request(repo / "workspaces")
+
+    with pytest.raises(ValueError, match="workspace parent skill leakage"):
+        _runner(tmp_path, codex).run(request)
 
 
 def test_codex_cli_runner_rejects_no_skill_leakage_before_subprocess(tmp_path):

--- a/tests/test_live_agent_runtime.py
+++ b/tests/test_live_agent_runtime.py
@@ -19,7 +19,7 @@ from hermes_skilleval.live_agent_runtime import (
 def _skill(skill_id: str = "skill/browser-login") -> LiveAgentSkill:
     return LiveAgentSkill(
         skill_id=skill_id,
-        name="Browser Login",
+        name=f"Browser Login {skill_id}",
         body="Use browser automation. token=SECRET123",
     )
 
@@ -217,13 +217,20 @@ def test_workspace_preparation_mounts_skills_and_rejects_reuse(tmp_path):
     )
 
     assert workspace.workspace_path.exists()
+    assert workspace.skill_dir == workspace.workspace_path / ".agents" / "skills"
     assert workspace.skill_dir.exists()
     mounted = workspace.mounted_skills[0]
     assert mounted["skill_id"] == "skill/browser-login"
     assert mounted["sha256"]
-    assert (workspace.workspace_path / mounted["relative_path"]).read_text(
+    skill_text = (workspace.workspace_path / mounted["relative_path"]).read_text(
         encoding="utf-8"
-    ) == skill.body
+    )
+    assert mounted["relative_path"].startswith(".agents/skills/")
+    assert mounted["relative_path"].endswith("/SKILL.md")
+    assert "name:" in skill_text
+    assert "Browser Login" in skill_text
+    assert "description:" in skill_text
+    assert skill.body in skill_text
 
     with pytest.raises(ValueError, match="already exists"):
         prepare_live_agent_workspace(
@@ -254,6 +261,29 @@ def test_workspace_mount_filenames_are_collision_resistant(tmp_path):
             mounted_skills=[_skill("skill/a"), _skill("skill/a")],
         )
     assert not (tmp_path / "run-duplicate").exists()
+
+
+def test_workspace_mount_rejects_duplicate_skill_names(tmp_path):
+    with pytest.raises(ValueError, match="duplicate skill name"):
+        prepare_live_agent_workspace(
+            base_dir=tmp_path,
+            run_id="run-duplicate-name",
+            mounted_skills=[
+                LiveAgentSkill(skill_id="skill/a", name="Duplicate", body="A"),
+                LiveAgentSkill(skill_id="skill/b", name="Duplicate", body="B"),
+            ],
+        )
+
+
+def test_no_skill_workspace_has_no_codex_benchmark_skills(tmp_path):
+    workspace = prepare_live_agent_workspace(
+        base_dir=tmp_path,
+        run_id="run-no-skill",
+        mounted_skills=[],
+    )
+
+    assert workspace.mounted_skills == []
+    assert not workspace.skill_dir.exists()
 
 
 def test_fake_runner_separates_process_exit_from_verifier_result(tmp_path):


### PR DESCRIPTION
## Summary

- Add `CodexCliRunnerConfig` and `CodexCliRunner` implementing the PR-4 `AgentRunner` contract for non-interactive `codex exec` subprocess runs.
- Default to isolated `CODEX_HOME`, `--json`, `--ephemeral`, `--ignore-user-config`, `--ignore-rules`, `--sandbox workspace-write`, approval policy never config, and output-last-message capture.
- Add preflight for version/help support, inherited smoke-only mode, global skills/plugins/MCP/config leakage, no-skill leakage, unsafe sandbox/bypass/yolo flags, control-flag overrides, and CODEX_HOME env override.
- Add process-group timeout cleanup with SIGTERM plus bounded SIGKILL fallback, defensive JSONL parsing, unknown/malformed event preservation, runner-level redaction/truncation, and strict verifier source-of-truth semantics.
- Add `schemas/live-agent-trace.schema.json`, OpenSpec PR-5 artifacts, and Chinese Human Brief.

## Scope Boundaries

- Does not integrate SkillsBench.
- Does not run full live-agent benchmark.
- Does not modify Phase 10 deterministic offline replay.
- Does not modify external matrix or SkillRouter scorer logic.
- Does not add router promotion or release gate logic.
- Does not train or tune routers.
- Does not use `--yolo`, `danger-full-access`, or dangerous bypass flags.
- Usage/cost remain `null` unless reliable token usage exists.

## Validation

- `python -m pytest -q tests/test_codex_cli_runner.py` -> 22 passed
- `python -m pytest -q tests/test_live_agent_runtime.py` -> 19 passed
- `python -m pytest -q` -> 525 passed
- `OPENSPEC_TELEMETRY=0 openspec validate --all --strict` -> 21 passed, 0 failed
- `PYTHONPATH=src python -m hermes_skilleval.cli release-check --phase17-output-dir docs/demo/phase17-calibrated-release-selector --release-output-dir docs/demo/phase18-ci-release-reproducibility` -> PASS
- `git diff --check` -> PASS
- v0.3 YAML parse check -> parsed 3 v0.3 YAML files
- CRLF/new-file line-ending check -> LF only in 11 changed/new text files

## Review Notes

Read-only review caught runner safety issues before commit. This PR includes regression coverage and fixes for:

- Rejecting `extra_env` `CODEX_HOME` overrides.
- Rejecting runner control-flag overrides in `extra_args`.
- Passing flag-like prompts after `--`.
- Timeout cleanup with SIGKILL fallback for ignored SIGTERM.
- Runner-level redaction/truncation for JSONL events and final-message content before returning `RunnerOutput`.
- Tighter live-agent trace schema checks for mounted skill records, skill-use states, and event objects.
