### PR TITLE
ops: export frozen SkillRouter predictions

### DIFF
--- a/src/hermes_skilleval/cli.py
+++ b/src/hermes_skilleval/cli.py
@@ -39,6 +39,10 @@ from hermes_skilleval.external.skillrouter_matrix import (
     run_skillrouter_matrix,
     write_skillrouter_matrix_plan,
 )
+from hermes_skilleval.external.skillrouter_prediction_export import (
+    FrozenRouterConfig,
+    write_skillrouter_prediction_artifacts,
+)
 from hermes_skilleval.external.skillrouter_scorer import write_skillrouter_score_report
 from hermes_skilleval.evidence_gate import write_evidence_decision_report
 from hermes_skilleval.failure_analysis import (
@@ -380,6 +384,43 @@ def _build_parser() -> argparse.ArgumentParser:
     external_matrix_parser.add_argument("--plan", required=True)
     external_matrix_parser.add_argument("--output", required=True)
     external_matrix_parser.set_defaults(handler=_run_external_matrix)
+
+    prediction_export_parser = subparsers.add_parser(
+        "external-export-predictions",
+        help="export frozen SkillRouter prediction files for existing routers",
+    )
+    prediction_export_parser.add_argument(
+        "--benchmark",
+        choices=("skillrouter",),
+        required=True,
+    )
+    prediction_export_parser.add_argument("--data-root", required=True)
+    prediction_export_parser.add_argument("--output-dir", required=True)
+    prediction_export_parser.add_argument("--run-id", required=True)
+    prediction_export_parser.add_argument(
+        "--router-config",
+        action="append",
+        required=True,
+        help=(
+            "frozen router config as router_id:field_view:tier "
+            "or config_id:router_id:field_view:tier"
+        ),
+    )
+    prediction_export_parser.add_argument("--top-k", type=int, default=50)
+    prediction_export_parser.add_argument(
+        "--embedding-backend",
+        choices=EMBEDDING_BACKENDS,
+        default="sentence-transformers",
+    )
+    prediction_export_parser.add_argument(
+        "--baseline-minilm-model",
+        default="sentence-transformers/all-MiniLM-L6-v2",
+    )
+    prediction_export_parser.add_argument("--baseline-minilm-revision", default=None)
+    prediction_export_parser.add_argument("--finetuned-embedding-checkpoint", default=None)
+    prediction_export_parser.add_argument("--finetuned-embedding-revision", default=None)
+    prediction_export_parser.add_argument("--finetuned-embedding-sha256", default=None)
+    prediction_export_parser.set_defaults(handler=_run_external_export_predictions)
 
     skillsbench_validate_parser = subparsers.add_parser(
         "skillsbench-validate",
@@ -1097,6 +1138,37 @@ def _run_external_matrix(args: argparse.Namespace) -> None:
     )
 
 
+def _run_external_export_predictions(args: argparse.Namespace) -> None:
+    if args.benchmark != "skillrouter":
+        raise ValueError(f"unsupported external benchmark: {args.benchmark}")
+    model = (
+        HashingEmbeddingModel()
+        if args.embedding_backend == "hashing"
+        else None
+    )
+    manifest = write_skillrouter_prediction_artifacts(
+        data_root=args.data_root,
+        output_dir=args.output_dir,
+        run_id=args.run_id,
+        configs=[
+            _parse_prediction_export_router_config(value, args)
+            for value in args.router_config
+        ],
+        top_k=args.top_k,
+        command=["skilleval", *sys.argv[1:]],
+        embedding_model=model,
+    )
+    pass_count = sum(1 for item in manifest["artifacts"] if item["status"] == "PASS")
+    unavailable_count = sum(
+        1 for item in manifest["artifacts"] if item["status"] == "UNAVAILABLE"
+    )
+    print(
+        "External predictions "
+        f"{manifest['run_id']}: {args.output_dir} "
+        f"({pass_count} exported, {unavailable_count} unavailable)"
+    )
+
+
 def _run_skillsbench_validate(args: argparse.Namespace) -> None:
     adapter = SkillsBenchAdapter(
         data_root=args.data_root,
@@ -1197,6 +1269,50 @@ def _parse_external_router_config(value: str) -> dict[str, str]:
             "--router-config must use router_id:field_view:predictions_path "
             "or config_id:router_id:field_view:predictions_path"
         )
+
+
+def _parse_prediction_export_router_config(
+    value: str,
+    args: argparse.Namespace,
+) -> FrozenRouterConfig:
+    parts = value.split(":", 3)
+    if len(parts) == 3 and all(part.strip() for part in parts):
+        router_id, field_view, tier = parts
+        config_id = f"{router_id}__{field_view}__{tier}"
+    elif len(parts) == 4 and all(part.strip() for part in parts):
+        config_id, router_id, field_view, tier = parts
+    else:
+        raise ValueError(
+            "--router-config must use router_id:field_view:tier "
+            "or config_id:router_id:field_view:tier"
+        )
+    if router_id == "baseline-minilm":
+        return FrozenRouterConfig(
+            router_id=router_id,
+            config_id=config_id,
+            field_view=field_view,
+            tier=tier,
+            model_name=args.baseline_minilm_model,
+            model_revision=args.baseline_minilm_revision,
+        )
+    if router_id == "finetuned-embedding":
+        return FrozenRouterConfig(
+            router_id=router_id,
+            config_id=config_id,
+            field_view=field_view,
+            tier=tier,
+            model_name="finetuned-embedding",
+            model_revision=args.finetuned_embedding_revision,
+            checkpoint_path=args.finetuned_embedding_checkpoint,
+            checkpoint_sha256=args.finetuned_embedding_sha256,
+        )
+    return FrozenRouterConfig(
+        router_id=router_id,
+        config_id=config_id,
+        field_view=field_view,
+        tier=tier,
+        model_name=router_id,
+    )
 
 
 def _parse_ci_checks(values: list[str]) -> list[tuple[str, str]]:

--- a/src/hermes_skilleval/cli.py
+++ b/src/hermes_skilleval/cli.py
@@ -41,6 +41,7 @@ from hermes_skilleval.external.skillrouter_matrix import (
 )
 from hermes_skilleval.external.skillrouter_prediction_export import (
     FrozenRouterConfig,
+    _is_immutable_revision,
     write_skillrouter_prediction_artifacts,
 )
 from hermes_skilleval.external.skillrouter_scorer import write_skillrouter_score_report
@@ -407,6 +408,11 @@ def _build_parser() -> argparse.ArgumentParser:
         ),
     )
     prediction_export_parser.add_argument("--top-k", type=int, default=50)
+    prediction_export_parser.add_argument(
+        "--non-final",
+        action="store_true",
+        help="mark export as non-final evidence; required for dirty local fixture smoke runs",
+    )
     prediction_export_parser.add_argument(
         "--embedding-backend",
         choices=EMBEDDING_BACKENDS,
@@ -1141,6 +1147,11 @@ def _run_external_matrix(args: argparse.Namespace) -> None:
 def _run_external_export_predictions(args: argparse.Namespace) -> None:
     if args.benchmark != "skillrouter":
         raise ValueError(f"unsupported external benchmark: {args.benchmark}")
+    configs = [
+        _parse_prediction_export_router_config(value, args)
+        for value in args.router_config
+    ]
+    _validate_prediction_export_cli_configs(configs, args)
     model = (
         HashingEmbeddingModel()
         if args.embedding_backend == "hashing"
@@ -1150,13 +1161,12 @@ def _run_external_export_predictions(args: argparse.Namespace) -> None:
         data_root=args.data_root,
         output_dir=args.output_dir,
         run_id=args.run_id,
-        configs=[
-            _parse_prediction_export_router_config(value, args)
-            for value in args.router_config
-        ],
+        configs=configs,
         top_k=args.top_k,
         command=["skilleval", *sys.argv[1:]],
         embedding_model=model,
+        embedding_backend=args.embedding_backend,
+        final_evidence=not args.non_final,
     )
     pass_count = sum(1 for item in manifest["artifacts"] if item["status"] == "PASS")
     unavailable_count = sum(
@@ -1313,6 +1323,24 @@ def _parse_prediction_export_router_config(
         tier=tier,
         model_name=router_id,
     )
+
+
+def _validate_prediction_export_cli_configs(
+    configs: list[FrozenRouterConfig],
+    args: argparse.Namespace,
+) -> None:
+    for config in configs:
+        if args.embedding_backend == "hashing" and config.router_id == "baseline-minilm":
+            raise ValueError(
+                "CLI hashing backend cannot export baseline-minilm prediction artifacts"
+            )
+        if config.router_id == "baseline-minilm" and not _is_immutable_revision(
+            config.model_revision
+        ):
+            raise ValueError(
+                "baseline-minilm requires --baseline-minilm-revision as an immutable "
+                "model commit SHA"
+            )
 
 
 def _parse_ci_checks(values: list[str]) -> list[tuple[str, str]]:

--- a/src/hermes_skilleval/external/skillrouter_prediction_export.py
+++ b/src/hermes_skilleval/external/skillrouter_prediction_export.py
@@ -26,8 +26,9 @@ SUPPORTED_TIERS = {"easy", "hard"}
 SUPPORTED_FIELD_VIEWS = {"name_only", "metadata", "full_body"}
 SUPPORTED_ROUTERS = {"baseline-minilm", "finetuned-embedding"}
 SAFE_FILENAME_RE = re.compile(r"^[A-Za-z0-9_.-]+$")
+BASELINE_MINILM_MODEL = "sentence-transformers/all-MiniLM-L6-v2"
 IMMUTABLE_REVISION_RE = re.compile(r"^[0-9a-fA-F]{40}([0-9a-fA-F]{24})?$")
-DIRTY_PATH_PREFIXES = ("src/", "tests/", "scripts/", "docs/", "openspec/")
+DIRTY_PATH_PREFIXES = ("src/", "tests/", "scripts/", "docs/", "openspec/", "configs/")
 DIRTY_PATH_NAMES = {"README.md", "pyproject.toml"}
 
 
@@ -103,6 +104,8 @@ def write_skillrouter_prediction_artifacts(
     tasks = _load_task_records(tasks_path)
     task_ids = {task.task_id for task in tasks}
     code_state = _git_state()
+    if final_evidence and embedding_model is not None:
+        raise ValueError("final evidence cannot use injected embedding models")
     if final_evidence and code_state.get("dirty_paths"):
         raise ValueError(
             "production prediction export requires clean source/config/test paths: "
@@ -141,6 +144,7 @@ def write_skillrouter_prediction_artifacts(
             normalized,
             embedding_backend=backend,
             injected_model=embedding_model is not None,
+            final_evidence=final_evidence,
         )
         artifact_base = _artifact_record(
             normalized,
@@ -302,6 +306,7 @@ def _router_availability(
     *,
     embedding_backend: str,
     injected_model: bool,
+    final_evidence: bool,
 ) -> dict[str, Any]:
     if config.router_id not in SUPPORTED_ROUTERS:
         return {
@@ -320,6 +325,14 @@ def _router_availability(
             ),
         }
     if config.router_id == "baseline-minilm":
+        if final_evidence and config.model_name != BASELINE_MINILM_MODEL:
+            return {
+                "status": "UNAVAILABLE",
+                "reason": (
+                    "baseline-minilm final evidence requires canonical model_name "
+                    f"{BASELINE_MINILM_MODEL}"
+                ),
+            }
         if not config.model_revision:
             return {
                 "status": "UNAVAILABLE",
@@ -556,6 +569,7 @@ def _git_state() -> dict[str, Any]:
                 "scripts",
                 "docs",
                 "openspec",
+                "configs",
                 "pyproject.toml",
                 "README.md",
             ],

--- a/src/hermes_skilleval/external/skillrouter_prediction_export.py
+++ b/src/hermes_skilleval/external/skillrouter_prediction_export.py
@@ -1,0 +1,471 @@
+from __future__ import annotations
+
+import gzip
+import hashlib
+import json
+import re
+import subprocess
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Iterable, Protocol
+
+from hermes_skilleval.external.skillrouter import ExternalSkill, SkillRouterAdapter
+from hermes_skilleval.external.skillrouter_matrix import build_field_view
+from hermes_skilleval.provenance import _reject_sensitive_values
+from hermes_skilleval.release_manifest import sha256_file
+from hermes_skilleval.routers.embedding import _cosine
+
+
+EXPORT_SCHEMA = "v0.3.skillrouter-prediction-export-manifest.v1"
+PREDICTION_SCHEMA = "skillrouter.scorer.predictions.v1"
+MIN_TOP_K = 50
+QUERY_FIELDS = ("instruction_text", "query", "prompt", "instruction")
+TASK_ID_FIELDS = ("id", "task_id")
+SUPPORTED_TIERS = {"easy", "hard"}
+SUPPORTED_FIELD_VIEWS = {"name_only", "metadata", "full_body"}
+SUPPORTED_ROUTERS = {"baseline-minilm", "finetuned-embedding"}
+SAFE_FILENAME_RE = re.compile(r"^[A-Za-z0-9_.-]+$")
+
+
+class BatchEmbeddingModel(Protocol):
+    cache_key: str
+
+    def encode_batch(self, texts: Iterable[str]) -> list[list[float]]:
+        raise NotImplementedError
+
+
+@dataclass(frozen=True)
+class FrozenRouterConfig:
+    router_id: str
+    field_view: str
+    tier: str
+    model_name: str
+    model_revision: str | None = None
+    config_id: str | None = None
+    checkpoint_path: str | None = None
+    checkpoint_sha256: str | None = None
+
+
+@dataclass(frozen=True)
+class _TaskRecord:
+    task_id: str
+    query: str
+
+
+class _SentenceTransformerBatchModel:
+    def __init__(self, *, model_name: str, revision: str | None = None) -> None:
+        try:
+            from sentence_transformers import SentenceTransformer
+        except (ImportError, ModuleNotFoundError) as exc:
+            raise RuntimeError(
+                "sentence-transformers is required to export baseline-minilm predictions"
+            ) from exc
+
+        kwargs = {"revision": revision} if revision else {}
+        self.model = SentenceTransformer(model_name, **kwargs)
+        self.cache_key = f"sentence-transformers:{model_name}@{revision or 'unversioned'}"
+
+    def encode_batch(self, texts: Iterable[str]) -> list[list[float]]:
+        embeddings = self.model.encode(list(texts), normalize_embeddings=True)
+        result = []
+        for vector in embeddings:
+            if hasattr(vector, "tolist"):
+                vector = vector.tolist()
+            result.append([float(item) for item in vector])
+        return result
+
+
+def write_skillrouter_prediction_artifacts(
+    *,
+    data_root: Path | str,
+    output_dir: Path | str,
+    run_id: str,
+    configs: Iterable[FrozenRouterConfig],
+    top_k: int = MIN_TOP_K,
+    command: list[str] | None = None,
+    embedding_model: BatchEmbeddingModel | None = None,
+) -> dict[str, Any]:
+    if top_k < MIN_TOP_K:
+        raise ValueError(f"top_k must be at least {MIN_TOP_K}")
+
+    frozen_configs = list(configs)
+    _assert_unique_config_ids(frozen_configs)
+    root = Path(data_root)
+    output_root = Path(output_dir)
+    output_root.mkdir(parents=True, exist_ok=True)
+    tasks = _load_task_records(root)
+    task_ids = {task.task_id for task in tasks}
+
+    manifest = {
+        "schema_version": EXPORT_SCHEMA,
+        "run_id": _non_empty(run_id, "run_id"),
+        "generated_at": _now(),
+        "code": _git_state(),
+        "data_root": str(root),
+        "top_k": top_k,
+        "command": list(command or []),
+        "relevance_labels_read": False,
+        "scope_guards": {
+            "no_training": True,
+            "no_threshold_tuning": True,
+            "no_hard_negative_mining": True,
+            "no_new_router_variants": True,
+            "no_scorer_matrix_gate_changes": True,
+            "prediction_generation_reads_relevance_labels": False,
+        },
+        "artifacts": [],
+    }
+
+    for config in frozen_configs:
+        normalized = _normalize_config(config)
+        availability = _router_availability(normalized)
+        artifact_base = _artifact_record(normalized, output_root, top_k)
+        if availability["status"] != "PASS":
+            manifest["artifacts"].append(artifact_base | availability)
+            continue
+
+        model = embedding_model or _load_model(normalized)
+        skills = _load_tier_skills(root, normalized.tier)
+        predictions = _rank_tasks(
+            tasks=tasks,
+            skills=skills,
+            field_view=normalized.field_view,
+            model=model,
+            top_k=top_k,
+        )
+        output_path = _prediction_output_path(output_root, normalized.config_id)
+        write_skillrouter_prediction_file(
+            output_path=output_path,
+            predictions=predictions,
+            task_ids=task_ids,
+            tier_skill_ids={skill.skill_id for skill in skills},
+        )
+        file_record = _prediction_file_record(output_path)
+        manifest["artifacts"].append(
+            artifact_base
+            | {
+                "status": "PASS",
+                "output_path": str(output_path),
+                "sha256": file_record["sha256"],
+                "size_bytes": file_record["size_bytes"],
+                "candidate_pool": _candidate_pool_record(root, normalized.tier),
+                "model": _model_record(normalized, model),
+            }
+        )
+
+    manifest_path = output_root / "manifest.json"
+    _reject_sensitive_values(manifest)
+    manifest_path.write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return manifest
+
+
+def write_skillrouter_prediction_file(
+    *,
+    output_path: Path | str,
+    predictions: dict[str, list[str]],
+    task_ids: set[str],
+    tier_skill_ids: set[str],
+) -> None:
+    normalized: dict[str, list[str]] = {}
+    for task_id in sorted(predictions):
+        if task_id not in task_ids:
+            raise ValueError(f"unknown prediction task id: {task_id}")
+        ranking = []
+        seen: set[str] = set()
+        for skill_id in predictions[task_id]:
+            if skill_id not in tier_skill_ids:
+                raise ValueError(f"unknown predicted skill id: {task_id} -> {skill_id}")
+            if skill_id not in seen:
+                seen.add(skill_id)
+                ranking.append(skill_id)
+        normalized[task_id] = ranking
+
+    missing = sorted(task_ids - set(normalized))
+    if missing:
+        raise ValueError(f"missing predictions for task ids: {', '.join(missing)}")
+
+    output = Path(output_path)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(
+        json.dumps(normalized, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _rank_tasks(
+    *,
+    tasks: list[_TaskRecord],
+    skills: list[ExternalSkill],
+    field_view: str,
+    model: BatchEmbeddingModel,
+    top_k: int,
+) -> dict[str, list[str]]:
+    if not skills:
+        raise ValueError("candidate skill pool is empty")
+    unique_skills = _unique_skills(skills)
+    task_vectors = model.encode_batch(task.query for task in tasks)
+    skill_texts = [build_field_view(skill, field_view)["text"] for skill in unique_skills]
+    skill_vectors = model.encode_batch(skill_texts)
+    predictions: dict[str, list[str]] = {}
+    for task, task_vector in zip(tasks, task_vectors, strict=True):
+        scored = [
+            (skill.skill_id, _cosine(task_vector, skill_vector))
+            for skill, skill_vector in zip(unique_skills, skill_vectors, strict=True)
+        ]
+        ranked = sorted(scored, key=lambda item: (-item[1], item[0]))
+        predictions[task.task_id] = [skill_id for skill_id, _ in ranked[:top_k]]
+    return predictions
+
+
+def _load_task_records(data_root: Path) -> list[_TaskRecord]:
+    path = _first_existing(data_root / "tasks.jsonl", data_root / "tasks" / "tasks.jsonl")
+    tasks = []
+    seen: set[str] = set()
+    with path.open(encoding="utf-8") as handle:
+        for line_number, line in enumerate(handle, start=1):
+            if not line.strip():
+                continue
+            record = json.loads(line)
+            task_id = _required_string(record, TASK_ID_FIELDS, f"{path}:{line_number} task id")
+            query = _required_string(record, QUERY_FIELDS, f"{path}:{line_number} query")
+            if task_id in seen:
+                raise ValueError(f"duplicate task id: {task_id}")
+            seen.add(task_id)
+            tasks.append(_TaskRecord(task_id=task_id, query=query))
+    if not tasks:
+        raise ValueError(f"no tasks found in {path}")
+    return tasks
+
+
+def _load_tier_skills(data_root: Path, tier: str) -> list[ExternalSkill]:
+    return list(SkillRouterAdapter(data_root=data_root, tiers=(tier,)).iter_skills(tier))
+
+
+def _normalize_config(config: FrozenRouterConfig) -> FrozenRouterConfig:
+    router_id = _non_empty(config.router_id, "router_id")
+    field_view = _non_empty(config.field_view, "field_view")
+    tier = _non_empty(config.tier, "tier")
+    if field_view not in SUPPORTED_FIELD_VIEWS:
+        raise ValueError(f"unsupported field_view: {field_view}")
+    if tier not in SUPPORTED_TIERS:
+        raise ValueError(f"unsupported candidate tier: {tier}")
+    config_id = config.config_id or f"{router_id}__{field_view}__{tier}"
+    _safe_config_id(config_id)
+    return FrozenRouterConfig(
+        router_id=router_id,
+        config_id=config_id,
+        field_view=field_view,
+        tier=tier,
+        model_name=_non_empty(config.model_name, "model_name"),
+        model_revision=config.model_revision,
+        checkpoint_path=config.checkpoint_path,
+        checkpoint_sha256=config.checkpoint_sha256,
+    )
+
+
+def _router_availability(config: FrozenRouterConfig) -> dict[str, Any]:
+    if config.router_id not in SUPPORTED_ROUTERS:
+        return {
+            "status": "UNAVAILABLE",
+            "reason": f"unsupported frozen router_id: {config.router_id}",
+        }
+    if config.router_id == "baseline-minilm":
+        if not config.model_revision:
+            return {
+                "status": "UNAVAILABLE",
+                "reason": "baseline-minilm requires a provenance-pinned model revision",
+            }
+        return {"status": "PASS"}
+    if config.router_id == "finetuned-embedding":
+        if not config.checkpoint_path:
+            return {
+                "status": "UNAVAILABLE",
+                "reason": "finetuned-embedding checkpoint_path is not configured",
+            }
+        checkpoint = Path(config.checkpoint_path)
+        if not checkpoint.exists():
+            return {
+                "status": "UNAVAILABLE",
+                "reason": f"finetuned-embedding checkpoint_path does not exist: {checkpoint}",
+            }
+        if not (config.checkpoint_sha256 or config.model_revision):
+            return {
+                "status": "UNAVAILABLE",
+                "reason": (
+                    "finetuned-embedding requires checkpoint_sha256 or model_revision "
+                    "for provenance"
+                ),
+            }
+        return {"status": "PASS"}
+    raise AssertionError("unreachable")
+
+
+def _load_model(config: FrozenRouterConfig) -> BatchEmbeddingModel:
+    model_name = config.checkpoint_path if config.checkpoint_path else config.model_name
+    return _SentenceTransformerBatchModel(
+        model_name=_non_empty(model_name, "model_name"),
+        revision=config.model_revision,
+    )
+
+
+def _model_record(config: FrozenRouterConfig, model: BatchEmbeddingModel) -> dict[str, Any]:
+    record: dict[str, Any] = {
+        "model_name": config.model_name,
+        "model_revision": config.model_revision,
+        "embedding_cache_key": getattr(model, "cache_key", None),
+    }
+    if config.checkpoint_path:
+        checkpoint = Path(config.checkpoint_path)
+        record["checkpoint_path"] = str(checkpoint)
+        record["checkpoint_sha256"] = config.checkpoint_sha256 or _path_sha256(checkpoint)
+    return record
+
+
+def _artifact_record(
+    config: FrozenRouterConfig,
+    output_root: Path,
+    top_k: int,
+) -> dict[str, Any]:
+    return {
+        "router_id": config.router_id,
+        "config_id": config.config_id,
+        "field_view": config.field_view,
+        "candidate_tier": config.tier,
+        "top_k": top_k,
+        "intended_output_path": str(_prediction_output_path(output_root, config.config_id)),
+    }
+
+
+def _candidate_pool_record(data_root: Path, tier: str) -> dict[str, Any]:
+    files = [_file_record(path, data_root) for path in _skill_files(data_root, tier)]
+    digest = hashlib.sha256(
+        json.dumps(files, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+    return {
+        "tier": tier,
+        "sha256": digest,
+        "size_bytes": sum(record["size_bytes"] for record in files),
+        "files": files,
+    }
+
+
+def _file_record(path: Path, root: Path) -> dict[str, Any]:
+    return {
+        "path": path.relative_to(root).as_posix(),
+        "sha256": sha256_file(path),
+        "size_bytes": path.stat().st_size,
+    }
+
+
+def _prediction_file_record(path: Path) -> dict[str, Any]:
+    return {"sha256": sha256_file(path), "size_bytes": path.stat().st_size}
+
+
+def _skill_files(data_root: Path, tier: str) -> list[Path]:
+    tier_dir = _first_existing(data_root / tier, data_root / "skills" / tier)
+    files = sorted([*tier_dir.glob("*.jsonl"), *tier_dir.glob("*.jsonl.gz")])
+    if not files:
+        raise ValueError(f"missing skill shard files for tier: {tier}")
+    return files
+
+
+def _unique_skills(skills: Iterable[ExternalSkill]) -> list[ExternalSkill]:
+    by_id: dict[str, ExternalSkill] = {}
+    for skill in skills:
+        by_id.setdefault(skill.skill_id, skill)
+    return [by_id[skill_id] for skill_id in sorted(by_id)]
+
+
+def _path_sha256(path: Path) -> str:
+    if path.is_file():
+        return sha256_file(path)
+    records = []
+    for child in sorted(item for item in path.rglob("*") if item.is_file()):
+        records.append(
+            {
+                "path": child.relative_to(path).as_posix(),
+                "sha256": sha256_file(child),
+                "size_bytes": child.stat().st_size,
+            }
+        )
+    return hashlib.sha256(
+        json.dumps(records, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+
+
+def _prediction_output_path(output_root: Path, config_id: str | None) -> Path:
+    safe_id = _safe_config_id(_non_empty(config_id, "config_id"))
+    return output_root / f"{safe_id}.predictions.json"
+
+
+def _safe_config_id(config_id: str) -> str:
+    if not SAFE_FILENAME_RE.match(config_id):
+        raise ValueError(f"config_id contains unsafe characters: {config_id}")
+    return config_id
+
+
+def _assert_unique_config_ids(configs: list[FrozenRouterConfig]) -> None:
+    seen: set[str] = set()
+    for config in configs:
+        config_id = config.config_id or f"{config.router_id}__{config.field_view}__{config.tier}"
+        if config_id in seen:
+            raise ValueError(f"duplicate config_id: {config_id}")
+        seen.add(config_id)
+
+
+def _first_existing(*paths: Path) -> Path:
+    for path in paths:
+        if path.exists():
+            return path
+    raise ValueError(f"missing required path; checked: {', '.join(str(path) for path in paths)}")
+
+
+def _required_string(record: dict[str, Any], fields: tuple[str, ...], label: str) -> str:
+    for field in fields:
+        value = record.get(field)
+        if isinstance(value, str) and value.strip():
+            return value
+    raise ValueError(f"missing {label}")
+
+
+def _non_empty(value: Any, label: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{label} must be a non-empty string")
+    return value
+
+
+def _git_state() -> dict[str, Any]:
+    try:
+        commit = subprocess.check_output(
+            ["git", "rev-parse", "HEAD"],
+            text=True,
+            stderr=subprocess.DEVNULL,
+        ).strip()
+        tag = subprocess.run(
+            ["git", "describe", "--tags", "--exact-match", "HEAD"],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            check=False,
+        )
+        dirty = subprocess.run(
+            ["git", "diff", "--quiet"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=False,
+        ).returncode != 0
+        return {
+            "commit": commit,
+            "tag": tag.stdout.strip() or None,
+            "dirty": dirty,
+        }
+    except (OSError, subprocess.CalledProcessError):
+        return {"commit": "UNAVAILABLE", "tag": None, "dirty": "UNAVAILABLE"}
+
+
+def _now() -> str:
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")

--- a/src/hermes_skilleval/external/skillrouter_prediction_export.py
+++ b/src/hermes_skilleval/external/skillrouter_prediction_export.py
@@ -26,6 +26,9 @@ SUPPORTED_TIERS = {"easy", "hard"}
 SUPPORTED_FIELD_VIEWS = {"name_only", "metadata", "full_body"}
 SUPPORTED_ROUTERS = {"baseline-minilm", "finetuned-embedding"}
 SAFE_FILENAME_RE = re.compile(r"^[A-Za-z0-9_.-]+$")
+IMMUTABLE_REVISION_RE = re.compile(r"^[0-9a-fA-F]{40}([0-9a-fA-F]{24})?$")
+DIRTY_PATH_PREFIXES = ("src/", "tests/", "scripts/", "docs/", "openspec/")
+DIRTY_PATH_NAMES = {"README.md", "pyproject.toml"}
 
 
 class BatchEmbeddingModel(Protocol):
@@ -85,6 +88,8 @@ def write_skillrouter_prediction_artifacts(
     top_k: int = MIN_TOP_K,
     command: list[str] | None = None,
     embedding_model: BatchEmbeddingModel | None = None,
+    embedding_backend: str | None = None,
+    final_evidence: bool = False,
 ) -> dict[str, Any]:
     if top_k < MIN_TOP_K:
         raise ValueError(f"top_k must be at least {MIN_TOP_K}")
@@ -94,17 +99,30 @@ def write_skillrouter_prediction_artifacts(
     root = Path(data_root)
     output_root = Path(output_dir)
     output_root.mkdir(parents=True, exist_ok=True)
-    tasks = _load_task_records(root)
+    tasks_path = _tasks_path(root)
+    tasks = _load_task_records(tasks_path)
     task_ids = {task.task_id for task in tasks}
+    code_state = _git_state()
+    if final_evidence and code_state.get("dirty_paths"):
+        raise ValueError(
+            "production prediction export requires clean source/config/test paths: "
+            + ", ".join(code_state["dirty_paths"])
+        )
+    backend = _embedding_backend_label(
+        embedding_backend=embedding_backend,
+        embedding_model=embedding_model,
+    )
 
     manifest = {
         "schema_version": EXPORT_SCHEMA,
         "run_id": _non_empty(run_id, "run_id"),
         "generated_at": _now(),
-        "code": _git_state(),
+        "code": code_state,
         "data_root": str(root),
+        "task_input": _task_input_record(tasks_path, root, len(tasks)),
         "top_k": top_k,
         "command": list(command or []),
+        "final_evidence": final_evidence,
         "relevance_labels_read": False,
         "scope_guards": {
             "no_training": True,
@@ -119,8 +137,17 @@ def write_skillrouter_prediction_artifacts(
 
     for config in frozen_configs:
         normalized = _normalize_config(config)
-        availability = _router_availability(normalized)
-        artifact_base = _artifact_record(normalized, output_root, top_k)
+        availability = _router_availability(
+            normalized,
+            embedding_backend=backend,
+            injected_model=embedding_model is not None,
+        )
+        artifact_base = _artifact_record(
+            normalized,
+            output_root,
+            top_k,
+            embedding_backend=backend,
+        )
         if availability["status"] != "PASS":
             manifest["artifacts"].append(artifact_base | availability)
             continue
@@ -221,8 +248,11 @@ def _rank_tasks(
     return predictions
 
 
-def _load_task_records(data_root: Path) -> list[_TaskRecord]:
-    path = _first_existing(data_root / "tasks.jsonl", data_root / "tasks" / "tasks.jsonl")
+def _tasks_path(data_root: Path) -> Path:
+    return _first_existing(data_root / "tasks.jsonl", data_root / "tasks" / "tasks.jsonl")
+
+
+def _load_task_records(path: Path) -> list[_TaskRecord]:
     tasks = []
     seen: set[str] = set()
     with path.open(encoding="utf-8") as handle:
@@ -267,17 +297,38 @@ def _normalize_config(config: FrozenRouterConfig) -> FrozenRouterConfig:
     )
 
 
-def _router_availability(config: FrozenRouterConfig) -> dict[str, Any]:
+def _router_availability(
+    config: FrozenRouterConfig,
+    *,
+    embedding_backend: str,
+    injected_model: bool,
+) -> dict[str, Any]:
     if config.router_id not in SUPPORTED_ROUTERS:
         return {
             "status": "UNAVAILABLE",
             "reason": f"unsupported frozen router_id: {config.router_id}",
+        }
+    if embedding_backend == "hashing" and config.router_id in {
+        "baseline-minilm",
+        "finetuned-embedding",
+    }:
+        return {
+            "status": "UNAVAILABLE",
+            "reason": (
+                "hashing backend cannot produce final baseline-minilm or "
+                "finetuned-embedding prediction artifacts"
+            ),
         }
     if config.router_id == "baseline-minilm":
         if not config.model_revision:
             return {
                 "status": "UNAVAILABLE",
                 "reason": "baseline-minilm requires a provenance-pinned model revision",
+            }
+        if not injected_model and not _is_immutable_revision(config.model_revision):
+            return {
+                "status": "UNAVAILABLE",
+                "reason": "baseline-minilm model revision must be an immutable commit SHA",
             }
         return {"status": "PASS"}
     if config.router_id == "finetuned-embedding":
@@ -292,13 +343,12 @@ def _router_availability(config: FrozenRouterConfig) -> dict[str, Any]:
                 "status": "UNAVAILABLE",
                 "reason": f"finetuned-embedding checkpoint_path does not exist: {checkpoint}",
             }
-        if not (config.checkpoint_sha256 or config.model_revision):
+        actual = _path_sha256(checkpoint)
+        if config.checkpoint_sha256 and config.checkpoint_sha256 != actual:
             return {
                 "status": "UNAVAILABLE",
-                "reason": (
-                    "finetuned-embedding requires checkpoint_sha256 or model_revision "
-                    "for provenance"
-                ),
+                "reason": "finetuned-embedding checkpoint sha256 mismatch",
+                "model": _checkpoint_hash_record(config, actual),
             }
         return {"status": "PASS"}
     raise AssertionError("unreachable")
@@ -321,7 +371,7 @@ def _model_record(config: FrozenRouterConfig, model: BatchEmbeddingModel) -> dic
     if config.checkpoint_path:
         checkpoint = Path(config.checkpoint_path)
         record["checkpoint_path"] = str(checkpoint)
-        record["checkpoint_sha256"] = config.checkpoint_sha256 or _path_sha256(checkpoint)
+        record.update(_checkpoint_hash_record(config, _path_sha256(checkpoint)))
     return record
 
 
@@ -329,14 +379,43 @@ def _artifact_record(
     config: FrozenRouterConfig,
     output_root: Path,
     top_k: int,
+    *,
+    embedding_backend: str,
 ) -> dict[str, Any]:
     return {
         "router_id": config.router_id,
         "config_id": config.config_id,
+        "router_family": "embedding",
+        "embedding_backend": embedding_backend,
         "field_view": config.field_view,
+        "text_builder": {
+            "name": "skillrouter-field-view",
+            "field_view": config.field_view,
+            "builder_version": "v0.3.pr3.field-view.v1",
+        },
         "candidate_tier": config.tier,
         "top_k": top_k,
         "intended_output_path": str(_prediction_output_path(output_root, config.config_id)),
+    }
+
+def _embedding_backend_label(
+    *,
+    embedding_backend: str | None,
+    embedding_model: BatchEmbeddingModel | None,
+) -> str:
+    if embedding_backend:
+        return embedding_backend
+    if embedding_model is not None:
+        return "test-injected"
+    return "sentence-transformers"
+
+
+def _task_input_record(path: Path, root: Path, task_count: int) -> dict[str, Any]:
+    return {
+        "path": path.relative_to(root).as_posix(),
+        "sha256": sha256_file(path),
+        "size_bytes": path.stat().st_size,
+        "task_count": task_count,
     }
 
 
@@ -397,6 +476,20 @@ def _path_sha256(path: Path) -> str:
     ).hexdigest()
 
 
+def _checkpoint_hash_record(
+    config: FrozenRouterConfig,
+    actual_sha256: str,
+) -> dict[str, Any]:
+    return {
+        "provided_checkpoint_sha256": config.checkpoint_sha256,
+        "actual_checkpoint_sha256": actual_sha256,
+        "checkpoint_hash_verified": (
+            config.checkpoint_sha256 is not None
+            and config.checkpoint_sha256 == actual_sha256
+        ),
+    }
+
+
 def _prediction_output_path(output_root: Path, config_id: str | None) -> Path:
     safe_id = _safe_config_id(_non_empty(config_id, "config_id"))
     return output_root / f"{safe_id}.predictions.json"
@@ -452,19 +545,57 @@ def _git_state() -> dict[str, Any]:
             stderr=subprocess.DEVNULL,
             check=False,
         )
-        dirty = subprocess.run(
-            ["git", "diff", "--quiet"],
-            stdout=subprocess.DEVNULL,
+        status = subprocess.run(
+            [
+                "git",
+                "status",
+                "--porcelain",
+                "--",
+                "src",
+                "tests",
+                "scripts",
+                "docs",
+                "openspec",
+                "pyproject.toml",
+                "README.md",
+            ],
+            text=True,
+            stdout=subprocess.PIPE,
             stderr=subprocess.DEVNULL,
             check=False,
-        ).returncode != 0
+        )
+        dirty_paths = _dirty_code_paths(status.stdout.splitlines())
         return {
             "commit": commit,
             "tag": tag.stdout.strip() or None,
-            "dirty": dirty,
+            "dirty": bool(dirty_paths),
+            "dirty_paths": dirty_paths,
         }
     except (OSError, subprocess.CalledProcessError):
-        return {"commit": "UNAVAILABLE", "tag": None, "dirty": "UNAVAILABLE"}
+        return {
+            "commit": "UNAVAILABLE",
+            "tag": None,
+            "dirty": "UNAVAILABLE",
+            "dirty_paths": [],
+        }
+
+
+def _dirty_code_paths(status_lines: Iterable[str]) -> list[str]:
+    paths: list[str] = []
+    for line in status_lines:
+        if len(line) < 4:
+            continue
+        path = line[3:].strip()
+        if " -> " in path:
+            path = path.rsplit(" -> ", 1)[1]
+        path = path.strip('"')
+        if path.startswith(DIRTY_PATH_PREFIXES) or path in DIRTY_PATH_NAMES:
+            paths.append(path)
+    return paths
+
+
+def _is_immutable_revision(revision: str | None) -> bool:
+    return isinstance(revision, str) and IMMUTABLE_REVISION_RE.fullmatch(revision) is not None
 
 
 def _now() -> str:

--- a/tests/test_external_skillrouter_prediction_export.py
+++ b/tests/test_external_skillrouter_prediction_export.py
@@ -1,0 +1,359 @@
+import gzip
+import json
+import shutil
+from pathlib import Path
+
+import pytest
+
+from hermes_skilleval.cli import main
+from hermes_skilleval.external.skillrouter_scorer import score_skillrouter_predictions
+from hermes_skilleval.external.skillrouter_prediction_export import (
+    FrozenRouterConfig,
+    write_skillrouter_prediction_artifacts,
+    write_skillrouter_prediction_file,
+)
+from hermes_skilleval.routers.embedding import HashingEmbeddingModel
+from hermes_skilleval.release_manifest import sha256_file
+
+
+FIXTURE = Path(__file__).parent / "fixtures" / "external" / "skillrouter_eval_core_tiny"
+
+
+def test_exported_predictions_are_accepted_by_existing_scorer_and_manifested(tmp_path):
+    manifest = write_skillrouter_prediction_artifacts(
+        data_root=FIXTURE,
+        output_dir=tmp_path / "predictions",
+        run_id="fixture-export",
+        configs=[
+            FrozenRouterConfig(
+                router_id="baseline-minilm",
+                config_id="baseline-minilm__metadata__easy",
+                field_view="metadata",
+                tier="easy",
+                model_name="sentence-transformers/all-MiniLM-L6-v2",
+                model_revision="fixture-revision",
+            )
+        ],
+        top_k=50,
+        command=["skilleval", "external-export-predictions", "--fixture"],
+        embedding_model=HashingEmbeddingModel(dimensions=64),
+    )
+
+    artifact = manifest["artifacts"][0]
+    predictions_path = Path(artifact["output_path"])
+    predictions = json.loads(predictions_path.read_text(encoding="utf-8"))
+    assert set(predictions) == {
+        "task-single-easy",
+        "task-multi-hard",
+        "task-generic-easy",
+        "task-medium-easy-pool",
+    }
+    assert artifact["sha256"] == sha256_file(predictions_path)
+    assert artifact["size_bytes"] == predictions_path.stat().st_size
+    assert manifest["relevance_labels_read"] is False
+    assert manifest["top_k"] == 50
+    assert manifest["code"]["commit"]
+    assert manifest["command"] == ["skilleval", "external-export-predictions", "--fixture"]
+
+    report = score_skillrouter_predictions(
+        data_root=FIXTURE,
+        predictions_path=predictions_path,
+        tier="easy",
+        mode="core",
+    )
+    assert report["aggregates"]["all"]["task_count"] == 2
+
+
+def test_exporter_filters_predictions_to_selected_candidate_tier(tmp_path):
+    manifest = write_skillrouter_prediction_artifacts(
+        data_root=FIXTURE,
+        output_dir=tmp_path / "predictions",
+        run_id="tier-export",
+        configs=[
+            FrozenRouterConfig(
+                router_id="baseline-minilm",
+                config_id="baseline-minilm__full_body__easy",
+                field_view="full_body",
+                tier="easy",
+                model_name="sentence-transformers/all-MiniLM-L6-v2",
+                model_revision="fixture-revision",
+            ),
+            FrozenRouterConfig(
+                router_id="baseline-minilm",
+                config_id="baseline-minilm__full_body__hard",
+                field_view="full_body",
+                tier="hard",
+                model_name="sentence-transformers/all-MiniLM-L6-v2",
+                model_revision="fixture-revision",
+            ),
+        ],
+        top_k=50,
+        command=["fixture"],
+        embedding_model=HashingEmbeddingModel(dimensions=64),
+    )
+
+    by_config = {artifact["config_id"]: artifact for artifact in manifest["artifacts"]}
+    easy_predictions = json.loads(
+        Path(by_config["baseline-minilm__full_body__easy"]["output_path"]).read_text(
+            encoding="utf-8"
+        )
+    )
+    hard_predictions = json.loads(
+        Path(by_config["baseline-minilm__full_body__hard"]["output_path"]).read_text(
+            encoding="utf-8"
+        )
+    )
+    easy_ids = {skill_id for ranking in easy_predictions.values() for skill_id in ranking}
+    hard_ids = {skill_id for ranking in hard_predictions.values() for skill_id in ranking}
+    assert easy_ids == {
+        "gt/browser-login",
+        "degraded/browser-login",
+        "gt/medium-easy",
+    }
+    assert hard_ids == {
+        "gt/workflow-debugging",
+        "gt/tdd-helper",
+        "degraded/workflow-debugging",
+    }
+
+
+def test_exporter_is_deterministic_and_deduplicates_rankings(tmp_path):
+    root = _fixture_with_duplicate_easy_skill(tmp_path)
+    kwargs = {
+        "data_root": root,
+        "run_id": "dedupe-export",
+        "configs": [
+            FrozenRouterConfig(
+                router_id="baseline-minilm",
+                config_id="baseline-minilm__name_only__easy",
+                field_view="name_only",
+                tier="easy",
+                model_name="sentence-transformers/all-MiniLM-L6-v2",
+                model_revision="fixture-revision",
+            )
+        ],
+        "top_k": 50,
+        "command": ["fixture"],
+        "embedding_model": HashingEmbeddingModel(dimensions=64),
+    }
+
+    first = write_skillrouter_prediction_artifacts(
+        output_dir=tmp_path / "first",
+        **kwargs,
+    )
+    second = write_skillrouter_prediction_artifacts(
+        output_dir=tmp_path / "second",
+        **kwargs,
+    )
+
+    first_predictions = json.loads(
+        Path(first["artifacts"][0]["output_path"]).read_text(encoding="utf-8")
+    )
+    second_predictions = json.loads(
+        Path(second["artifacts"][0]["output_path"]).read_text(encoding="utf-8")
+    )
+    assert first_predictions == second_predictions
+    for ranking in first_predictions.values():
+        assert len(ranking) == len(set(ranking))
+
+
+def test_prediction_file_writer_fails_closed_on_unknown_skill_id(tmp_path):
+    with pytest.raises(ValueError, match="unknown predicted skill id"):
+        write_skillrouter_prediction_file(
+            output_path=tmp_path / "predictions.json",
+            predictions={"task-1": ["missing-skill"]},
+            task_ids={"task-1"},
+            tier_skill_ids={"known-skill"},
+        )
+
+
+def test_exporter_enforces_top_k_and_minimum_official_depth(tmp_path):
+    root = _fixture_with_many_easy_skills(tmp_path, count=55)
+    config = FrozenRouterConfig(
+        router_id="baseline-minilm",
+        config_id="baseline-minilm__metadata__easy",
+        field_view="metadata",
+        tier="easy",
+        model_name="sentence-transformers/all-MiniLM-L6-v2",
+        model_revision="fixture-revision",
+    )
+
+    with pytest.raises(ValueError, match="top_k must be at least 50"):
+        write_skillrouter_prediction_artifacts(
+            data_root=root,
+            output_dir=tmp_path / "too-shallow",
+            run_id="bad-top-k",
+            configs=[config],
+            top_k=49,
+            command=["fixture"],
+            embedding_model=HashingEmbeddingModel(dimensions=64),
+        )
+
+    manifest = write_skillrouter_prediction_artifacts(
+        data_root=root,
+        output_dir=tmp_path / "predictions",
+        run_id="top-k-export",
+        configs=[config],
+        top_k=50,
+        command=["fixture"],
+        embedding_model=HashingEmbeddingModel(dimensions=64),
+    )
+    predictions = json.loads(
+        Path(manifest["artifacts"][0]["output_path"]).read_text(encoding="utf-8")
+    )
+    assert all(len(ranking) == 50 for ranking in predictions.values())
+
+
+def test_exporter_manifest_includes_hash_and_size_for_every_prediction_file(tmp_path):
+    manifest = write_skillrouter_prediction_artifacts(
+        data_root=FIXTURE,
+        output_dir=tmp_path / "predictions",
+        run_id="manifest-export",
+        configs=[
+            FrozenRouterConfig(
+                router_id="baseline-minilm",
+                config_id="baseline-minilm__metadata__easy",
+                field_view="metadata",
+                tier="easy",
+                model_name="sentence-transformers/all-MiniLM-L6-v2",
+                model_revision="fixture-revision",
+            ),
+            FrozenRouterConfig(
+                router_id="baseline-minilm",
+                config_id="baseline-minilm__metadata__hard",
+                field_view="metadata",
+                tier="hard",
+                model_name="sentence-transformers/all-MiniLM-L6-v2",
+                model_revision="fixture-revision",
+            ),
+        ],
+        top_k=50,
+        command=["fixture"],
+        embedding_model=HashingEmbeddingModel(dimensions=64),
+    )
+
+    assert len(manifest["artifacts"]) == 2
+    for artifact in manifest["artifacts"]:
+        output_path = Path(artifact["output_path"])
+        assert artifact["status"] == "PASS"
+        assert artifact["sha256"] == sha256_file(output_path)
+        assert artifact["size_bytes"] == output_path.stat().st_size
+        assert artifact["candidate_pool"]["sha256"]
+        assert artifact["candidate_pool"]["size_bytes"] > 0
+
+
+def test_exporter_fails_closed_on_duplicate_config_id(tmp_path):
+    config = FrozenRouterConfig(
+        router_id="baseline-minilm",
+        config_id="duplicated",
+        field_view="metadata",
+        tier="easy",
+        model_name="sentence-transformers/all-MiniLM-L6-v2",
+        model_revision="fixture-revision",
+    )
+
+    with pytest.raises(ValueError, match="duplicate config_id"):
+        write_skillrouter_prediction_artifacts(
+            data_root=FIXTURE,
+            output_dir=tmp_path / "predictions",
+            run_id="duplicate-export",
+            configs=[config, config],
+            top_k=50,
+            command=["fixture"],
+            embedding_model=HashingEmbeddingModel(dimensions=64),
+        )
+
+
+def test_exporter_does_not_require_relevance_json_for_prediction_generation(tmp_path):
+    root = tmp_path / "without-relevance"
+    shutil.copytree(FIXTURE, root)
+    (root / "relevance.json").unlink()
+
+    manifest = write_skillrouter_prediction_artifacts(
+        data_root=root,
+        output_dir=tmp_path / "predictions",
+        run_id="no-relevance-export",
+        configs=[
+            FrozenRouterConfig(
+                router_id="baseline-minilm",
+                config_id="baseline-minilm__name_only__easy",
+                field_view="name_only",
+                tier="easy",
+                model_name="sentence-transformers/all-MiniLM-L6-v2",
+                model_revision="fixture-revision",
+            )
+        ],
+        top_k=50,
+        command=["fixture"],
+        embedding_model=HashingEmbeddingModel(dimensions=64),
+    )
+
+    assert manifest["relevance_labels_read"] is False
+    assert Path(manifest["artifacts"][0]["output_path"]).exists()
+
+
+def test_cli_external_export_predictions_writes_manifest_and_unavailable_entries(tmp_path):
+    output_dir = tmp_path / "cli-predictions"
+
+    exit_code = main(
+        [
+            "external-export-predictions",
+            "--benchmark",
+            "skillrouter",
+            "--data-root",
+            str(FIXTURE),
+            "--output-dir",
+            str(output_dir),
+            "--run-id",
+            "cli-export",
+            "--embedding-backend",
+            "hashing",
+            "--baseline-minilm-revision",
+            "fixture-revision",
+            "--router-config",
+            "baseline-minilm:metadata:easy",
+            "--router-config",
+            "finetuned-embedding:metadata:easy",
+        ]
+    )
+
+    assert exit_code == 0
+    manifest = json.loads((output_dir / "manifest.json").read_text(encoding="utf-8"))
+    by_config = {artifact["config_id"]: artifact for artifact in manifest["artifacts"]}
+    assert by_config["baseline-minilm__metadata__easy"]["status"] == "PASS"
+    assert Path(by_config["baseline-minilm__metadata__easy"]["output_path"]).exists()
+    assert by_config["finetuned-embedding__metadata__easy"]["status"] == "UNAVAILABLE"
+    assert "checkpoint_path is not configured" in by_config[
+        "finetuned-embedding__metadata__easy"
+    ]["reason"]
+
+
+def _fixture_with_duplicate_easy_skill(tmp_path: Path) -> Path:
+    root = tmp_path / "duplicate-skill"
+    shutil.copytree(FIXTURE, root)
+    shard = root / "easy" / "shard-000.jsonl.gz"
+    rows = gzip.open(shard, "rt", encoding="utf-8").read().splitlines()
+    rows.append(rows[0])
+    with gzip.open(shard, "wt", encoding="utf-8") as handle:
+        handle.write("\n".join(rows) + "\n")
+    return root
+
+
+def _fixture_with_many_easy_skills(tmp_path: Path, *, count: int) -> Path:
+    root = tmp_path / "many-skills"
+    shutil.copytree(FIXTURE, root)
+    shard = root / "easy" / "shard-000.jsonl.gz"
+    rows = [
+        {
+            "id": f"fixture/skill-{index:03d}",
+            "name": f"Fixture Skill {index:03d}",
+            "description": f"Fixture skill number {index:03d}",
+            "body": f"Use fixture skill {index:03d} for deterministic routing.",
+            "tier": "easy",
+        }
+        for index in range(count)
+    ]
+    with gzip.open(shard, "wt", encoding="utf-8") as handle:
+        for row in rows:
+            handle.write(json.dumps(row, sort_keys=True) + "\n")
+    return root

--- a/tests/test_external_skillrouter_prediction_export.py
+++ b/tests/test_external_skillrouter_prediction_export.py
@@ -302,6 +302,62 @@ def test_exporter_does_not_require_relevance_json_for_prediction_generation(tmp_
     assert Path(manifest["artifacts"][0]["output_path"]).exists()
 
 
+def test_final_evidence_rejects_injected_embedding_model(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "hermes_skilleval.external.skillrouter_prediction_export._git_state",
+        lambda: {"commit": "fixture", "tag": None, "dirty": False, "dirty_paths": []},
+    )
+    with pytest.raises(ValueError, match="final evidence cannot use injected embedding models"):
+        write_skillrouter_prediction_artifacts(
+            data_root=FIXTURE,
+            output_dir=tmp_path / "predictions",
+            run_id="final-injected",
+            configs=[
+                FrozenRouterConfig(
+                    router_id="baseline-minilm",
+                    config_id="baseline-minilm__metadata__easy",
+                    field_view="metadata",
+                    tier="easy",
+                    model_name="sentence-transformers/all-MiniLM-L6-v2",
+                    model_revision="0" * 40,
+                )
+            ],
+            top_k=50,
+            command=["fixture"],
+            embedding_model=HashingEmbeddingModel(dimensions=64),
+            final_evidence=True,
+        )
+
+
+def test_final_baseline_minilm_requires_canonical_model_name(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "hermes_skilleval.external.skillrouter_prediction_export._git_state",
+        lambda: {"commit": "fixture", "tag": None, "dirty": False, "dirty_paths": []},
+    )
+    manifest = write_skillrouter_prediction_artifacts(
+        data_root=FIXTURE,
+        output_dir=tmp_path / "predictions",
+        run_id="wrong-model",
+        configs=[
+            FrozenRouterConfig(
+                router_id="baseline-minilm",
+                config_id="baseline-minilm__metadata__easy",
+                field_view="metadata",
+                tier="easy",
+                model_name="sentence-transformers/not-minilm",
+                model_revision="0" * 40,
+            )
+        ],
+        top_k=50,
+        command=["fixture"],
+        final_evidence=True,
+    )
+
+    artifact = manifest["artifacts"][0]
+    assert artifact["status"] == "UNAVAILABLE"
+    assert "canonical model_name" in artifact["reason"]
+
+
 def test_cli_hashing_backend_cannot_label_baseline_minilm_artifacts(tmp_path):
     output_dir = tmp_path / "cli-predictions"
 
@@ -478,6 +534,8 @@ def test_dirty_code_path_detection_covers_staged_unstaged_and_untracked_sources(
         "M  src/hermes_skilleval/cli.py",
         " M tests/test_external_skillrouter_prediction_export.py",
         "?? src/hermes_skilleval/new_file.py",
+        "?? configs/v0.3/export.yaml",
+        " M configs/v0.3/plan.yaml",
         "?? artifacts/v0.3/run/output.json",
     ]
 
@@ -485,6 +543,8 @@ def test_dirty_code_path_detection_covers_staged_unstaged_and_untracked_sources(
         "src/hermes_skilleval/cli.py",
         "tests/test_external_skillrouter_prediction_export.py",
         "src/hermes_skilleval/new_file.py",
+        "configs/v0.3/export.yaml",
+        "configs/v0.3/plan.yaml",
     ]
 
 

--- a/tests/test_external_skillrouter_prediction_export.py
+++ b/tests/test_external_skillrouter_prediction_export.py
@@ -9,6 +9,8 @@ from hermes_skilleval.cli import main
 from hermes_skilleval.external.skillrouter_scorer import score_skillrouter_predictions
 from hermes_skilleval.external.skillrouter_prediction_export import (
     FrozenRouterConfig,
+    _dirty_code_paths,
+    _path_sha256,
     write_skillrouter_prediction_artifacts,
     write_skillrouter_prediction_file,
 )
@@ -54,6 +56,14 @@ def test_exported_predictions_are_accepted_by_existing_scorer_and_manifested(tmp
     assert manifest["top_k"] == 50
     assert manifest["code"]["commit"]
     assert manifest["command"] == ["skilleval", "external-export-predictions", "--fixture"]
+    assert manifest["task_input"]["path"] == "tasks.jsonl"
+    assert manifest["task_input"]["sha256"] == sha256_file(FIXTURE / "tasks.jsonl")
+    assert manifest["task_input"]["size_bytes"] == (FIXTURE / "tasks.jsonl").stat().st_size
+    assert manifest["task_input"]["task_count"] == 4
+    assert artifact["router_family"] == "embedding"
+    assert artifact["embedding_backend"] == "test-injected"
+    assert artifact["text_builder"]["field_view"] == "metadata"
+    assert artifact["text_builder"]["builder_version"]
 
     report = score_skillrouter_predictions(
         data_root=FIXTURE,
@@ -292,7 +302,7 @@ def test_exporter_does_not_require_relevance_json_for_prediction_generation(tmp_
     assert Path(manifest["artifacts"][0]["output_path"]).exists()
 
 
-def test_cli_external_export_predictions_writes_manifest_and_unavailable_entries(tmp_path):
+def test_cli_hashing_backend_cannot_label_baseline_minilm_artifacts(tmp_path):
     output_dir = tmp_path / "cli-predictions"
 
     exit_code = main(
@@ -312,6 +322,50 @@ def test_cli_external_export_predictions_writes_manifest_and_unavailable_entries
             "fixture-revision",
             "--router-config",
             "baseline-minilm:metadata:easy",
+        ]
+    )
+
+    assert exit_code == 2
+    assert not (output_dir / "manifest.json").exists()
+
+
+def test_cli_rejects_mutable_baseline_minilm_revision(tmp_path):
+    exit_code = main(
+        [
+            "external-export-predictions",
+            "--benchmark",
+            "skillrouter",
+            "--data-root",
+            str(FIXTURE),
+            "--output-dir",
+            str(tmp_path / "cli-predictions"),
+            "--run-id",
+            "cli-export",
+            "--baseline-minilm-revision",
+            "main",
+            "--router-config",
+            "baseline-minilm:metadata:easy",
+        ]
+    )
+
+    assert exit_code == 2
+
+
+def test_cli_external_export_predictions_records_unavailable_finetuned(tmp_path):
+    output_dir = tmp_path / "cli-predictions"
+
+    exit_code = main(
+        [
+            "external-export-predictions",
+            "--benchmark",
+            "skillrouter",
+            "--data-root",
+            str(FIXTURE),
+            "--output-dir",
+            str(output_dir),
+            "--run-id",
+            "cli-export",
+            "--non-final",
             "--router-config",
             "finetuned-embedding:metadata:easy",
         ]
@@ -320,12 +374,118 @@ def test_cli_external_export_predictions_writes_manifest_and_unavailable_entries
     assert exit_code == 0
     manifest = json.loads((output_dir / "manifest.json").read_text(encoding="utf-8"))
     by_config = {artifact["config_id"]: artifact for artifact in manifest["artifacts"]}
-    assert by_config["baseline-minilm__metadata__easy"]["status"] == "PASS"
-    assert Path(by_config["baseline-minilm__metadata__easy"]["output_path"]).exists()
     assert by_config["finetuned-embedding__metadata__easy"]["status"] == "UNAVAILABLE"
     assert "checkpoint_path is not configured" in by_config[
         "finetuned-embedding__metadata__easy"
     ]["reason"]
+
+
+def test_finetuned_checkpoint_matching_sha_is_verified(tmp_path):
+    checkpoint = tmp_path / "checkpoint"
+    checkpoint.mkdir()
+    (checkpoint / "weights.bin").write_text("fixture checkpoint\n", encoding="utf-8")
+    expected = _path_sha256(checkpoint)
+
+    manifest = write_skillrouter_prediction_artifacts(
+        data_root=FIXTURE,
+        output_dir=tmp_path / "predictions",
+        run_id="finetuned-export",
+        configs=[
+            FrozenRouterConfig(
+                router_id="finetuned-embedding",
+                config_id="finetuned-embedding__metadata__easy",
+                field_view="metadata",
+                tier="easy",
+                model_name="finetuned-embedding",
+                checkpoint_path=str(checkpoint),
+                checkpoint_sha256=expected,
+            )
+        ],
+        top_k=50,
+        command=["fixture"],
+        embedding_model=HashingEmbeddingModel(dimensions=64),
+    )
+
+    model = manifest["artifacts"][0]["model"]
+    assert manifest["artifacts"][0]["status"] == "PASS"
+    assert model["provided_checkpoint_sha256"] == expected
+    assert model["actual_checkpoint_sha256"] == expected
+    assert model["checkpoint_hash_verified"] is True
+
+
+def test_finetuned_checkpoint_mismatching_sha_fails_closed(tmp_path):
+    checkpoint = tmp_path / "checkpoint.bin"
+    checkpoint.write_text("fixture checkpoint\n", encoding="utf-8")
+
+    manifest = write_skillrouter_prediction_artifacts(
+        data_root=FIXTURE,
+        output_dir=tmp_path / "predictions",
+        run_id="finetuned-export",
+        configs=[
+            FrozenRouterConfig(
+                router_id="finetuned-embedding",
+                config_id="finetuned-embedding__metadata__easy",
+                field_view="metadata",
+                tier="easy",
+                model_name="finetuned-embedding",
+                checkpoint_path=str(checkpoint),
+                checkpoint_sha256="0" * 64,
+            )
+        ],
+        top_k=50,
+        command=["fixture"],
+        embedding_model=HashingEmbeddingModel(dimensions=64),
+    )
+
+    artifact = manifest["artifacts"][0]
+    assert artifact["status"] == "UNAVAILABLE"
+    assert "checkpoint sha256 mismatch" in artifact["reason"]
+
+
+def test_finetuned_checkpoint_missing_sha_records_computed_digest(tmp_path):
+    checkpoint = tmp_path / "checkpoint.bin"
+    checkpoint.write_text("fixture checkpoint\n", encoding="utf-8")
+    actual = _path_sha256(checkpoint)
+
+    manifest = write_skillrouter_prediction_artifacts(
+        data_root=FIXTURE,
+        output_dir=tmp_path / "predictions",
+        run_id="finetuned-export",
+        configs=[
+            FrozenRouterConfig(
+                router_id="finetuned-embedding",
+                config_id="finetuned-embedding__metadata__easy",
+                field_view="metadata",
+                tier="easy",
+                model_name="finetuned-embedding",
+                checkpoint_path=str(checkpoint),
+            )
+        ],
+        top_k=50,
+        command=["fixture"],
+        embedding_model=HashingEmbeddingModel(dimensions=64),
+    )
+
+    model = manifest["artifacts"][0]["model"]
+    assert manifest["artifacts"][0]["status"] == "PASS"
+    assert model["provided_checkpoint_sha256"] is None
+    assert model["actual_checkpoint_sha256"] == actual
+    assert model["checkpoint_hash_verified"] is False
+
+
+def test_dirty_code_path_detection_covers_staged_unstaged_and_untracked_sources():
+    status_lines = [
+        "M  src/hermes_skilleval/cli.py",
+        " M tests/test_external_skillrouter_prediction_export.py",
+        "?? src/hermes_skilleval/new_file.py",
+        "?? artifacts/v0.3/run/output.json",
+    ]
+
+    assert _dirty_code_paths(status_lines) == [
+        "src/hermes_skilleval/cli.py",
+        "tests/test_external_skillrouter_prediction_export.py",
+        "src/hermes_skilleval/new_file.py",
+    ]
 
 
 def _fixture_with_duplicate_easy_skill(tmp_path: Path) -> Path:


### PR DESCRIPTION
This is Stage 1.5 evidence collection tooling, not PR-8.

No real prediction artifacts were generated in this patch.

No Stage 2 work was started.

No scorer/matrix/gate/live-agent semantics changed.

It adds a frozen SkillRouter prediction exporter with final-evidence provenance guards.

Test results:
- `python -m pytest -q tests/test_external_skillrouter_prediction_export.py` -> 17 passed
- targeted external scorer/matrix/evidence-gate tests -> 82 passed
- `python -m pytest -q` -> 606 passed
- `openspec validate --all --strict` -> 23 passed
- `release-check` -> PASS
- `git diff --check` -> pass