### PR TITLE
PR-7: add v0.3 evidence validity gate

### DIFF
--- a/docs/human-briefs/2026-06-28-evidence-validity-release-gate.html
+++ b/docs/human-briefs/2026-06-28-evidence-validity-release-gate.html
@@ -1,0 +1,67 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Hermes SkillEval v0.3 PR-7 Evidence Gate Human Brief</title>
+  <style>
+    body { margin: 0; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; color: #17202a; background: #f7f9fb; }
+    main { max-width: 980px; margin: 0 auto; padding: 40px 24px 56px; }
+    header { border-left: 6px solid #2563eb; padding-left: 18px; margin-bottom: 28px; }
+    h1 { font-size: 28px; margin: 0 0 8px; }
+    h2 { font-size: 18px; margin: 26px 0 10px; }
+    p, li { line-height: 1.7; }
+    code { background: #e8edf5; padding: 2px 5px; border-radius: 4px; }
+    .status { display: inline-block; padding: 4px 10px; border-radius: 6px; background: #dcfce7; color: #14532d; font-weight: 700; }
+    section { background: #fff; border: 1px solid #e5e7eb; border-radius: 8px; padding: 18px 20px; margin: 16px 0; }
+    ul { padding-left: 20px; }
+  </style>
+</head>
+<body>
+<main>
+  <header>
+    <h1>PR-7 证据有效性与发布门禁</h1>
+    <p><span class="status">needs review</span> 结论：已实现统一证据 validator/reporting，默认保持基线，不执行模型、训练、live benchmark 或 release promotion。</p>
+  </header>
+
+  <section>
+    <h2>本阶段变更</h2>
+    <ul>
+      <li>新增 <code>hermes_skilleval.evidence_gate</code>，消费 PR-3 SkillRouter external matrix 与 PR-6 SkillsBench live-agent artifacts。</li>
+      <li>新增 <code>v0.3-evidence-gate</code> CLI，输出 JSON 决策报告和可选 Markdown 摘要。</li>
+      <li>Benchmark Validity Gate 只产生 <code>VALID_EVIDENCE</code>、<code>INVALID_EVIDENCE</code>、<code>REVIEW_REQUIRED</code>；<code>UNAVAILABLE</code> 只作为字段级 marker。</li>
+      <li>Router Promotion Gate 默认 <code>KEEP_BASELINE</code>；无有效证据时阻止 promotion。</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>关键检查</h2>
+    <ul>
+      <li>External: frozen plan schema、input hash/provenance、prediction hash、official metrics 与 Hermes diagnostics 分离。</li>
+      <li>Live-agent: plan digest、input hash、derived hash、prompt hash equality、oracle qualification、verifier evidence、trace completeness、no-skill leakage、overlap status、secret redaction。</li>
+      <li>Reporting: external metrics、live condition pass count、routed-vs-no-skill delta、oracle gap、timeout/process errors、skill-use evidence、per-task regressions 分开呈现。</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>验证结果</h2>
+    <ul>
+      <li><code>python -m pytest -q tests/test_v0_3_evidence_gate.py</code>: 本次本地验证通过。</li>
+      <li><code>python -m pytest -q</code>: 本次本地验证通过。</li>
+      <li><code>OPENSPEC_TELEMETRY=0 openspec validate --all --strict</code>: 23 passed。</li>
+      <li><code>PYTHONPATH=src python -m hermes_skilleval.cli release-check ...</code>: PASS。</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>不要过度声明</h2>
+    <p>PR-7 只验证和汇总 frozen evidence。它不证明新 router 可上线，不运行真实 Codex benchmark，不替代 PR-1..PR-6 的 artifact 合同，也不允许把 linked transfer 当作独立泛化结论。</p>
+  </section>
+
+  <section>
+    <h2>下一步</h2>
+    <p>完成 diff、YAML、CRLF 检查后，进入 PR-7 review。若 review 通过，再合回 <code>codex/v0.3-pr0-protocol</code>。</p>
+  </section>
+</main>
+</body>
+</html>

--- a/openspec/changes/evidence-validity-release-gate/.openspec.yaml
+++ b/openspec/changes/evidence-validity-release-gate/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-28

--- a/openspec/changes/evidence-validity-release-gate/design.md
+++ b/openspec/changes/evidence-validity-release-gate/design.md
@@ -1,0 +1,38 @@
+## Context
+
+PR-1 through PR-6 created bounded inputs: SkillRouter adapter/provenance, official scorer parity, frozen external matrix reports, live-agent runtime contracts, Codex runner isolation, and SkillsBench live-agent plans/reports. PR-7 must consume those artifacts as evidence, not rerun benchmark logic or promote routers.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Produce one v0.3 evidence packet with separate validity and promotion sections.
+- Keep Benchmark Validity Gate statuses limited to `VALID_EVIDENCE`, `INVALID_EVIDENCE`, and `REVIEW_REQUIRED`.
+- Keep `UNAVAILABLE` field-level only, with reasons.
+- Default Router Promotion Gate to `KEEP_BASELINE`.
+- Fail closed on missing/corrupted frozen inputs, mismatched digests, invalid overlap claims, prompt-hash mismatch, incomplete verifier evidence, no-skill leakage, trace incompleteness, or redaction failures.
+- Report external routing metrics and live-agent outcomes without merging the namespaces.
+
+**Non-Goals:**
+
+- No model inference, router training, threshold tuning, hard-negative mining, full live-agent benchmark execution, Phase 10 changes, or release promotion.
+- No changes to SkillRouter official scorer, external matrix, live-agent runtime, or Codex runner unless a validator integration bug proves a contract issue.
+
+## Decisions
+
+1. **Validator consumes artifacts by path.** The CLI accepts optional external matrix report/plan and live-agent report/plan paths, plus an output path. Missing optional groups become field-level `UNAVAILABLE`; malformed provided artifacts fail closed.
+
+2. **Validity and promotion are independent report sections.** Validity answers whether the evidence can support the preregistered question. Promotion defaults to `KEEP_BASELINE`; invalid evidence blocks promotion even if metrics look favorable.
+
+3. **Checks are explicit records.** Each check emits a stable ID, status, severity, summary, and optional details. Top-level validity is derived from check severities rather than free-form prose.
+
+4. **Earlier PR contracts remain source of truth.** PR-7 validates existing plan/report fields and hashes; it does not recompute official metrics, rerun routers, rerun live agents, or mutate evidence artifacts.
+
+5. **Reports are conservative.** Linked-transfer overlap, missing optional diagnostics, and partial evidence are surfaced as caveats or review requirements. Public numeric claims are not generated unless backing artifacts are present.
+
+## Risks / Trade-offs
+
+- **Risk: validator becomes a second scorer.** Mitigation: read and summarize scorer outputs only; never recompute router metrics beyond structural checks.
+- **Risk: missing optional artifacts produce a misleading PASS.** Mitigation: optional groups are field-level `UNAVAILABLE`; required provided artifacts still fail closed when corrupt.
+- **Risk: promotion status leaks into validity.** Mitigation: separate enums and tests that reject top-level `UNAVAILABLE`.
+- **Risk: trace validation grows too broad.** Mitigation: check core schema-like fields and redaction markers without changing runtime trace schema.

--- a/openspec/changes/evidence-validity-release-gate/proposal.md
+++ b/openspec/changes/evidence-validity-release-gate/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+v0.3 now has frozen SkillRouter external artifacts and live-agent artifacts, but there is no single fail-closed packet that says whether the evidence is valid or whether router promotion is allowed. PR-7 adds that consolidation without running new models or changing earlier benchmark/runtime logic.
+
+## What Changes
+
+- Add a unified evidence validator and report writer for v0.3 evidence packets.
+- Separate Benchmark Validity Gate status from Router Promotion Gate decision.
+- Validate frozen plan hashes, plan digests, derived hashes, scorer/report separation, overlap caveats, prompt-hash equality, oracle qualification, verifier evidence, trace completeness, leakage inventory, and field-level `UNAVAILABLE` markers.
+- Summarize external routing metrics, live-agent verifier outcomes, oracle gap, routed-vs-no-skill delta, timeout/process errors, skill-use evidence, and per-task regressions separately.
+- Default promotion to `KEEP_BASELINE` and block promotion when validity is `INVALID_EVIDENCE`.
+- Add focused tests, CLI wiring, OpenSpec artifacts, and a concise Chinese Human Brief.
+
+## Capabilities
+
+### New Capabilities
+
+- `evidence-validity-release-gate`: Unified v0.3 evidence validity and conservative router-promotion reporting.
+
+### Modified Capabilities
+
+- None.
+
+## Impact
+
+- Affected code: new evidence validator module, scoped CLI command, tests, OpenSpec change, and Human Brief.
+- Existing SkillRouter adapter/scorer/matrix, live-agent runtime, Codex runner, Phase 10 replay, and Phase 17/18 release artifacts remain unchanged.
+- No new runtime dependency, model execution, training, tuning, live benchmark run, or release promotion is introduced.

--- a/openspec/changes/evidence-validity-release-gate/specs/evidence-validity-release-gate/spec.md
+++ b/openspec/changes/evidence-validity-release-gate/specs/evidence-validity-release-gate/spec.md
@@ -1,0 +1,45 @@
+## ADDED Requirements
+
+### Requirement: Validate v0.3 evidence packets
+
+The system SHALL validate v0.3 external-routing and live-agent evidence artifacts without running new models, training, tuning, live-agent benchmarks, or release promotion.
+
+#### Scenario: Validity gate emits only allowed statuses
+
+- **WHEN** the evidence validator writes a report
+- **THEN** the Benchmark Validity Gate status MUST be one of `VALID_EVIDENCE`, `INVALID_EVIDENCE`, or `REVIEW_REQUIRED`
+- **AND** `UNAVAILABLE` MUST appear only as a field-level marker with a reason
+
+#### Scenario: Frozen evidence fails closed
+
+- **WHEN** a provided frozen plan, digest, source hash, derived hash, scorer report, matrix report, live-agent report, or trace is missing, malformed, contaminated, or inconsistent
+- **THEN** the validator MUST mark the evidence `INVALID_EVIDENCE` or `REVIEW_REQUIRED` with explicit check records
+
+### Requirement: Keep promotion separate and conservative
+
+The system SHALL keep router promotion decisions separate from evidence validity.
+
+#### Scenario: Invalid validity blocks promotion
+
+- **WHEN** Benchmark Validity Gate status is `INVALID_EVIDENCE`
+- **THEN** Router Promotion Gate MUST emit `KEEP_BASELINE`
+- **AND** it MUST record that promotion is blocked by invalid evidence
+
+#### Scenario: Default promotion is baseline
+
+- **WHEN** evidence is valid or reviewable but no preregistered promotion approval artifact exists
+- **THEN** Router Promotion Gate MUST emit `KEEP_BASELINE`
+
+### Requirement: Report external and live-agent evidence separately
+
+The system SHALL summarize external routing evidence and live-agent evidence in distinct report sections.
+
+#### Scenario: External metrics are namespaced
+
+- **WHEN** a SkillRouter external matrix report is supplied
+- **THEN** the validator MUST report official routing metrics separately from Hermes diagnostics and overlap caveats
+
+#### Scenario: Live-agent verifier outcomes are namespaced
+
+- **WHEN** a SkillsBench live-agent matrix report is supplied
+- **THEN** the validator MUST report verifier pass/fail, no-skill/routed/oracle outcomes, oracle gap, routed-vs-no-skill delta, timeout/process errors, skill-use evidence, and per-task regressions separately

--- a/openspec/changes/evidence-validity-release-gate/tasks.md
+++ b/openspec/changes/evidence-validity-release-gate/tasks.md
@@ -1,0 +1,34 @@
+## 1. OpenSpec And Scope
+
+- [x] 1.1 Create PR-7 OpenSpec proposal, design, spec, and task artifacts.
+- [x] 1.2 Keep PR-7 limited to evidence validation and reporting.
+
+## 2. Tests First
+
+- [x] 2.1 Add RED tests for allowed validity statuses and field-level `UNAVAILABLE`.
+- [x] 2.2 Add RED tests for frozen external matrix input/hash/plan checks.
+- [x] 2.3 Add RED tests for live-agent prompt hash, no-skill leakage, verifier, trace, and overlap checks.
+- [x] 2.4 Add RED tests that promotion defaults to `KEEP_BASELINE` and invalid validity blocks promotion.
+
+## 3. Evidence Validator
+
+- [x] 3.1 Implement artifact loading, hash/digest checks, and structured check records.
+- [x] 3.2 Implement external routing evidence validation and summary extraction.
+- [x] 3.3 Implement live-agent evidence validation and summary extraction.
+- [x] 3.4 Implement validity status derivation and conservative promotion gate.
+
+## 4. CLI And Reporting
+
+- [x] 4.1 Add a scoped CLI command for v0.3 evidence validation.
+- [x] 4.2 Write JSON and optional Markdown decision reports.
+- [x] 4.3 Add concise Chinese Human Brief for PR-7.
+
+## 5. Validation
+
+- [x] 5.1 Run focused PR-7 tests.
+- [x] 5.2 Run `python -m pytest -q`.
+- [x] 5.3 Run `OPENSPEC_TELEMETRY=0 openspec validate --all --strict`.
+- [x] 5.4 Run `PYTHONPATH=src python -m hermes_skilleval.cli release-check --phase17-output-dir docs/demo/phase17-calibrated-release-selector --release-output-dir docs/demo/phase18-ci-release-reproducibility`.
+- [x] 5.5 Run `git diff --check`.
+- [x] 5.6 Run v0.3 YAML parse check.
+- [x] 5.7 Run CRLF/new-file line-ending check.

--- a/src/hermes_skilleval/cli.py
+++ b/src/hermes_skilleval/cli.py
@@ -40,6 +40,7 @@ from hermes_skilleval.external.skillrouter_matrix import (
     write_skillrouter_matrix_plan,
 )
 from hermes_skilleval.external.skillrouter_scorer import write_skillrouter_score_report
+from hermes_skilleval.evidence_gate import write_evidence_decision_report
 from hermes_skilleval.failure_analysis import (
     result_paths_from_comparison_dir,
     write_failure_analysis_report,
@@ -417,6 +418,18 @@ def _build_parser() -> argparse.ArgumentParser:
     skillsbench_matrix_parser.add_argument("--plan", required=True)
     skillsbench_matrix_parser.add_argument("--output", required=True)
     skillsbench_matrix_parser.set_defaults(handler=_run_skillsbench_matrix)
+
+    evidence_gate_parser = subparsers.add_parser(
+        "v0.3-evidence-gate",
+        help="validate frozen v0.3 external and live-agent evidence before promotion",
+    )
+    evidence_gate_parser.add_argument("--output", required=True)
+    evidence_gate_parser.add_argument("--markdown-output", default=None)
+    evidence_gate_parser.add_argument("--external-plan", default=None)
+    evidence_gate_parser.add_argument("--external-report", default=None)
+    evidence_gate_parser.add_argument("--live-plan", default=None)
+    evidence_gate_parser.add_argument("--live-report", default=None)
+    evidence_gate_parser.set_defaults(handler=_run_v0_3_evidence_gate)
 
     index_parser = subparsers.add_parser("index", help="scan skills and write an index")
     index_parser.add_argument("--skills-path", required=True)
@@ -1141,6 +1154,22 @@ def _run_skillsbench_matrix(args: argparse.Namespace) -> None:
         "SkillsBench live-agent matrix "
         f"{report['run_id']}: {args.output} "
         f"({len(report['runs'])} runs)"
+    )
+
+
+def _run_v0_3_evidence_gate(args: argparse.Namespace) -> None:
+    report = write_evidence_decision_report(
+        output_path=args.output,
+        markdown_output_path=args.markdown_output,
+        external_plan_path=args.external_plan,
+        external_report_path=args.external_report,
+        live_plan_path=args.live_plan,
+        live_report_path=args.live_report,
+    )
+    print(
+        "v0.3 evidence gate "
+        f"{report['benchmark_validity_gate']['status']}: {args.output} "
+        f"({report['router_promotion_gate']['decision']})"
     )
 
 

--- a/src/hermes_skilleval/evidence_gate.py
+++ b/src/hermes_skilleval/evidence_gate.py
@@ -225,6 +225,7 @@ def _evaluate_external(
         if isinstance(official, dict) and bool(official)
         else "official SkillRouter metrics are missing",
     )
+    _check_external_report_completeness(checks, plan, report)
     _check(
         checks,
         "external.hermes_diagnostics_separate",
@@ -327,9 +328,10 @@ def _evaluate_live_agent(
     _check_oracle_qualification(checks, plan)
     _check_verifier_evidence(checks, report)
     _check_no_skill_leakage(checks, report)
-    _check_trace_completeness(checks, report)
+    _check_global_capability_inventory(checks, report, report_path.parent)
+    _check_trace_completeness(checks, report, report_path.parent)
     _check_overlap_status(checks, report)
-    _check_secret_redaction(checks, report)
+    _check_secret_redaction(checks, report, report_path.parent)
 
     runs = report.get("runs") if isinstance(report, dict) else []
     run_records = runs if isinstance(runs, list) else []
@@ -403,6 +405,93 @@ def _external_router_configs(plan: dict[str, Any]) -> list[dict[str, Any]]:
         for config in configs
         if isinstance(config, dict)
     ]
+
+
+def _check_external_report_completeness(
+    checks: list[dict[str, Any]],
+    plan: dict[str, Any],
+    report: dict[str, Any],
+) -> None:
+    expected = [
+        str(config.get("config_id"))
+        for config in plan.get("frozen_routers", [])
+        if isinstance(config, dict) and config.get("config_id")
+    ]
+    official = report.get("official") if isinstance(report, dict) else None
+    actual = sorted(official) if isinstance(official, dict) else []
+    missing = sorted(set(expected) - set(actual))
+    extra = sorted(set(actual) - set(expected))
+    structure_errors = []
+    tiers = [str(tier) for tier in plan.get("tiers", ("easy", "hard"))]
+    if isinstance(official, dict):
+        for config_id in sorted(set(expected) & set(actual)):
+            structure_errors.extend(
+                _official_config_structure_errors(config_id, official[config_id], tiers)
+            )
+    _check(
+        checks,
+        "external.report_completeness",
+        PASS if not missing and not extra and not structure_errors else FAIL,
+        BLOCKING,
+        "external official report covers exactly the frozen configs and tiers"
+        if not missing and not extra and not structure_errors
+        else "external official report does not match frozen config/tier structure",
+        {
+            "expected_config_ids": expected,
+            "actual_config_ids": actual,
+            "missing_config_ids": missing,
+            "unexpected_config_ids": extra,
+            "structure_errors": structure_errors,
+        },
+    )
+
+
+def _official_config_structure_errors(
+    config_id: str,
+    payload: Any,
+    tiers: list[str],
+) -> list[dict[str, Any]]:
+    errors = []
+    if not isinstance(payload, dict):
+        return [{"config_id": config_id, "reason": "config report is not an object"}]
+    score = payload
+    if score.get("schema_version") != "v0.3.skillrouter-official-scorer.v1":
+        errors.append({"config_id": config_id, "reason": "missing official scorer schema"})
+    by_tier = score.get("by_tier")
+    if not isinstance(by_tier, dict):
+        return errors + [{"config_id": config_id, "reason": "missing by_tier object"}]
+    missing_tiers = sorted(set(tiers) - set(by_tier))
+    extra_tiers = sorted(set(by_tier) - set(tiers))
+    for tier in missing_tiers:
+        errors.append({"config_id": config_id, "tier": tier, "reason": "missing tier"})
+    for tier in extra_tiers:
+        errors.append({"config_id": config_id, "tier": tier, "reason": "unexpected tier"})
+    for tier in sorted(set(tiers) & set(by_tier)):
+        tier_report = by_tier[tier]
+        if not isinstance(tier_report, dict):
+            errors.append({"config_id": config_id, "tier": tier, "reason": "tier is not object"})
+            continue
+        aggregates = tier_report.get("aggregates")
+        if not isinstance(aggregates, dict):
+            errors.append({"config_id": config_id, "tier": tier, "reason": "missing aggregates"})
+        else:
+            for slice_name in ("all", "single", "multi"):
+                if not isinstance(aggregates.get(slice_name), dict):
+                    errors.append(
+                        {
+                            "config_id": config_id,
+                            "tier": tier,
+                            "slice": slice_name,
+                            "reason": "missing aggregate slice",
+                        }
+                    )
+        if not isinstance(tier_report.get("tasks"), list):
+            errors.append({"config_id": config_id, "tier": tier, "reason": "missing tasks"})
+        if not isinstance(tier_report.get("task_count"), int):
+            errors.append(
+                {"config_id": config_id, "tier": tier, "reason": "missing task_count"}
+            )
+    return errors
 
 
 def _schema_check(
@@ -560,19 +649,74 @@ def _prompt_hash_mismatches(records: Any) -> list[str]:
 
 
 def _check_oracle_qualification(checks: list[dict[str, Any]], plan: dict[str, Any]) -> None:
-    selected = {task.get("task_id") for task in plan.get("selected_tasks", []) if isinstance(task, dict)}
-    qualified = set(plan.get("oracle_qualification_records", {}))
+    selected_tasks = [
+        task for task in plan.get("selected_tasks", []) if isinstance(task, dict)
+    ]
+    selected = {task.get("task_id") for task in selected_tasks}
+    records = plan.get("oracle_qualification_records", {})
+    qualified = set(records) if isinstance(records, dict) else set()
     missing = sorted(str(task_id) for task_id in selected - qualified)
+    failures = [{"task_id": task_id, "reason": "missing oracle qualification"} for task_id in missing]
+    if isinstance(records, dict):
+        for task in selected_tasks:
+            task_id = str(task.get("task_id"))
+            if task_id not in records:
+                continue
+            failures.extend(_oracle_record_failures(task, records[task_id]))
+    else:
+        failures.append({"reason": "oracle_qualification_records is not an object"})
     _check(
         checks,
         "live_agent.oracle_qualification",
-        PASS if not missing else FAIL,
+        PASS if not failures else FAIL,
         BLOCKING,
-        "oracle qualification exists for every selected live task"
-        if not missing
-        else "selected live tasks are missing oracle qualification",
-        {"missing_task_ids": missing},
+        "oracle qualification passed for every selected live task"
+        if not failures
+        else "selected live tasks failed oracle qualification requirements",
+        {"failures": failures},
     )
+
+
+def _oracle_record_failures(
+    task: dict[str, Any],
+    record: Any,
+) -> list[dict[str, Any]]:
+    task_id = str(task.get("task_id"))
+    failures = []
+    if not isinstance(record, dict):
+        return [{"task_id": task_id, "reason": "oracle record is not an object"}]
+    if record.get("condition") not in {None, "oracle-skill"}:
+        failures.append({"task_id": task_id, "reason": "oracle record condition is not oracle-skill"})
+    passed = record.get("verifier_passed", record.get("passed"))
+    if passed is not True:
+        failures.append({"task_id": task_id, "reason": "oracle verifier did not pass"})
+    pass_rate = record.get("pass_rate", record.get("oracle_pass_rate"))
+    if pass_rate is not None:
+        parsed_rate = _float_value(pass_rate)
+        if parsed_rate is None or parsed_rate < 1.0:
+            failures.append({"task_id": task_id, "reason": "oracle pass_rate is below 1.0"})
+    passes = record.get("passes", record.get("pass_count"))
+    trials = record.get("trials", record.get("trial_count"))
+    if passes is not None and trials is not None:
+        parsed_passes = _int_or_none(passes)
+        parsed_trials = _int_or_none(trials)
+        if (
+            parsed_passes is None
+            or parsed_trials is None
+            or parsed_passes != parsed_trials
+        ):
+            failures.append({"task_id": task_id, "reason": "oracle passes do not equal trials"})
+    for field in ("verifier_stable", "stable", "deterministic", "verifier_deterministic"):
+        if field in record and record[field] is not True:
+            failures.append({"task_id": task_id, "reason": f"oracle {field} is not true"})
+    verifier = task.get("verifier")
+    if not isinstance(verifier, dict) or verifier.get("type") != "deterministic":
+        failures.append({"task_id": task_id, "reason": "task verifier is not deterministic"})
+    if task.get("requires_private_credentials") is True:
+        failures.append({"task_id": task_id, "reason": "task requires private credentials"})
+    if task.get("network", "none") not in {"none", "controlled"}:
+        failures.append({"task_id": task_id, "reason": "task network requirement is uncontrolled"})
+    return failures
 
 
 def _check_verifier_evidence(checks: list[dict[str, Any]], report: dict[str, Any]) -> None:
@@ -637,12 +781,190 @@ def _check_no_skill_leakage(checks: list[dict[str, Any]], report: dict[str, Any]
     )
 
 
-def _check_trace_completeness(checks: list[dict[str, Any]], report: dict[str, Any]) -> None:
+def _check_global_capability_inventory(
+    checks: list[dict[str, Any]],
+    report: dict[str, Any],
+    report_dir: Path,
+) -> None:
+    failures = []
+    reviews = []
+    inventories = _capability_inventories(report, report_dir)
+    for source, inventory in inventories:
+        failures.extend(_capability_inventory_failures(source, inventory))
+        reviews.extend(_capability_inventory_reviews(source, inventory))
+    if failures:
+        status = FAIL
+        severity = BLOCKING
+        summary = "global capability inventory shows skill leakage"
+    elif reviews:
+        status = REVIEW
+        severity = REVIEW_SEVERITY
+        summary = "global capability inventory requires review"
+    else:
+        status = PASS
+        severity = INFO
+        summary = "global capability inventory has no detected user/admin/repo leakage"
+    _check(
+        checks,
+        "live_agent.global_capability_inventory",
+        status,
+        severity,
+        summary,
+        {
+            "inventory_count": len(inventories),
+            "failures": failures,
+            "reviews": reviews,
+        },
+    )
+
+
+def _capability_inventories(
+    report: dict[str, Any],
+    report_dir: Path,
+) -> list[tuple[str, dict[str, Any]]]:
+    inventories = []
+    for key in ("global_capability_inventory", "preflight"):
+        value = report.get(key)
+        if isinstance(value, dict):
+            inventory = value.get("global_capability_inventory", value)
+            if isinstance(inventory, dict):
+                inventories.append((f"report.{key}", _inventory_with_preflight_mode(inventory, value)))
+    for run in _runs(report):
+        trace_path = _trace_path_for_run(run, report_dir)
+        if trace_path is None or not trace_path.exists():
+            continue
+        try:
+            trace = _read_json(trace_path)
+        except (OSError, json.JSONDecodeError, ValueError):
+            continue
+        for event in trace.get("events", []):
+            if not isinstance(event, dict) or event.get("type") != "preflight":
+                continue
+            inventory = event.get("global_capability_inventory") or event.get("skill_inventory")
+            if isinstance(inventory, dict):
+                inventories.append(
+                    (
+                        f"trace.{run.get('run_id')}.preflight",
+                        _inventory_with_preflight_mode(inventory, event),
+                    )
+                )
+    return inventories
+
+
+def _inventory_with_preflight_mode(
+    inventory: dict[str, Any],
+    preflight: dict[str, Any],
+) -> dict[str, Any]:
+    merged = dict(inventory)
+    for key in ("codex_home_mode", "evidence_mode"):
+        if key in preflight and key not in merged:
+            merged[key] = preflight[key]
+    return merged
+
+
+def _capability_inventory_failures(
+    source: str,
+    inventory: dict[str, Any],
+) -> list[dict[str, Any]]:
+    failures = []
+    user = inventory.get("user_skill_dir")
+    if isinstance(user, dict) and _entry_count(user) > 0:
+        failures.append({"source": source, "surface": "user_skill_dir", "reason": "non-empty"})
+    admin_dirs = inventory.get("admin_skill_dirs", [])
+    if isinstance(admin_dirs, list):
+        for index, item in enumerate(admin_dirs):
+            if isinstance(item, dict) and _entry_count(item) > 0:
+                failures.append(
+                    {
+                        "source": source,
+                        "surface": f"admin_skill_dirs[{index}]",
+                        "reason": "non-empty",
+                    }
+                )
+    workspace = inventory.get("workspace_skill_dirs")
+    if isinstance(workspace, dict):
+        for key, value in workspace.items():
+            if "parent" in str(key) and str(key).endswith("count") and _int_value(value) > 0:
+                failures.append(
+                    {
+                        "source": source,
+                        "surface": f"workspace_skill_dirs.{key}",
+                        "reason": "workspace-parent skills are non-empty",
+                    }
+                )
+        for key in ("unexpected_entry_count", "leaked_entry_count", "parent_leak_count"):
+            if _int_value(workspace.get(key)) > 0:
+                failures.append(
+                    {
+                        "source": source,
+                        "surface": f"workspace_skill_dirs.{key}",
+                        "reason": "workspace skills are not run-created",
+                    }
+                )
+    return failures
+
+
+def _capability_inventory_reviews(
+    source: str,
+    inventory: dict[str, Any],
+) -> list[dict[str, Any]]:
+    reviews = []
+    user = inventory.get("user_skill_dir")
+    if isinstance(user, dict) and user.get("status") == "SMOKE_ONLY":
+        reviews.append({"source": source, "surface": "user_skill_dir", "reason": "smoke-only"})
+    for key in ("codex_home_mode", "evidence_mode"):
+        value = inventory.get(key)
+        if value in {"inherit", "smoke-only"}:
+            reviews.append({"source": source, "surface": key, "reason": str(value)})
+    return reviews
+
+
+def _entry_count(value: dict[str, Any]) -> int:
+    for key in ("entry_count", "entries", "skill_count", "count"):
+        count = _int_value(value.get(key))
+        if count:
+            return count
+    return 0
+
+
+def _int_value(value: Any) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _int_or_none(value: Any) -> int | None:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _float_value(value: Any) -> float | None:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _check_trace_completeness(
+    checks: list[dict[str, Any]],
+    report: dict[str, Any],
+    report_dir: Path,
+) -> None:
     failures = []
     for run in _runs(report):
-        trace_path = Path(str(run.get("trace_path")))
+        trace_path = _trace_path_for_run(run, report_dir)
+        if trace_path is None:
+            failures.append({"run_id": run.get("run_id"), "reason": "trace path escapes artifact directory"})
+            continue
         if not trace_path.exists():
             failures.append({"run_id": run.get("run_id"), "reason": "trace file is missing"})
+            continue
+        expected_hash = _trace_hash_from_run(run)
+        if expected_hash and sha256_file(trace_path) != expected_hash:
+            failures.append({"run_id": run.get("run_id"), "reason": "trace hash mismatch"})
             continue
         try:
             trace = _read_json(trace_path)
@@ -671,6 +993,34 @@ def _check_trace_completeness(checks: list[dict[str, Any]], report: dict[str, An
         else "live-agent trace files are missing, incomplete, or inconsistent with report rows",
         {"failures": failures},
     )
+
+
+def _trace_path_for_run(run: dict[str, Any], report_dir: Path) -> Path | None:
+    raw = run.get("trace_path")
+    if not isinstance(raw, str) or not raw.strip():
+        return None
+    path = Path(raw)
+    if not path.is_absolute():
+        path = report_dir / path
+    try:
+        resolved = path.resolve()
+        resolved.relative_to(report_dir.resolve())
+    except (OSError, ValueError):
+        return None
+    return resolved
+
+
+def _trace_hash_from_run(run: dict[str, Any]) -> str | None:
+    for key in ("trace_sha256", "trace_hash", "trace_file_sha256"):
+        value = run.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    trace_file = run.get("trace_file")
+    if isinstance(trace_file, dict):
+        value = trace_file.get("sha256")
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None
 
 
 def _trace_report_mismatches(run: dict[str, Any], trace: dict[str, Any]) -> list[dict[str, Any]]:
@@ -720,7 +1070,16 @@ def _trace_report_mismatches(run: dict[str, Any], trace: dict[str, Any]) -> list
 def _check_overlap_status(checks: list[dict[str, Any]], report: dict[str, Any]) -> None:
     overlap = report.get("overlap_report")
     decision = overlap.get("decision") if isinstance(overlap, dict) else None
-    if decision == "INVALID":
+    independent_claim = (
+        overlap.get("independent_generalization_claim")
+        if isinstance(overlap, dict)
+        else None
+    )
+    if decision != "DISJOINT" and independent_claim is True:
+        status = FAIL
+        severity = BLOCKING
+        summary = "overlap independent_generalization_claim conflicts with overlap decision"
+    elif decision == "INVALID":
         status = FAIL
         severity = BLOCKING
         summary = "overlap report is invalid"
@@ -742,16 +1101,25 @@ def _check_overlap_status(checks: list[dict[str, Any]], report: dict[str, Any]) 
         status,
         severity,
         summary,
-        {"decision": decision},
+        {
+            "decision": decision,
+            "independent_generalization_claim": independent_claim,
+        },
     )
 
 
-def _check_secret_redaction(checks: list[dict[str, Any]], report: dict[str, Any]) -> None:
+def _check_secret_redaction(
+    checks: list[dict[str, Any]],
+    report: dict[str, Any],
+    report_dir: Path,
+) -> None:
     leaks = []
     if SECRET_RE.search(json.dumps(report, sort_keys=True, default=str)):
         leaks.append({"artifact": "live_report"})
     for run in _runs(report):
-        trace_path = Path(str(run.get("trace_path")))
+        trace_path = _trace_path_for_run(run, report_dir)
+        if trace_path is None:
+            continue
         if not trace_path.exists():
             continue
         text = trace_path.read_text(encoding="utf-8")

--- a/src/hermes_skilleval/evidence_gate.py
+++ b/src/hermes_skilleval/evidence_gate.py
@@ -1,0 +1,978 @@
+from __future__ import annotations
+
+import json
+import re
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from hermes_skilleval.external.skillrouter import SkillRouterAdapter
+from hermes_skilleval.external.skillrouter_matrix import (
+    PLAN_SCHEMA as EXTERNAL_PLAN_SCHEMA,
+    REPORT_SCHEMA as EXTERNAL_REPORT_SCHEMA,
+    _validate_frozen_plan as _validate_external_plan,
+    _verify_adapter_provenance as _verify_external_adapter_provenance,
+    _verify_frozen_predictions,
+)
+from hermes_skilleval.live_agent_skillsbench import (
+    PLAN_SCHEMA as LIVE_PLAN_SCHEMA,
+    REPORT_SCHEMA as LIVE_REPORT_SCHEMA,
+    _verify_derived_fields as _verify_live_derived_fields,
+    _verify_plan_digest as _verify_live_plan_digest,
+    _verify_plan_inputs as _verify_live_plan_inputs,
+)
+from hermes_skilleval.release_manifest import sha256_file
+
+
+REPORT_SCHEMA = "v0.3.evidence-decision-report.v1"
+ARTIFACT_TYPE = "v0.3-evidence-validity-release-gate"
+VALID_EVIDENCE = "VALID_EVIDENCE"
+INVALID_EVIDENCE = "INVALID_EVIDENCE"
+REVIEW_REQUIRED = "REVIEW_REQUIRED"
+KEEP_BASELINE = "KEEP_BASELINE"
+UNAVAILABLE = "UNAVAILABLE"
+PASS = "PASS"
+FAIL = "FAIL"
+REVIEW = "REVIEW"
+PRESENT = "PRESENT"
+BLOCKING = "blocking"
+REVIEW_SEVERITY = "review"
+INFO = "info"
+SECRET_RE = re.compile(
+    r"(sk-[A-Za-z0-9]{10,}|Bearer\s+[A-Za-z0-9._-]+|api[_-]?key\s*=|password\s*=)",
+    re.IGNORECASE,
+)
+
+
+def write_evidence_decision_report(
+    *,
+    output_path: Path | str,
+    markdown_output_path: Path | str | None = None,
+    external_plan_path: Path | str | None = None,
+    external_report_path: Path | str | None = None,
+    live_plan_path: Path | str | None = None,
+    live_report_path: Path | str | None = None,
+) -> dict[str, Any]:
+    report = build_evidence_decision_report(
+        external_plan_path=external_plan_path,
+        external_report_path=external_report_path,
+        live_plan_path=live_plan_path,
+        live_report_path=live_report_path,
+    )
+    output = Path(output_path)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    if markdown_output_path is not None:
+        markdown = Path(markdown_output_path)
+        markdown.parent.mkdir(parents=True, exist_ok=True)
+        markdown.write_text(render_evidence_markdown(report), encoding="utf-8")
+    return report
+
+
+def build_evidence_decision_report(
+    *,
+    external_plan_path: Path | str | None = None,
+    external_report_path: Path | str | None = None,
+    live_plan_path: Path | str | None = None,
+    live_report_path: Path | str | None = None,
+) -> dict[str, Any]:
+    checks: list[dict[str, Any]] = []
+    field_markers: dict[str, dict[str, Any]] = {}
+    inputs: dict[str, Any] = {}
+
+    external = _evaluate_external(
+        external_plan_path=external_plan_path,
+        external_report_path=external_report_path,
+        checks=checks,
+        field_markers=field_markers,
+        inputs=inputs,
+    )
+    live = _evaluate_live_agent(
+        live_plan_path=live_plan_path,
+        live_report_path=live_report_path,
+        checks=checks,
+        field_markers=field_markers,
+        inputs=inputs,
+    )
+
+    validity_status = _validity_status(checks)
+    promotion = _promotion_gate(validity_status, external)
+    return {
+        "schema_version": REPORT_SCHEMA,
+        "artifact_type": ARTIFACT_TYPE,
+        "generated_at": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+        "inputs": inputs,
+        "field_markers": field_markers,
+        "benchmark_validity_gate": {
+            "status": validity_status,
+            "checks": checks,
+        },
+        "router_promotion_gate": promotion,
+        "external_routing": external,
+        "live_agent": live,
+        "claim_boundaries": {
+            "benchmark_validity_gate_statuses": [
+                VALID_EVIDENCE,
+                INVALID_EVIDENCE,
+                REVIEW_REQUIRED,
+            ],
+            "unavailable_is_field_level_only": True,
+            "promotion_requires_valid_evidence": True,
+            "default_router_promotion_decision": KEEP_BASELINE,
+            "no_new_model_runs": True,
+            "no_training_or_threshold_tuning": True,
+            "deterministic_verifier_is_live_agent_success_source": True,
+        },
+    }
+
+
+def render_evidence_markdown(report: dict[str, Any]) -> str:
+    checks = report["benchmark_validity_gate"]["checks"]
+    failing = [check for check in checks if check["status"] == FAIL]
+    review = [check for check in checks if check["status"] in {REVIEW, UNAVAILABLE}]
+    lines = [
+        "# Hermes SkillEval v0.3 Evidence Gate",
+        "",
+        f"- Benchmark Validity Gate: {report['benchmark_validity_gate']['status']}",
+        f"- Router Promotion Gate: {report['router_promotion_gate']['decision']}",
+        f"- Invalid evidence blocks promotion: {report['router_promotion_gate']['blocked_by_validity']}",
+        f"- Blocking failures: {len(failing)}",
+        f"- Review or unavailable fields: {len(review)}",
+        "",
+        "## Field Markers",
+    ]
+    for field, marker in sorted(report["field_markers"].items()):
+        reason = f" - {marker['reason']}" if marker.get("reason") else ""
+        lines.append(f"- {field}: {marker['status']}{reason}")
+    lines.extend(["", "## Checks"])
+    for check in checks:
+        lines.append(f"- {check['status']} {check['id']}: {check['summary']}")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _evaluate_external(
+    *,
+    external_plan_path: Path | str | None,
+    external_report_path: Path | str | None,
+    checks: list[dict[str, Any]],
+    field_markers: dict[str, dict[str, Any]],
+    inputs: dict[str, Any],
+) -> dict[str, Any]:
+    if external_plan_path is None and external_report_path is None:
+        field_markers["external_routing"] = {
+            "status": UNAVAILABLE,
+            "reason": "external routing plan/report paths were not provided",
+        }
+        _check(
+            checks,
+            "external.available",
+            UNAVAILABLE,
+            REVIEW_SEVERITY,
+            "external routing evidence was not provided",
+        )
+        return {"status": UNAVAILABLE, "reason": field_markers["external_routing"]["reason"]}
+    if external_plan_path is None or external_report_path is None:
+        field_markers["external_routing"] = {
+            "status": UNAVAILABLE,
+            "reason": "both external plan and report paths are required",
+        }
+        _check(
+            checks,
+            "external.available",
+            FAIL,
+            BLOCKING,
+            "external routing evidence is incomplete",
+        )
+        return {"status": UNAVAILABLE, "reason": field_markers["external_routing"]["reason"]}
+
+    plan_path = Path(external_plan_path)
+    report_path = Path(external_report_path)
+    inputs["external_plan"] = _input_record(plan_path)
+    inputs["external_report"] = _input_record(report_path)
+    field_markers["external_routing"] = {"status": PRESENT}
+    plan = _read_json_for_gate(checks, "external.plan_load", plan_path)
+    report = _read_json_for_gate(checks, "external.report_load", report_path)
+
+    _schema_check(checks, "external.plan_schema", plan, EXTERNAL_PLAN_SCHEMA)
+    _schema_check(checks, "external.report_schema", report, EXTERNAL_REPORT_SCHEMA)
+    _call_check(
+        checks,
+        "external.frozen_plan",
+        "external frozen plan is internally valid",
+        lambda: _validate_external_plan(plan),
+    )
+    _call_check(
+        checks,
+        "external.input_hashes",
+        "external frozen data and prediction hashes match the plan",
+        lambda: _verify_external_inputs(plan),
+    )
+    _check_report_plan_path(
+        checks,
+        "external.report_plan_path",
+        report.get("plan_path"),
+        plan_path,
+    )
+    official = report.get("official") if isinstance(report, dict) else None
+    diagnostics = report.get("hermes_diagnostics") if isinstance(report, dict) else None
+    _check(
+        checks,
+        "external.official_metrics_present",
+        PASS if isinstance(official, dict) and bool(official) else FAIL,
+        BLOCKING,
+        "official SkillRouter metrics are present"
+        if isinstance(official, dict) and bool(official)
+        else "official SkillRouter metrics are missing",
+    )
+    _check(
+        checks,
+        "external.hermes_diagnostics_separate",
+        PASS if isinstance(diagnostics, dict) else FAIL,
+        BLOCKING,
+        "Hermes diagnostics are present separately from official metrics"
+        if isinstance(diagnostics, dict)
+        else "Hermes diagnostics are missing",
+    )
+    paired = diagnostics.get("paired_bootstrap_ci", {}) if isinstance(diagnostics, dict) else {}
+    return {
+        "status": PRESENT,
+        "run_id": report.get("run_id"),
+        "official_metric_configs": sorted(official) if isinstance(official, dict) else [],
+        "official_metrics": official if isinstance(official, dict) else {},
+        "hermes_diagnostics_present": isinstance(diagnostics, dict),
+        "paired_bootstrap_keys": sorted(paired) if isinstance(paired, dict) else [],
+        "negative_hit_rate": {
+            "status": UNAVAILABLE,
+            "reason": "explicit negative labels are not present for SkillRouter",
+        },
+        "evaluated_router_configs": _external_router_configs(plan),
+    }
+
+
+def _evaluate_live_agent(
+    *,
+    live_plan_path: Path | str | None,
+    live_report_path: Path | str | None,
+    checks: list[dict[str, Any]],
+    field_markers: dict[str, dict[str, Any]],
+    inputs: dict[str, Any],
+) -> dict[str, Any]:
+    if live_plan_path is None and live_report_path is None:
+        field_markers["live_agent"] = {
+            "status": UNAVAILABLE,
+            "reason": "live-agent plan/report paths were not provided",
+        }
+        _check(
+            checks,
+            "live_agent.available",
+            UNAVAILABLE,
+            REVIEW_SEVERITY,
+            "live-agent evidence was not provided",
+        )
+        return {"status": UNAVAILABLE, "reason": field_markers["live_agent"]["reason"]}
+    if live_plan_path is None or live_report_path is None:
+        field_markers["live_agent"] = {
+            "status": UNAVAILABLE,
+            "reason": "both live-agent plan and report paths are required",
+        }
+        _check(
+            checks,
+            "live_agent.available",
+            FAIL,
+            BLOCKING,
+            "live-agent evidence is incomplete",
+        )
+        return {"status": UNAVAILABLE, "reason": field_markers["live_agent"]["reason"]}
+
+    plan_path = Path(live_plan_path)
+    report_path = Path(live_report_path)
+    inputs["live_plan"] = _input_record(plan_path)
+    digest_path = plan_path.with_name(f"{plan_path.name}.sha256")
+    if digest_path.exists():
+        inputs["live_plan_digest"] = _input_record(digest_path)
+    inputs["live_report"] = _input_record(report_path)
+    field_markers["live_agent"] = {"status": PRESENT}
+
+    _call_check(
+        checks,
+        "live_agent.plan_digest",
+        "SkillsBench plan digest matches its sidecar",
+        lambda: _verify_live_plan_digest(plan_path),
+    )
+    plan = _read_json_for_gate(checks, "live_agent.plan_load", plan_path)
+    report = _read_json_for_gate(checks, "live_agent.report_load", report_path)
+    _schema_check(checks, "live_agent.plan_schema", plan, LIVE_PLAN_SCHEMA)
+    _schema_check(checks, "live_agent.report_schema", report, LIVE_REPORT_SCHEMA)
+    _call_check(
+        checks,
+        "live_agent.input_hashes",
+        "SkillsBench source, router, oracle, and overlap input hashes match the plan",
+        lambda: _verify_live_plan_inputs(plan),
+    )
+    _call_check(
+        checks,
+        "live_agent.derived_hashes",
+        "SkillsBench derived plan fields match frozen source inputs",
+        lambda: _verify_live_derived_fields(plan),
+    )
+    _check_report_plan_path(
+        checks,
+        "live_agent.report_plan_path",
+        report.get("plan_path"),
+        plan_path,
+    )
+    _check_live_matrix_completeness(checks, plan, report)
+    _check_prompt_hash_equality(checks, plan, report)
+    _check_oracle_qualification(checks, plan)
+    _check_verifier_evidence(checks, report)
+    _check_no_skill_leakage(checks, report)
+    _check_trace_completeness(checks, report)
+    _check_overlap_status(checks, report)
+    _check_secret_redaction(checks, report)
+
+    runs = report.get("runs") if isinstance(report, dict) else []
+    run_records = runs if isinstance(runs, list) else []
+    condition_summary = _condition_summary(run_records)
+    no_skill_rate = _success_rate(condition_summary.get("no-skill"))
+    routed_rate = _success_rate(condition_summary.get("routed-skill"))
+    oracle_rate = _success_rate(condition_summary.get("oracle-skill"))
+    timeout_process_errors = _timeout_process_errors(run_records)
+    per_task_regressions = _per_task_regressions(run_records)
+    _check_live_runtime_anomalies(checks, timeout_process_errors)
+    _check_live_task_regressions(checks, per_task_regressions)
+    return {
+        "status": PRESENT,
+        "run_id": report.get("run_id"),
+        "mode": report.get("mode"),
+        "condition_summary": condition_summary,
+        "routed_vs_no_skill_delta": {
+            "task_success_delta": _nullable_delta(routed_rate, no_skill_rate),
+        },
+        "oracle_gap": {
+            "routed_minus_oracle_success_delta": _nullable_delta(routed_rate, oracle_rate),
+        },
+        "timeout_process_errors": timeout_process_errors,
+        "skill_use_evidence": _skill_use_summary(run_records),
+        "per_task_regressions": per_task_regressions,
+        "overlap_report": report.get("overlap_report"),
+        "negative_hit_rate": {
+            "status": UNAVAILABLE,
+            "reason": "explicit negative labels are not present for SkillsBench",
+        },
+    }
+
+
+def _verify_external_inputs(plan: dict[str, Any]) -> None:
+    adapter = SkillRouterAdapter(
+        data_root=plan["data_root"],
+        upstream_ref=plan["adapter_provenance"]["upstream_ref"],
+        license_note=plan["adapter_provenance"]["license_note"],
+        tiers=tuple(plan.get("tiers") or ("easy", "hard")),
+    )
+    _verify_external_adapter_provenance(adapter, plan)
+    _verify_frozen_predictions(plan)
+
+
+def _promotion_gate(validity_status: str, external: dict[str, Any]) -> dict[str, Any]:
+    unavailable = {
+        "status": UNAVAILABLE,
+        "reason": "no preregistered promotion artifact was provided",
+    }
+    return {
+        "decision": KEEP_BASELINE,
+        "blocked_by_validity": validity_status == INVALID_EVIDENCE,
+        "reasons": _promotion_reasons(validity_status),
+        "evaluated_router_configs": external.get("evaluated_router_configs", []),
+        "baseline_router": unavailable,
+        "candidate_router": unavailable,
+    }
+
+
+def _external_router_configs(plan: dict[str, Any]) -> list[dict[str, Any]]:
+    configs = plan.get("frozen_routers") if isinstance(plan, dict) else []
+    if not isinstance(configs, list):
+        return []
+    return [
+        {
+            "config_id": config.get("config_id"),
+            "router_id": config.get("router_id"),
+            "field_view": config.get("field_view"),
+            "version": config.get("version"),
+        }
+        for config in configs
+        if isinstance(config, dict)
+    ]
+
+
+def _schema_check(
+    checks: list[dict[str, Any]],
+    check_id: str,
+    payload: dict[str, Any],
+    expected: str,
+) -> None:
+    actual = payload.get("schema_version") if isinstance(payload, dict) else None
+    _check(
+        checks,
+        check_id,
+        PASS if actual == expected else FAIL,
+        BLOCKING,
+        f"{check_id} matches {expected}"
+        if actual == expected
+        else f"{check_id} expected {expected}, got {actual}",
+        {"expected": expected, "actual": actual},
+    )
+
+
+def _check_report_plan_path(
+    checks: list[dict[str, Any]],
+    check_id: str,
+    actual_path: Any,
+    expected_path: Path,
+) -> None:
+    try:
+        matches = Path(str(actual_path)).resolve() == expected_path.resolve()
+    except OSError:
+        matches = False
+    _check(
+        checks,
+        check_id,
+        PASS if matches else FAIL,
+        BLOCKING,
+        "report points at the validated frozen plan"
+        if matches
+        else "report plan_path does not match the validated plan",
+        {"expected": str(expected_path), "actual": actual_path},
+    )
+
+
+def _check_prompt_hash_equality(
+    checks: list[dict[str, Any]],
+    plan: dict[str, Any],
+    report: dict[str, Any],
+) -> None:
+    plan_mismatches = _prompt_hash_mismatches(plan.get("matrix", []))
+    report_mismatches = _prompt_hash_mismatches(report.get("runs", []))
+    mismatches = sorted(set(plan_mismatches + report_mismatches))
+    _check(
+        checks,
+        "live_agent.prompt_hash_equality",
+        PASS if not mismatches else FAIL,
+        BLOCKING,
+        "all conditions use the same prompt hash per task"
+        if not mismatches
+        else "prompt hash mismatch across live-agent conditions",
+        {"task_ids": mismatches},
+    )
+
+
+def _check_live_matrix_completeness(
+    checks: list[dict[str, Any]],
+    plan: dict[str, Any],
+    report: dict[str, Any],
+) -> None:
+    matrix = plan.get("matrix") if isinstance(plan, dict) else []
+    runs = report.get("runs") if isinstance(report, dict) else []
+    if not isinstance(matrix, list) or not isinstance(runs, list):
+        _check(
+            checks,
+            "live_agent.matrix_completeness",
+            FAIL,
+            BLOCKING,
+            "live-agent matrix or runs are malformed",
+        )
+        return
+
+    expected: dict[str, dict[str, Any]] = {}
+    duplicate_expected = []
+    for entry in matrix:
+        if not isinstance(entry, dict):
+            continue
+        run_id = str(entry.get("run_id"))
+        if run_id in expected:
+            duplicate_expected.append(run_id)
+        expected[run_id] = entry
+
+    actual: dict[str, dict[str, Any]] = {}
+    duplicate_actual = []
+    for run in runs:
+        if not isinstance(run, dict):
+            continue
+        run_id = str(run.get("run_id"))
+        if run_id in actual:
+            duplicate_actual.append(run_id)
+        actual[run_id] = run
+
+    mismatches = []
+    for run_id in sorted(set(expected) & set(actual)):
+        entry = expected[run_id]
+        run = actual[run_id]
+        for field in ("task_id", "condition", "prompt_hash"):
+            if run.get(field) != entry.get(field):
+                mismatches.append(
+                    {
+                        "run_id": run_id,
+                        "field": field,
+                        "expected": entry.get(field),
+                        "actual": run.get(field),
+                    }
+                )
+        if list(run.get("mounted_skill_ids") or []) != list(entry.get("mounted_skill_ids") or []):
+            mismatches.append(
+                {
+                    "run_id": run_id,
+                    "field": "mounted_skill_ids",
+                    "expected": entry.get("mounted_skill_ids"),
+                    "actual": run.get("mounted_skill_ids"),
+                }
+            )
+
+    failures = {
+        "missing_run_ids": sorted(set(expected) - set(actual)),
+        "extra_run_ids": sorted(set(actual) - set(expected)),
+        "duplicate_expected_run_ids": sorted(duplicate_expected),
+        "duplicate_actual_run_ids": sorted(duplicate_actual),
+        "mismatches": mismatches,
+    }
+    is_complete = not any(failures.values())
+    _check(
+        checks,
+        "live_agent.matrix_completeness",
+        PASS if is_complete else FAIL,
+        BLOCKING,
+        "live-agent report contains exactly the frozen matrix runs"
+        if is_complete
+        else "live-agent report does not match the frozen matrix",
+        failures,
+    )
+
+
+def _prompt_hash_mismatches(records: Any) -> list[str]:
+    by_task: dict[str, set[str]] = {}
+    if not isinstance(records, list):
+        return ["<malformed>"]
+    for record in records:
+        if not isinstance(record, dict):
+            return ["<malformed>"]
+        task_id = str(record.get("task_id"))
+        by_task.setdefault(task_id, set()).add(str(record.get("prompt_hash")))
+    return [task_id for task_id, hashes in by_task.items() if len(hashes) > 1]
+
+
+def _check_oracle_qualification(checks: list[dict[str, Any]], plan: dict[str, Any]) -> None:
+    selected = {task.get("task_id") for task in plan.get("selected_tasks", []) if isinstance(task, dict)}
+    qualified = set(plan.get("oracle_qualification_records", {}))
+    missing = sorted(str(task_id) for task_id in selected - qualified)
+    _check(
+        checks,
+        "live_agent.oracle_qualification",
+        PASS if not missing else FAIL,
+        BLOCKING,
+        "oracle qualification exists for every selected live task"
+        if not missing
+        else "selected live tasks are missing oracle qualification",
+        {"missing_task_ids": missing},
+    )
+
+
+def _check_verifier_evidence(checks: list[dict[str, Any]], report: dict[str, Any]) -> None:
+    failures = []
+    for run in _runs(report):
+        verifier = run.get("verifier")
+        if not isinstance(verifier, dict) or not isinstance(verifier.get("passed"), bool):
+            failures.append({"run_id": run.get("run_id"), "reason": "missing verifier.passed"})
+            continue
+        if run.get("task_success") is not verifier.get("passed"):
+            failures.append(
+                {"run_id": run.get("run_id"), "reason": "task_success differs from verifier.passed"}
+            )
+        if run.get("verifier_passed") is not verifier.get("passed"):
+            failures.append(
+                {
+                    "run_id": run.get("run_id"),
+                    "reason": "verifier_passed differs from verifier.passed",
+                }
+            )
+    source_ok = report.get("summary", {}).get("task_success_source") == "verifier_pass_fail"
+    if not source_ok:
+        failures.append({"run_id": "<summary>", "reason": "task success source is not verifier"})
+    _check(
+        checks,
+        "live_agent.verifier_evidence",
+        PASS if not failures else FAIL,
+        BLOCKING,
+        "deterministic verifier records are complete and source task success"
+        if not failures
+        else "verifier evidence is incomplete or not the success source",
+        {"failures": failures},
+    )
+
+
+def _check_no_skill_leakage(checks: list[dict[str, Any]], report: dict[str, Any]) -> None:
+    failures = []
+    for run in _runs(report):
+        if run.get("condition") != "no-skill":
+            continue
+        if run.get("mounted_skill_count") != 0 or run.get("mounted_skill_ids"):
+            failures.append({"run_id": run.get("run_id"), "reason": "benchmark skills mounted"})
+        for skill_id, evidence in (run.get("skill_use") or {}).items():
+            state = evidence.get("state") if isinstance(evidence, dict) else None
+            if state in {"MOUNTED_ONLY", "READ"}:
+                failures.append(
+                    {
+                        "run_id": run.get("run_id"),
+                        "skill_id": skill_id,
+                        "reason": f"no-skill evidence state {state}",
+                    }
+                )
+    _check(
+        checks,
+        "live_agent.no_skill_leakage",
+        PASS if not failures else FAIL,
+        BLOCKING,
+        "no-skill condition mounted no benchmark skills"
+        if not failures
+        else "no-skill condition shows benchmark skill leakage",
+        {"failures": failures},
+    )
+
+
+def _check_trace_completeness(checks: list[dict[str, Any]], report: dict[str, Any]) -> None:
+    failures = []
+    for run in _runs(report):
+        trace_path = Path(str(run.get("trace_path")))
+        if not trace_path.exists():
+            failures.append({"run_id": run.get("run_id"), "reason": "trace file is missing"})
+            continue
+        try:
+            trace = _read_json(trace_path)
+        except (OSError, json.JSONDecodeError, ValueError) as exc:
+            failures.append({"run_id": run.get("run_id"), "reason": str(exc)})
+            continue
+        required = {"schema_version", "request", "result", "mounted_skills", "skill_use", "events"}
+        missing = sorted(required - set(trace))
+        if trace.get("schema_version") != "live-agent.v1" or missing:
+            failures.append(
+                {
+                    "run_id": run.get("run_id"),
+                    "reason": "trace schema or required fields are incomplete",
+                    "missing": missing,
+                }
+            )
+            continue
+        failures.extend(_trace_report_mismatches(run, trace))
+    _check(
+        checks,
+        "live_agent.trace_completeness",
+        PASS if not failures else FAIL,
+        BLOCKING,
+        "all live-agent runs have complete trace files"
+        if not failures
+        else "live-agent trace files are missing, incomplete, or inconsistent with report rows",
+        {"failures": failures},
+    )
+
+
+def _trace_report_mismatches(run: dict[str, Any], trace: dict[str, Any]) -> list[dict[str, Any]]:
+    result = trace.get("result") if isinstance(trace.get("result"), dict) else {}
+    verifier = result.get("verifier") if isinstance(result.get("verifier"), dict) else {}
+    comparisons = {
+        "process_exit_code": (run.get("process_exit_code"), result.get("process_exit_code")),
+        "timed_out": (run.get("timed_out"), result.get("timed_out")),
+        "task_success": (run.get("task_success"), result.get("task_success")),
+        "verifier.passed": (run.get("verifier_passed"), verifier.get("passed")),
+    }
+    failures = [
+        {
+            "run_id": run.get("run_id"),
+            "reason": "trace/report field mismatch",
+            "field": field,
+            "report": report_value,
+            "trace": trace_value,
+        }
+        for field, (report_value, trace_value) in comparisons.items()
+        if report_value != trace_value
+    ]
+    trace_skill_ids = [
+        record.get("skill_id")
+        for record in trace.get("mounted_skills", [])
+        if isinstance(record, dict)
+    ]
+    if list(run.get("mounted_skill_ids") or []) != trace_skill_ids:
+        failures.append(
+            {
+                "run_id": run.get("run_id"),
+                "reason": "trace/report mounted_skill_ids mismatch",
+                "report": run.get("mounted_skill_ids"),
+                "trace": trace_skill_ids,
+            }
+        )
+    if _canonical_json(run.get("skill_use") or {}) != _canonical_json(trace.get("skill_use") or {}):
+        failures.append(
+            {
+                "run_id": run.get("run_id"),
+                "reason": "trace/report skill_use mismatch",
+            }
+        )
+    return failures
+
+
+def _check_overlap_status(checks: list[dict[str, Any]], report: dict[str, Any]) -> None:
+    overlap = report.get("overlap_report")
+    decision = overlap.get("decision") if isinstance(overlap, dict) else None
+    if decision == "INVALID":
+        status = FAIL
+        severity = BLOCKING
+        summary = "overlap report is invalid"
+    elif decision in {"LINKED_TRANSFER", "UNAVAILABLE"}:
+        status = REVIEW
+        severity = REVIEW_SEVERITY
+        summary = "overlap report requires caveated generalization claims"
+    elif decision == "DISJOINT":
+        status = PASS
+        severity = INFO
+        summary = "overlap report supports independent generalization framing"
+    else:
+        status = FAIL
+        severity = BLOCKING
+        summary = "overlap report decision is missing or unsupported"
+    _check(
+        checks,
+        "live_agent.overlap_status",
+        status,
+        severity,
+        summary,
+        {"decision": decision},
+    )
+
+
+def _check_secret_redaction(checks: list[dict[str, Any]], report: dict[str, Any]) -> None:
+    leaks = []
+    if SECRET_RE.search(json.dumps(report, sort_keys=True, default=str)):
+        leaks.append({"artifact": "live_report"})
+    for run in _runs(report):
+        trace_path = Path(str(run.get("trace_path")))
+        if not trace_path.exists():
+            continue
+        text = trace_path.read_text(encoding="utf-8")
+        if SECRET_RE.search(text):
+            leaks.append({"artifact": "trace", "run_id": run.get("run_id")})
+    _check(
+        checks,
+        "live_agent.secret_redaction",
+        PASS if not leaks else FAIL,
+        BLOCKING,
+        "live-agent report and traces do not contain obvious secret tokens"
+        if not leaks
+        else "live-agent report or traces contain secret-like strings",
+        {"leaks": leaks},
+    )
+
+
+def _check_live_runtime_anomalies(
+    checks: list[dict[str, Any]],
+    anomalies: list[dict[str, Any]],
+) -> None:
+    _check(
+        checks,
+        "live_agent.timeout_process_errors",
+        REVIEW if anomalies else PASS,
+        REVIEW_SEVERITY if anomalies else INFO,
+        "live-agent timeout or process errors require review"
+        if anomalies
+        else "no live-agent timeout or process errors were reported",
+        {"errors": anomalies},
+    )
+
+
+def _check_live_task_regressions(
+    checks: list[dict[str, Any]],
+    regressions: list[dict[str, Any]],
+) -> None:
+    _check(
+        checks,
+        "live_agent.per_task_regressions",
+        REVIEW if regressions else PASS,
+        REVIEW_SEVERITY if regressions else INFO,
+        "routed-skill regressions versus no-skill require review"
+        if regressions
+        else "no routed-skill per-task regressions versus no-skill were reported",
+        {"regressions": regressions},
+    )
+
+
+def _condition_summary(runs: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    summary: dict[str, dict[str, Any]] = {}
+    for condition in ("no-skill", "routed-skill", "oracle-skill"):
+        selected = [run for run in runs if run.get("condition") == condition]
+        summary[condition] = {
+            "run_count": len(selected),
+            "verifier_pass_count": sum(1 for run in selected if run.get("verifier_passed") is True),
+            "task_success_count": sum(1 for run in selected if run.get("task_success") is True),
+            "timeout_count": sum(1 for run in selected if run.get("timed_out") is True),
+            "process_error_count": sum(
+                1
+                for run in selected
+                if run.get("process_exit_code") not in (0, None)
+            ),
+        }
+    return summary
+
+
+def _success_rate(summary: dict[str, Any] | None) -> float | None:
+    if not summary or not summary.get("run_count"):
+        return None
+    return float(summary["task_success_count"]) / float(summary["run_count"])
+
+
+def _nullable_delta(left: float | None, right: float | None) -> float | None:
+    if left is None or right is None:
+        return None
+    return left - right
+
+
+def _timeout_process_errors(runs: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [
+        {
+            "run_id": run.get("run_id"),
+            "task_id": run.get("task_id"),
+            "condition": run.get("condition"),
+            "timed_out": run.get("timed_out"),
+            "process_exit_code": run.get("process_exit_code"),
+        }
+        for run in runs
+        if run.get("timed_out") or run.get("process_exit_code") not in (0, None)
+    ]
+
+
+def _skill_use_summary(runs: list[dict[str, Any]]) -> dict[str, int]:
+    counts = {"MOUNTED": 0, "READ": 0, "UNKNOWN": 0, "DECLARED": 0}
+    for run in runs:
+        for evidence in (run.get("skill_use") or {}).values():
+            if isinstance(evidence, dict):
+                state = str(evidence.get("state"))
+                counts[state] = counts.get(state, 0) + 1
+    return counts
+
+
+def _per_task_regressions(runs: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    by_task: dict[str, dict[str, bool]] = {}
+    for run in runs:
+        by_task.setdefault(str(run.get("task_id")), {})[str(run.get("condition"))] = bool(
+            run.get("task_success")
+        )
+    regressions = []
+    for task_id, outcomes in sorted(by_task.items()):
+        if outcomes.get("no-skill") is True and outcomes.get("routed-skill") is False:
+            regressions.append(
+                {
+                    "task_id": task_id,
+                    "no_skill_success": True,
+                    "routed_skill_success": False,
+                }
+            )
+    return regressions
+
+
+def _validity_status(checks: list[dict[str, Any]]) -> str:
+    if any(check["status"] == FAIL and check["severity"] == BLOCKING for check in checks):
+        return INVALID_EVIDENCE
+    if any(check["status"] in {REVIEW, UNAVAILABLE} for check in checks):
+        return REVIEW_REQUIRED
+    return VALID_EVIDENCE
+
+
+def _promotion_reasons(validity_status: str) -> list[str]:
+    if validity_status == INVALID_EVIDENCE:
+        return ["invalid benchmark evidence blocks promotion"]
+    if validity_status == REVIEW_REQUIRED:
+        return ["benchmark evidence requires review; promotion defaults to baseline"]
+    return ["no preregistered promotion artifact was provided; defaulting to baseline"]
+
+
+def _runs(report: dict[str, Any]) -> list[dict[str, Any]]:
+    runs = report.get("runs") if isinstance(report, dict) else []
+    return [run for run in runs if isinstance(run, dict)] if isinstance(runs, list) else []
+
+
+def _call_check(
+    checks: list[dict[str, Any]],
+    check_id: str,
+    pass_summary: str,
+    callback: Any,
+) -> None:
+    try:
+        callback()
+    except Exception as exc:  # noqa: BLE001 - gate must preserve failure details.
+        _check(
+            checks,
+            check_id,
+            FAIL,
+            BLOCKING,
+            str(exc),
+            {"exception_type": exc.__class__.__name__},
+        )
+    else:
+        _check(checks, check_id, PASS, INFO, pass_summary)
+
+
+def _check(
+    checks: list[dict[str, Any]],
+    check_id: str,
+    status: str,
+    severity: str,
+    summary: str,
+    details: dict[str, Any] | None = None,
+) -> None:
+    checks.append(
+        {
+            "id": check_id,
+            "status": status,
+            "severity": severity,
+            "summary": summary,
+            "details": details or {},
+        }
+    )
+
+
+def _input_record(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {"path": str(path), "exists": False}
+    return {
+        "path": str(path),
+        "exists": True,
+        "size_bytes": path.stat().st_size,
+        "sha256": sha256_file(path),
+    }
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return payload
+
+
+def _read_json_for_gate(
+    checks: list[dict[str, Any]],
+    check_id: str,
+    path: Path,
+) -> dict[str, Any]:
+    try:
+        payload = _read_json(path)
+    except Exception as exc:  # noqa: BLE001 - missing/malformed inputs become gate checks.
+        _check(
+            checks,
+            check_id,
+            FAIL,
+            BLOCKING,
+            f"could not load JSON artifact: {exc}",
+            {"path": str(path), "exception_type": exc.__class__.__name__},
+        )
+        return {}
+    _check(checks, check_id, PASS, INFO, "JSON artifact loaded", {"path": str(path)})
+    return payload
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), default=str)

--- a/src/hermes_skilleval/evidence_gate.py
+++ b/src/hermes_skilleval/evidence_gate.py
@@ -792,7 +792,11 @@ def _check_global_capability_inventory(
     for source, inventory in inventories:
         failures.extend(_capability_inventory_failures(source, inventory))
         reviews.extend(_capability_inventory_reviews(source, inventory))
-    if failures:
+    if not inventories:
+        status = REVIEW
+        severity = REVIEW_SEVERITY
+        summary = "global capability inventory is missing"
+    elif failures:
         status = FAIL
         severity = BLOCKING
         summary = "global capability inventory shows skill leakage"

--- a/tests/test_v0_3_evidence_gate.py
+++ b/tests/test_v0_3_evidence_gate.py
@@ -403,6 +403,37 @@ def test_evidence_gate_inherit_mode_is_not_valid_final_evidence(tmp_path):
     assert _check_by_id(report, "live_agent.global_capability_inventory")["status"] == "REVIEW"
 
 
+def test_evidence_gate_missing_global_capability_inventory_requires_review(tmp_path):
+    external_plan, external_report = _write_external_artifacts(tmp_path)
+    live_plan, live_report = _write_live_artifacts(tmp_path, disjoint_overlap=True)
+    _strip_capability_inventory_surfaces(live_report)
+    output = tmp_path / "evidence.json"
+
+    exit_code = main(
+        [
+            "v0.3-evidence-gate",
+            "--output",
+            str(output),
+            "--external-plan",
+            str(external_plan),
+            "--external-report",
+            str(external_report),
+            "--live-plan",
+            str(live_plan),
+            "--live-report",
+            str(live_report),
+        ]
+    )
+
+    assert exit_code == 0
+    report = json.loads(output.read_text(encoding="utf-8"))
+    assert report["benchmark_validity_gate"]["status"] == "REVIEW_REQUIRED"
+    check = _check_by_id(report, "live_agent.global_capability_inventory")
+    assert check["status"] == "REVIEW"
+    assert check["details"]["inventory_count"] == 0
+    assert "missing" in check["summary"]
+
+
 def test_evidence_gate_missing_frozen_live_run_is_invalid(tmp_path):
     external_plan, external_report = _write_external_artifacts(tmp_path)
     live_plan, live_report = _write_live_artifacts(tmp_path, disjoint_overlap=True)
@@ -695,6 +726,7 @@ def _write_live_artifacts(
         runner=FakeAgentRunner(exit_code=0, events=[{"type": "final", "message": "ok"}]),
         verifier=FakeVerifier(pass_=True, details={"reason": "fixture pass"}),
     )
+    _append_preflight_to_first_trace(report_path, _preflight_inventory())
     return plan_path, report_path
 
 
@@ -723,6 +755,33 @@ def _append_preflight_to_first_trace(live_report: Path, preflight: dict[str, obj
     trace = json.loads(trace_path.read_text(encoding="utf-8"))
     trace.setdefault("events", []).insert(0, preflight)
     _write_json(trace_path, trace)
+
+
+def _strip_capability_inventory_surfaces(live_report: Path) -> None:
+    payload = json.loads(live_report.read_text(encoding="utf-8"))
+    payload.pop("global_capability_inventory", None)
+    payload.pop("skill_inventory", None)
+    payload.pop("preflight", None)
+    for run in payload["runs"]:
+        trace_path = Path(run["trace_path"])
+        trace = json.loads(trace_path.read_text(encoding="utf-8"))
+        trace["events"] = [
+            _event_without_capability_inventory(event)
+            for event in trace.get("events", [])
+            if not (isinstance(event, dict) and event.get("type") == "preflight")
+        ]
+        _write_json(trace_path, trace)
+    _write_json(live_report, payload)
+
+
+def _event_without_capability_inventory(event: object) -> object:
+    if not isinstance(event, dict):
+        return event
+    event = dict(event)
+    event.pop("global_capability_inventory", None)
+    event.pop("skill_inventory", None)
+    event.pop("preflight", None)
+    return event
 
 
 def _preflight_inventory(

--- a/tests/test_v0_3_evidence_gate.py
+++ b/tests/test_v0_3_evidence_gate.py
@@ -12,9 +12,11 @@ from hermes_skilleval.external.skillrouter_matrix import (
 )
 from hermes_skilleval.live_agent_runtime import FakeAgentRunner, FakeVerifier
 from hermes_skilleval.live_agent_skillsbench import (
+    _derived_hashes,
     run_skillsbench_matrix,
     write_skillsbench_plan,
 )
+from hermes_skilleval.release_manifest import sha256_file
 
 
 SKILLROUTER_FIXTURE = Path("tests/fixtures/external/skillrouter_eval_core_tiny")
@@ -93,6 +95,84 @@ def test_evidence_gate_promotion_uses_evaluated_configs_not_hardcoded_names(tmp_
     assert "finetuned-embedding" not in json.dumps(report["router_promotion_gate"])
 
 
+def test_evidence_gate_fails_when_external_report_missing_frozen_configs(tmp_path):
+    routers = [
+        {
+            "router_id": "fixture-router-a",
+            "field_view": "name_only",
+            "predictions_path": str(SKILLROUTER_PREDICTIONS),
+            "version": "fixture",
+        },
+        {
+            "router_id": "fixture-router-b",
+            "field_view": "metadata",
+            "predictions_path": str(SKILLROUTER_PREDICTIONS),
+            "version": "fixture",
+        },
+        {
+            "router_id": "fixture-router-c",
+            "field_view": "full_body",
+            "predictions_path": str(SKILLROUTER_PREDICTIONS),
+            "version": "fixture",
+        },
+    ]
+    external_plan, external_report = _write_external_artifacts(tmp_path, routers=routers)
+    live_plan, live_report = _write_live_artifacts(tmp_path, disjoint_overlap=True)
+    payload = json.loads(external_report.read_text(encoding="utf-8"))
+    first_config = sorted(payload["official"])[0]
+    payload["official"] = {first_config: payload["official"][first_config]}
+    external_report.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    report = write_evidence_decision_report(
+        output_path=tmp_path / "evidence.json",
+        external_plan_path=external_plan,
+        external_report_path=external_report,
+        live_plan_path=live_plan,
+        live_report_path=live_report,
+    )
+
+    assert report["benchmark_validity_gate"]["status"] == "INVALID_EVIDENCE"
+    check = _check_by_id(report, "external.report_completeness")
+    assert check["status"] == "FAIL"
+    assert check["details"]["missing_config_ids"]
+
+
+def test_evidence_gate_fails_when_external_report_has_unknown_config(tmp_path):
+    external_plan, external_report = _write_external_artifacts(tmp_path)
+    live_plan, live_report = _write_live_artifacts(tmp_path, disjoint_overlap=True)
+    payload = json.loads(external_report.read_text(encoding="utf-8"))
+    payload["official"]["unknown-config"] = next(iter(payload["official"].values()))
+    external_report.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    report = write_evidence_decision_report(
+        output_path=tmp_path / "evidence.json",
+        external_plan_path=external_plan,
+        external_report_path=external_report,
+        live_plan_path=live_plan,
+        live_report_path=live_report,
+    )
+
+    assert report["benchmark_validity_gate"]["status"] == "INVALID_EVIDENCE"
+    check = _check_by_id(report, "external.report_completeness")
+    assert check["status"] == "FAIL"
+    assert check["details"]["unexpected_config_ids"] == ["unknown-config"]
+
+
+def test_evidence_gate_passes_when_external_report_covers_all_configs(tmp_path):
+    external_plan, external_report = _write_external_artifacts(tmp_path)
+    live_plan, live_report = _write_live_artifacts(tmp_path, disjoint_overlap=True)
+
+    report = write_evidence_decision_report(
+        output_path=tmp_path / "evidence.json",
+        external_plan_path=external_plan,
+        external_report_path=external_report,
+        live_plan_path=live_plan,
+        live_report_path=live_report,
+    )
+
+    assert _check_by_id(report, "external.report_completeness")["status"] == "PASS"
+
+
 def test_evidence_gate_missing_live_agent_is_review_required_field_unavailable(tmp_path):
     external_plan, external_report = _write_external_artifacts(tmp_path)
 
@@ -152,6 +232,70 @@ def test_evidence_gate_invalid_live_plan_digest_blocks_promotion(tmp_path):
     )
 
 
+def test_evidence_gate_fails_when_oracle_record_present_but_failed(tmp_path):
+    external_plan, external_report = _write_external_artifacts(tmp_path)
+    live_plan, live_report = _write_live_artifacts(tmp_path, disjoint_overlap=True)
+    plan = json.loads(live_plan.read_text(encoding="utf-8"))
+    plan["oracle_qualification_records"]["sb-task-login"]["verifier_passed"] = False
+    _write_json(live_plan, plan)
+
+    report = write_evidence_decision_report(
+        output_path=tmp_path / "evidence.json",
+        external_plan_path=external_plan,
+        external_report_path=external_report,
+        live_plan_path=live_plan,
+        live_report_path=live_report,
+    )
+
+    assert report["benchmark_validity_gate"]["status"] == "INVALID_EVIDENCE"
+    check = _check_by_id(report, "live_agent.oracle_qualification")
+    assert check["status"] == "FAIL"
+    assert any("did not pass" in failure["reason"] for failure in check["details"]["failures"])
+
+
+def test_evidence_gate_fails_when_oracle_pass_rate_below_one(tmp_path):
+    external_plan, external_report = _write_external_artifacts(tmp_path)
+    live_plan, live_report = _write_live_artifacts(tmp_path, disjoint_overlap=True)
+    plan = json.loads(live_plan.read_text(encoding="utf-8"))
+    plan["oracle_qualification_records"]["sb-task-login"]["pass_rate"] = 0.5
+    _write_json(live_plan, plan)
+
+    report = write_evidence_decision_report(
+        output_path=tmp_path / "evidence.json",
+        external_plan_path=external_plan,
+        external_report_path=external_report,
+        live_plan_path=live_plan,
+        live_report_path=live_report,
+    )
+
+    assert report["benchmark_validity_gate"]["status"] == "INVALID_EVIDENCE"
+    check = _check_by_id(report, "live_agent.oracle_qualification")
+    assert check["status"] == "FAIL"
+    assert any("pass_rate" in failure["reason"] for failure in check["details"]["failures"])
+
+
+def test_evidence_gate_passes_when_oracle_records_are_qualified(tmp_path):
+    external_plan, external_report = _write_external_artifacts(tmp_path)
+    live_plan, live_report = _write_live_artifacts(tmp_path, disjoint_overlap=True)
+    plan = json.loads(live_plan.read_text(encoding="utf-8"))
+    record = plan["oracle_qualification_records"]["sb-task-login"]
+    record["pass_rate"] = 1.0
+    record["passes"] = 3
+    record["trials"] = 3
+    record["verifier_stable"] = True
+    _write_json(live_plan, plan, update_digest=True)
+
+    report = write_evidence_decision_report(
+        output_path=tmp_path / "evidence.json",
+        external_plan_path=external_plan,
+        external_report_path=external_report,
+        live_plan_path=live_plan,
+        live_report_path=live_report,
+    )
+
+    assert _check_by_id(report, "live_agent.oracle_qualification")["status"] == "PASS"
+
+
 def test_evidence_gate_detects_no_skill_leakage_and_trace_loss(tmp_path):
     external_plan, external_report = _write_external_artifacts(tmp_path)
     live_plan, live_report = _write_live_artifacts(tmp_path, disjoint_overlap=True)
@@ -202,6 +346,63 @@ def test_evidence_gate_detects_mounted_only_no_skill_leakage(tmp_path):
     )
 
 
+def test_evidence_gate_fails_on_user_global_skill_inventory_leakage(tmp_path):
+    external_plan, external_report = _write_external_artifacts(tmp_path)
+    live_plan, live_report = _write_live_artifacts(tmp_path, disjoint_overlap=True)
+    _append_preflight_to_first_trace(
+        live_report,
+        _preflight_inventory(user_entries=1),
+    )
+
+    report = write_evidence_decision_report(
+        output_path=tmp_path / "evidence.json",
+        external_plan_path=external_plan,
+        external_report_path=external_report,
+        live_plan_path=live_plan,
+        live_report_path=live_report,
+    )
+
+    assert report["benchmark_validity_gate"]["status"] == "INVALID_EVIDENCE"
+    assert _check_by_id(report, "live_agent.global_capability_inventory")["status"] == "FAIL"
+
+
+def test_evidence_gate_passes_with_clean_isolated_capability_inventory(tmp_path):
+    external_plan, external_report = _write_external_artifacts(tmp_path)
+    live_plan, live_report = _write_live_artifacts(tmp_path, disjoint_overlap=True)
+    _append_preflight_to_first_trace(live_report, _preflight_inventory())
+
+    report = write_evidence_decision_report(
+        output_path=tmp_path / "evidence.json",
+        external_plan_path=external_plan,
+        external_report_path=external_report,
+        live_plan_path=live_plan,
+        live_report_path=live_report,
+    )
+
+    assert _check_by_id(report, "live_agent.global_capability_inventory")["status"] == "PASS"
+    assert report["benchmark_validity_gate"]["status"] == "VALID_EVIDENCE"
+
+
+def test_evidence_gate_inherit_mode_is_not_valid_final_evidence(tmp_path):
+    external_plan, external_report = _write_external_artifacts(tmp_path)
+    live_plan, live_report = _write_live_artifacts(tmp_path, disjoint_overlap=True)
+    _append_preflight_to_first_trace(
+        live_report,
+        _preflight_inventory(codex_home_mode="inherit", evidence_mode="smoke-only"),
+    )
+
+    report = write_evidence_decision_report(
+        output_path=tmp_path / "evidence.json",
+        external_plan_path=external_plan,
+        external_report_path=external_report,
+        live_plan_path=live_plan,
+        live_report_path=live_report,
+    )
+
+    assert report["benchmark_validity_gate"]["status"] == "REVIEW_REQUIRED"
+    assert _check_by_id(report, "live_agent.global_capability_inventory")["status"] == "REVIEW"
+
+
 def test_evidence_gate_missing_frozen_live_run_is_invalid(tmp_path):
     external_plan, external_report = _write_external_artifacts(tmp_path)
     live_plan, live_report = _write_live_artifacts(tmp_path, disjoint_overlap=True)
@@ -246,6 +447,48 @@ def test_evidence_gate_linked_transfer_requires_review_not_independent_claim(tmp
         check["id"] == "live_agent.overlap_status" and check["status"] == "REVIEW"
         for check in report["benchmark_validity_gate"]["checks"]
     )
+
+
+def test_evidence_gate_fails_linked_transfer_with_independent_claim(tmp_path):
+    external_plan, external_report = _write_external_artifacts(tmp_path)
+    live_plan, live_report = _write_live_artifacts(tmp_path, disjoint_overlap=False)
+    payload = json.loads(live_report.read_text(encoding="utf-8"))
+    payload["overlap_report"]["independent_generalization_claim"] = True
+    _write_json(live_report, payload)
+
+    report = write_evidence_decision_report(
+        output_path=tmp_path / "evidence.json",
+        external_plan_path=external_plan,
+        external_report_path=external_report,
+        live_plan_path=live_plan,
+        live_report_path=live_report,
+    )
+
+    assert report["benchmark_validity_gate"]["status"] == "INVALID_EVIDENCE"
+    assert _check_by_id(report, "live_agent.overlap_status")["status"] == "FAIL"
+
+
+def test_evidence_gate_fails_unavailable_overlap_with_independent_claim(tmp_path):
+    external_plan, external_report = _write_external_artifacts(tmp_path)
+    live_plan, live_report = _write_live_artifacts(tmp_path, disjoint_overlap=True)
+    payload = json.loads(live_report.read_text(encoding="utf-8"))
+    payload["overlap_report"] = {
+        "decision": "UNAVAILABLE",
+        "independent_generalization_claim": True,
+        "reason": "missing SkillRouter input",
+    }
+    _write_json(live_report, payload)
+
+    report = write_evidence_decision_report(
+        output_path=tmp_path / "evidence.json",
+        external_plan_path=external_plan,
+        external_report_path=external_report,
+        live_plan_path=live_plan,
+        live_report_path=live_report,
+    )
+
+    assert report["benchmark_validity_gate"]["status"] == "INVALID_EVIDENCE"
+    assert _check_by_id(report, "live_agent.overlap_status")["status"] == "FAIL"
 
 
 def test_evidence_gate_verifier_conflict_is_invalid_and_regression_is_reported(tmp_path):
@@ -453,3 +696,63 @@ def _write_live_artifacts(
         verifier=FakeVerifier(pass_=True, details={"reason": "fixture pass"}),
     )
     return plan_path, report_path
+
+
+def _check_by_id(report: dict[str, object], check_id: str) -> dict[str, object]:
+    return next(
+        check
+        for check in report["benchmark_validity_gate"]["checks"]
+        if check["id"] == check_id
+    )
+
+
+def _write_json(path: Path, payload: dict[str, object], *, update_digest: bool = False) -> None:
+    if update_digest and "derived_hashes" in payload:
+        payload["derived_hashes"] = _derived_hashes(payload)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    if update_digest:
+        path.with_name(f"{path.name}.sha256").write_text(
+            f"{sha256_file(path)}  {path.name}\n",
+            encoding="utf-8",
+        )
+
+
+def _append_preflight_to_first_trace(live_report: Path, preflight: dict[str, object]) -> None:
+    payload = json.loads(live_report.read_text(encoding="utf-8"))
+    trace_path = Path(payload["runs"][0]["trace_path"])
+    trace = json.loads(trace_path.read_text(encoding="utf-8"))
+    trace.setdefault("events", []).insert(0, preflight)
+    _write_json(trace_path, trace)
+
+
+def _preflight_inventory(
+    *,
+    user_entries: int = 0,
+    codex_home_mode: str = "isolated",
+    evidence_mode: str = "final-evidence",
+) -> dict[str, object]:
+    return {
+        "type": "preflight",
+        "codex_home_mode": codex_home_mode,
+        "evidence_mode": evidence_mode,
+        "global_capability_inventory": {
+            "home_isolated": codex_home_mode == "isolated",
+            "user_skill_dir": {
+                "status": "ISOLATED_HOME" if codex_home_mode == "isolated" else "SMOKE_ONLY",
+                "entry_count": user_entries,
+            },
+            "admin_skill_dirs": [
+                {
+                    "status": "ABSENT",
+                    "entry_count": 0,
+                }
+            ],
+            "workspace_skill_dirs": {
+                "workspace_status": "CLEAR",
+                "mounted_entry_count": 0,
+                "parent_skill_dirs_checked": 3,
+                "empty_parent_skill_dirs": 0,
+            },
+            "bundled_skills": {"status": "SYSTEM_MANAGED_UNKNOWN"},
+        },
+    }

--- a/tests/test_v0_3_evidence_gate.py
+++ b/tests/test_v0_3_evidence_gate.py
@@ -1,0 +1,455 @@
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+from hermes_skilleval.cli import main
+from hermes_skilleval.evidence_gate import write_evidence_decision_report
+from hermes_skilleval.external.skillrouter_matrix import (
+    run_skillrouter_matrix,
+    write_skillrouter_matrix_plan,
+)
+from hermes_skilleval.live_agent_runtime import FakeAgentRunner, FakeVerifier
+from hermes_skilleval.live_agent_skillsbench import (
+    run_skillsbench_matrix,
+    write_skillsbench_plan,
+)
+
+
+SKILLROUTER_FIXTURE = Path("tests/fixtures/external/skillrouter_eval_core_tiny")
+SKILLROUTER_PREDICTIONS = SKILLROUTER_FIXTURE / "predictions.json"
+SKILLSBENCH_FIXTURE = Path("tests/fixtures/live_agent/skillsbench_tiny")
+UPSTREAM_SHA = "b" * 40
+
+
+def test_evidence_gate_validates_full_packet_and_keeps_baseline(tmp_path):
+    external_plan, external_report = _write_external_artifacts(tmp_path)
+    live_plan, live_report = _write_live_artifacts(tmp_path, disjoint_overlap=True)
+
+    report = write_evidence_decision_report(
+        output_path=tmp_path / "evidence.json",
+        markdown_output_path=tmp_path / "evidence.md",
+        external_plan_path=external_plan,
+        external_report_path=external_report,
+        live_plan_path=live_plan,
+        live_report_path=live_report,
+    )
+
+    assert report["schema_version"] == "v0.3.evidence-decision-report.v1"
+    assert report["benchmark_validity_gate"]["status"] == "VALID_EVIDENCE"
+    assert report["router_promotion_gate"]["decision"] == "KEEP_BASELINE"
+    assert report["router_promotion_gate"]["blocked_by_validity"] is False
+    assert report["router_promotion_gate"]["baseline_router"]["status"] == "UNAVAILABLE"
+    assert report["router_promotion_gate"]["candidate_router"]["status"] == "UNAVAILABLE"
+    assert report["field_markers"]["external_routing"]["status"] == "PRESENT"
+    assert report["field_markers"]["live_agent"]["status"] == "PRESENT"
+    assert "UNAVAILABLE" not in {
+        report["benchmark_validity_gate"]["status"],
+        report["router_promotion_gate"]["decision"],
+    }
+    assert report["external_routing"]["official_metric_configs"]
+    assert report["external_routing"]["hermes_diagnostics_present"] is True
+    assert report["live_agent"]["condition_summary"]["oracle-skill"]["run_count"] == 1
+    assert report["live_agent"]["routed_vs_no_skill_delta"]["task_success_delta"] == 0.0
+    assert report["live_agent"]["oracle_gap"]["routed_minus_oracle_success_delta"] == 0.0
+    assert (tmp_path / "evidence.md").is_file()
+
+
+def test_evidence_gate_promotion_uses_evaluated_configs_not_hardcoded_names(tmp_path):
+    external_plan, external_report = _write_external_artifacts(
+        tmp_path,
+        routers=[
+            {
+                "router_id": "fixture-router-a",
+                "field_view": "name_only",
+                "predictions_path": str(SKILLROUTER_PREDICTIONS),
+                "version": "fixture",
+            },
+            {
+                "router_id": "fixture-router-b",
+                "field_view": "full_body",
+                "predictions_path": str(SKILLROUTER_PREDICTIONS),
+                "version": "fixture",
+            },
+        ],
+    )
+    live_plan, live_report = _write_live_artifacts(tmp_path, disjoint_overlap=True)
+
+    report = write_evidence_decision_report(
+        output_path=tmp_path / "evidence.json",
+        external_plan_path=external_plan,
+        external_report_path=external_report,
+        live_plan_path=live_plan,
+        live_report_path=live_report,
+    )
+
+    evaluated = report["router_promotion_gate"]["evaluated_router_configs"]
+    assert [config["router_id"] for config in evaluated] == [
+        "fixture-router-a",
+        "fixture-router-b",
+    ]
+    assert "baseline-minilm" not in json.dumps(report["router_promotion_gate"])
+    assert "finetuned-embedding" not in json.dumps(report["router_promotion_gate"])
+
+
+def test_evidence_gate_missing_live_agent_is_review_required_field_unavailable(tmp_path):
+    external_plan, external_report = _write_external_artifacts(tmp_path)
+
+    report = write_evidence_decision_report(
+        output_path=tmp_path / "evidence.json",
+        external_plan_path=external_plan,
+        external_report_path=external_report,
+    )
+
+    assert report["benchmark_validity_gate"]["status"] == "REVIEW_REQUIRED"
+    assert report["field_markers"]["live_agent"] == {
+        "status": "UNAVAILABLE",
+        "reason": "live-agent plan/report paths were not provided",
+    }
+    assert report["router_promotion_gate"]["decision"] == "KEEP_BASELINE"
+
+
+def test_evidence_gate_missing_artifact_path_writes_invalid_report(tmp_path):
+    external_plan, _external_report = _write_external_artifacts(tmp_path)
+
+    report = write_evidence_decision_report(
+        output_path=tmp_path / "evidence.json",
+        external_plan_path=external_plan,
+        external_report_path=tmp_path / "missing-external-report.json",
+    )
+
+    assert report["benchmark_validity_gate"]["status"] == "INVALID_EVIDENCE"
+    assert report["router_promotion_gate"]["decision"] == "KEEP_BASELINE"
+    assert any(
+        check["id"] == "external.report_load" and check["status"] == "FAIL"
+        for check in report["benchmark_validity_gate"]["checks"]
+    )
+
+
+def test_evidence_gate_invalid_live_plan_digest_blocks_promotion(tmp_path):
+    external_plan, external_report = _write_external_artifacts(tmp_path)
+    live_plan, live_report = _write_live_artifacts(tmp_path, disjoint_overlap=True)
+    plan = json.loads(live_plan.read_text(encoding="utf-8"))
+    plan["selected_tasks"][0]["prompt"] = "tampered prompt"
+    live_plan.write_text(json.dumps(plan, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    report = write_evidence_decision_report(
+        output_path=tmp_path / "evidence.json",
+        external_plan_path=external_plan,
+        external_report_path=external_report,
+        live_plan_path=live_plan,
+        live_report_path=live_report,
+    )
+
+    assert report["benchmark_validity_gate"]["status"] == "INVALID_EVIDENCE"
+    assert report["router_promotion_gate"]["decision"] == "KEEP_BASELINE"
+    assert report["router_promotion_gate"]["blocked_by_validity"] is True
+    assert any(
+        check["id"] == "live_agent.plan_digest"
+        and check["status"] == "FAIL"
+        for check in report["benchmark_validity_gate"]["checks"]
+    )
+
+
+def test_evidence_gate_detects_no_skill_leakage_and_trace_loss(tmp_path):
+    external_plan, external_report = _write_external_artifacts(tmp_path)
+    live_plan, live_report = _write_live_artifacts(tmp_path, disjoint_overlap=True)
+    payload = json.loads(live_report.read_text(encoding="utf-8"))
+    no_skill_run = next(run for run in payload["runs"] if run["condition"] == "no-skill")
+    no_skill_run["mounted_skill_count"] = 1
+    Path(no_skill_run["trace_path"]).unlink()
+    live_report.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    report = write_evidence_decision_report(
+        output_path=tmp_path / "evidence.json",
+        external_plan_path=external_plan,
+        external_report_path=external_report,
+        live_plan_path=live_plan,
+        live_report_path=live_report,
+    )
+
+    assert report["benchmark_validity_gate"]["status"] == "INVALID_EVIDENCE"
+    failing_ids = {
+        check["id"]
+        for check in report["benchmark_validity_gate"]["checks"]
+        if check["status"] == "FAIL"
+    }
+    assert "live_agent.no_skill_leakage" in failing_ids
+    assert "live_agent.trace_completeness" in failing_ids
+
+
+def test_evidence_gate_detects_mounted_only_no_skill_leakage(tmp_path):
+    external_plan, external_report = _write_external_artifacts(tmp_path)
+    live_plan, live_report = _write_live_artifacts(tmp_path, disjoint_overlap=True)
+    payload = json.loads(live_report.read_text(encoding="utf-8"))
+    no_skill_run = next(run for run in payload["runs"] if run["condition"] == "no-skill")
+    no_skill_run["skill_use"] = {"skill/browser-login": {"state": "MOUNTED_ONLY"}}
+    live_report.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    report = write_evidence_decision_report(
+        output_path=tmp_path / "evidence.json",
+        external_plan_path=external_plan,
+        external_report_path=external_report,
+        live_plan_path=live_plan,
+        live_report_path=live_report,
+    )
+
+    assert report["benchmark_validity_gate"]["status"] == "INVALID_EVIDENCE"
+    assert any(
+        check["id"] == "live_agent.no_skill_leakage" and check["status"] == "FAIL"
+        for check in report["benchmark_validity_gate"]["checks"]
+    )
+
+
+def test_evidence_gate_missing_frozen_live_run_is_invalid(tmp_path):
+    external_plan, external_report = _write_external_artifacts(tmp_path)
+    live_plan, live_report = _write_live_artifacts(tmp_path, disjoint_overlap=True)
+    payload = json.loads(live_report.read_text(encoding="utf-8"))
+    payload["runs"] = [run for run in payload["runs"] if run["condition"] != "no-skill"]
+    live_report.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    report = write_evidence_decision_report(
+        output_path=tmp_path / "evidence.json",
+        external_plan_path=external_plan,
+        external_report_path=external_report,
+        live_plan_path=live_plan,
+        live_report_path=live_report,
+    )
+
+    assert report["benchmark_validity_gate"]["status"] == "INVALID_EVIDENCE"
+    matrix_check = next(
+        check
+        for check in report["benchmark_validity_gate"]["checks"]
+        if check["id"] == "live_agent.matrix_completeness"
+    )
+    assert matrix_check["status"] == "FAIL"
+    assert matrix_check["details"]["missing_run_ids"]
+
+
+def test_evidence_gate_linked_transfer_requires_review_not_independent_claim(tmp_path):
+    external_plan, external_report = _write_external_artifacts(tmp_path)
+    live_plan, live_report = _write_live_artifacts(tmp_path, disjoint_overlap=False)
+
+    report = write_evidence_decision_report(
+        output_path=tmp_path / "evidence.json",
+        external_plan_path=external_plan,
+        external_report_path=external_report,
+        live_plan_path=live_plan,
+        live_report_path=live_report,
+    )
+
+    assert report["benchmark_validity_gate"]["status"] == "REVIEW_REQUIRED"
+    assert report["live_agent"]["overlap_report"]["decision"] == "LINKED_TRANSFER"
+    assert report["live_agent"]["overlap_report"]["independent_generalization_claim"] is False
+    assert any(
+        check["id"] == "live_agent.overlap_status" and check["status"] == "REVIEW"
+        for check in report["benchmark_validity_gate"]["checks"]
+    )
+
+
+def test_evidence_gate_verifier_conflict_is_invalid_and_regression_is_reported(tmp_path):
+    external_plan, external_report = _write_external_artifacts(tmp_path)
+    live_plan, live_report = _write_live_artifacts(tmp_path, disjoint_overlap=True)
+    payload = json.loads(live_report.read_text(encoding="utf-8"))
+    no_skill_run = next(run for run in payload["runs"] if run["condition"] == "no-skill")
+    routed_run = next(run for run in payload["runs"] if run["condition"] == "routed-skill")
+    no_skill_run["task_success"] = True
+    no_skill_run["verifier_passed"] = True
+    no_skill_run["verifier"]["passed"] = True
+    routed_run["task_success"] = False
+    routed_run["verifier_passed"] = True
+    routed_run["verifier"]["passed"] = True
+    routed_run["timed_out"] = True
+    live_report.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    report = write_evidence_decision_report(
+        output_path=tmp_path / "evidence.json",
+        external_plan_path=external_plan,
+        external_report_path=external_report,
+        live_plan_path=live_plan,
+        live_report_path=live_report,
+    )
+
+    assert report["benchmark_validity_gate"]["status"] == "INVALID_EVIDENCE"
+    assert report["live_agent"]["per_task_regressions"] == [
+        {
+            "task_id": "sb-task-login",
+            "no_skill_success": True,
+            "routed_skill_success": False,
+        }
+    ]
+    checks = {
+        check["id"]: check["status"]
+        for check in report["benchmark_validity_gate"]["checks"]
+    }
+    assert checks["live_agent.verifier_evidence"] == "FAIL"
+    assert checks["live_agent.timeout_process_errors"] == "REVIEW"
+    assert checks["live_agent.per_task_regressions"] == "REVIEW"
+
+
+def test_evidence_gate_detects_top_level_verifier_passed_inconsistency(tmp_path):
+    external_plan, external_report = _write_external_artifacts(tmp_path)
+    live_plan, live_report = _write_live_artifacts(tmp_path, disjoint_overlap=True)
+    payload = json.loads(live_report.read_text(encoding="utf-8"))
+    run = payload["runs"][0]
+    run["verifier_passed"] = not run["verifier"]["passed"]
+    live_report.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    report = write_evidence_decision_report(
+        output_path=tmp_path / "evidence.json",
+        external_plan_path=external_plan,
+        external_report_path=external_report,
+        live_plan_path=live_plan,
+        live_report_path=live_report,
+    )
+
+    assert report["benchmark_validity_gate"]["status"] == "INVALID_EVIDENCE"
+    failing_ids = {
+        check["id"]
+        for check in report["benchmark_validity_gate"]["checks"]
+        if check["status"] == "FAIL"
+    }
+    assert "live_agent.verifier_evidence" in failing_ids
+    assert "live_agent.trace_completeness" in failing_ids
+
+
+def test_evidence_gate_detects_trace_report_divergence(tmp_path):
+    external_plan, external_report = _write_external_artifacts(tmp_path)
+    live_plan, live_report = _write_live_artifacts(tmp_path, disjoint_overlap=True)
+    payload = json.loads(live_report.read_text(encoding="utf-8"))
+    run = payload["runs"][0]
+    run["process_exit_code"] = 99
+    live_report.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    report = write_evidence_decision_report(
+        output_path=tmp_path / "evidence.json",
+        external_plan_path=external_plan,
+        external_report_path=external_report,
+        live_plan_path=live_plan,
+        live_report_path=live_report,
+    )
+
+    assert report["benchmark_validity_gate"]["status"] == "INVALID_EVIDENCE"
+    trace_check = next(
+        check
+        for check in report["benchmark_validity_gate"]["checks"]
+        if check["id"] == "live_agent.trace_completeness"
+    )
+    assert trace_check["status"] == "FAIL"
+    assert any(
+        failure.get("field") == "process_exit_code"
+        for failure in trace_check["details"]["failures"]
+    )
+
+
+def test_evidence_gate_cli_writes_json_and_markdown(tmp_path):
+    external_plan, external_report = _write_external_artifacts(tmp_path)
+    live_plan, live_report = _write_live_artifacts(tmp_path, disjoint_overlap=True)
+    output = tmp_path / "cli-evidence.json"
+    markdown = tmp_path / "cli-evidence.md"
+
+    exit_code = main(
+        [
+            "v0.3-evidence-gate",
+            "--output",
+            str(output),
+            "--markdown-output",
+            str(markdown),
+            "--external-plan",
+            str(external_plan),
+            "--external-report",
+            str(external_report),
+            "--live-plan",
+            str(live_plan),
+            "--live-report",
+            str(live_report),
+        ]
+    )
+
+    assert exit_code == 0
+    assert json.loads(output.read_text(encoding="utf-8"))["router_promotion_gate"][
+        "decision"
+    ] == "KEEP_BASELINE"
+    assert "KEEP_BASELINE" in markdown.read_text(encoding="utf-8")
+
+
+def _write_external_artifacts(
+    tmp_path: Path,
+    *,
+    routers: list[dict[str, str]] | None = None,
+) -> tuple[Path, Path]:
+    plan_path = tmp_path / "external-plan.json"
+    report_path = tmp_path / "external-report.json"
+    write_skillrouter_matrix_plan(
+        data_root=SKILLROUTER_FIXTURE,
+        output_path=plan_path,
+        upstream_ref="fixture-ref",
+        license_note="fixture-only",
+        run_id="external-evidence-fixture",
+        routers=routers
+        or [
+            {
+                "router_id": "baseline-minilm",
+                "field_view": "name_only",
+                "predictions_path": str(SKILLROUTER_PREDICTIONS),
+                "version": "fixture",
+            },
+            {
+                "router_id": "finetuned-embedding",
+                "field_view": "full_body",
+                "predictions_path": str(SKILLROUTER_PREDICTIONS),
+                "version": "fixture",
+            },
+        ],
+        stress_candidate_sizes=(1, 3),
+        matrix_output_path=report_path,
+        bootstrap_iterations=200,
+    )
+    run_skillrouter_matrix(plan_path=plan_path, output_path=report_path)
+    return plan_path, report_path
+
+
+def _write_live_artifacts(
+    tmp_path: Path,
+    *,
+    disjoint_overlap: bool,
+) -> tuple[Path, Path]:
+    root = tmp_path / "skillsbench"
+    shutil.copytree(SKILLSBENCH_FIXTURE, root)
+    if disjoint_overlap:
+        tasks = [
+            json.loads(line)
+            for line in (root / "tasks.jsonl").read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+        for task in tasks:
+            task.pop("skillrouter_task_id", None)
+        (root / "tasks.jsonl").write_text(
+            "".join(json.dumps(task, sort_keys=True) + "\n" for task in tasks),
+            encoding="utf-8",
+        )
+    plan_path = tmp_path / "live-plan.json"
+    report_path = tmp_path / "live-report.json"
+    write_skillsbench_plan(
+        data_root=root,
+        output_path=plan_path,
+        upstream_ref=UPSTREAM_SHA,
+        license_note="fixture-only",
+        run_id="live-evidence-fixture",
+        mode="frozen",
+        selected_task_ids=["sb-task-login"],
+        routed_predictions_path=root / "routed_predictions.json",
+        oracle_qualification_path=root / "oracle_qualification.jsonl",
+        matrix_output_path=report_path,
+        workspace_root=tmp_path / "workspaces",
+        router_top_k=1,
+        skillrouter_data_root=SKILLROUTER_FIXTURE,
+    )
+    run_skillsbench_matrix(
+        plan_path=plan_path,
+        output_path=report_path,
+        runner=FakeAgentRunner(exit_code=0, events=[{"type": "final", "message": "ok"}]),
+        verifier=FakeVerifier(pass_=True, details={"reason": "fixture pass"}),
+    )
+    return plan_path, report_path


### PR DESCRIPTION
## Summary
- Add a unified v0.3 evidence validator/report writer for SkillRouter external matrix and SkillsBench live-agent artifacts.
- Keep Benchmark Validity Gate separate from Router Promotion Gate: top-level validity is only VALID_EVIDENCE, INVALID_EVIDENCE, or REVIEW_REQUIRED; UNAVAILABLE is field-level only.
- Default promotion to KEEP_BASELINE, block promotion on invalid evidence, and avoid hardcoded router promotion participants.
- Add CLI command: v0.3-evidence-gate.
- Add OpenSpec PR-7 artifacts and Chinese Human Brief.

## Validation
- python -m pytest -q tests/test_v0_3_evidence_gate.py
- python -m pytest -q
- OPENSPEC_TELEMETRY=0 openspec validate --all --strict
- PYTHONPATH=src python -m hermes_skilleval.cli release-check --phase17-output-dir docs/demo/phase17-calibrated-release-selector --release-output-dir docs/demo/phase18-ci-release-reproducibility
- git diff --check
- v0.3 YAML parse check
- CRLF/new-file line-ending check

## Scope Boundaries
- No new models, training, tuning, full live-agent benchmark runs, Phase 10 changes, or release promotion.
- No SkillRouter scorer/matrix or Codex runner behavior changes.