### PR TITLE
ops: prepare Stage 2 real Codex pilot inputs

### DIFF
--- a/artifacts/v0.3/skillsbench-pilot/v0.3-stage2-real-codex-pilot-prep-missing-inputs-20260629T053333Z/stage2-real-codex-pilot-prep-missing-input-report.json
+++ b/artifacts/v0.3/skillsbench-pilot/v0.3-stage2-real-codex-pilot-prep-missing-inputs-20260629T053333Z/stage2-real-codex-pilot-prep-missing-input-report.json
@@ -1,0 +1,78 @@
+{
+  "schema_version": "v0.3.stage2-real-codex-pilot-prep.v1",
+  "status": "BLOCKED_MISSING_INPUTS",
+  "created_at": "2026-06-29T05:33:33Z",
+  "branch": "ops/prepare-stage2-real-codex-pilot-inputs",
+  "base_accepted_blocked_artifact_commit": "98eec36601cd504c3c9466ed36ed7fd4421fb1fa",
+  "previous_blocked_report": "artifacts/v0.3/skillsbench-pilot/v0.3-stage2-pilot-blocked-20260629T045907Z/stage2-pilot-blocked-report.json",
+  "requested_pilot_shape": {
+    "task_count": 4,
+    "conditions": [
+      "no-skill",
+      "routed-skill",
+      "oracle-skill"
+    ],
+    "trials_per_condition": 1,
+    "total_runs": 12,
+    "evidence_label": "pilot_non_final"
+  },
+  "inspection_summary": {
+    "blocked_report": "Accepted Stage 2 report already recorded missing real or approved 4-task SkillsBench data, deterministic verifier artifacts, oracle qualification, routed predictions, and real matrix runner wiring.",
+    "runbook": "Stage 2 pilot is a wiring and safety check only, not frozen live-agent evidence or a performance claim.",
+    "live_agent_runtime": "CodexCliRunner exists with isolated CODEX_HOME/HOME preflight and no-skill leakage checks.",
+    "live_agent_skillsbench": "Plan and matrix helpers existed, but fixture defaults needed real-evidence fail-closed guards.",
+    "skillsbench_live_matrix_tests": "Fixture tests remain allowed for unit coverage only.",
+    "codex_cli_runner_tests": "Fake Codex executables remain test doubles, not real evidence.",
+    "live_agent_config": "Config remains placeholder-only and not executable evidence."
+  },
+  "preparation_results": {
+    "real_or_approved_four_task_data_root": {
+      "status": "BLOCKED",
+      "reason": "No non-fixture or explicitly approved SkillsBench pilot data root with exactly 4 selectable tasks is present in this branch."
+    },
+    "deterministic_verifier_artifacts": {
+      "status": "BLOCKED",
+      "reason": "No deterministic verifier implementation/artifact set was provided for 4 real pilot tasks. Real evidence mode now requires verifier code/config/input hashes before execution."
+    },
+    "oracle_qualification": {
+      "status": "BLOCKED",
+      "reason": "No oracle qualification artifact exists for 4 real tasks. Real evidence mode now requires task hash, verifier hash, skill hash, trials, pass rate, and constraints."
+    },
+    "routed_predictions": {
+      "status": "BLOCKED",
+      "reason": "No routed prediction artifact exists for 4 real tasks. Routed prediction envelopes now record router id, config hash, top-k, per-task prediction hash, and global registry hash."
+    },
+    "real_codex_runner_path": {
+      "status": "PREPARED_BUT_NOT_EXECUTED",
+      "reason": "skillsbench-matrix exposes CodexCliRunner via --runner codex-cli and --evidence-mode real. Real mode fails closed without an explicit deterministic verifier and final-evidence preflight."
+    },
+    "stage2_pilot_shape_support": {
+      "status": "PREPARED_BUT_NOT_FROZEN",
+      "reason": "Pilot mode supports 4 selected tasks x 3 conditions x 1 trial = 12 matrix entries. No real pilot plan was frozen in this branch."
+    }
+  },
+  "new_fail_closed_guards": [
+    "Real evidence mode rejects tests/fixtures/live_agent/skillsbench_tiny and other fixture-only SkillsBench data.",
+    "Real evidence mode rejects FakeAgentRunner and FakeVerifier.",
+    "Real evidence mode requires a runner preflight event proving final-evidence mode, isolated CODEX_HOME, and isolated HOME.",
+    "Real evidence mode requires task/verifier/oracle/routing hashes before matrix execution."
+  ],
+  "non_actions": {
+    "stage2_pilot_run": false,
+    "codex_cli_run": false,
+    "pilot_plan_frozen": false,
+    "live_agent_traces_created": false,
+    "evidence_gate_rerun_with_fake_live_artifacts": false,
+    "fixture_data_used_as_real_evidence": false,
+    "fake_runner_or_verifier_used_as_real_evidence": false,
+    "scorer_matrix_or_evidence_gate_semantics_modified": false,
+    "performance_claims": false
+  },
+  "remaining_blockers": [
+    "Provide or approve a non-fixture SkillsBench pilot data root with exactly 4 selectable tasks.",
+    "Provide deterministic verifier code/config/input artifacts for each selected task.",
+    "Run and record non-fabricated oracle qualification for all 4 tasks.",
+    "Provide routed predictions over the global skill registry with router id, config hash, and top-k.",
+    "Add a deterministic verifier integration to pair with CodexCliRunner for real matrix execution."
+  ]
+}

--- a/artifacts/v0.3/skillsbench-pilot/v0.3-stage2-real-codex-pilot-prep-missing-inputs-20260629T053333Z/stage2-real-codex-pilot-prep-missing-input-report.md
+++ b/artifacts/v0.3/skillsbench-pilot/v0.3-stage2-real-codex-pilot-prep-missing-inputs-20260629T053333Z/stage2-real-codex-pilot-prep-missing-input-report.md
@@ -1,0 +1,57 @@
+# Stage 2 Real Codex Pilot Prep Missing Inputs
+
+Status: `BLOCKED_MISSING_INPUTS`
+
+Created: `2026-06-29T05:33:33Z`
+
+Branch: `ops/prepare-stage2-real-codex-pilot-inputs`
+
+Base accepted blocked artifact commit:
+`98eec36601cd504c3c9466ed36ed7fd4421fb1fa`
+
+## Conclusion
+
+The branch prepared fail-closed real-evidence guards and exposed the real
+`CodexCliRunner` path, but it did not prepare a runnable Stage 2 pilot package
+because the real 4-task inputs, deterministic verifier artifacts, oracle
+qualification, routed predictions, and deterministic verifier integration are
+still missing.
+
+## Requested Pilot Shape
+
+- 4 selected SkillsBench tasks.
+- 3 conditions per task: `no-skill`, `routed-skill`, `oracle-skill`.
+- 1 trial per condition.
+- 12 total runs.
+- Evidence label: `pilot_non_final`.
+
+## Prepared
+
+- Real evidence mode rejects fixture-only SkillsBench data.
+- Real evidence mode rejects `FakeAgentRunner` and `FakeVerifier`.
+- Real evidence mode requires final-evidence runner preflight with isolated
+  `CODEX_HOME` and `HOME`.
+- Plans now record task hashes, prompt hashes, verifier hashes, verifier
+  code/config/input hashes, oracle qualification hashes, routed prediction
+  hashes, router/config/top-k metadata, and global registry hash.
+- `skillsbench-matrix` now exposes `--runner codex-cli` and
+  `--evidence-mode real`.
+
+## Still Missing
+
+- A non-fixture or explicitly approved 4-task SkillsBench pilot data root.
+- Deterministic verifier code/config/input artifacts for all 4 tasks.
+- Oracle qualification records for all 4 tasks.
+- Routed predictions over the global skill registry for all 4 tasks.
+- A deterministic verifier integration for real matrix execution.
+
+## Non-Actions Confirmed
+
+- Stage 2 pilot was not run.
+- Codex CLI was not run.
+- No pilot plan was frozen.
+- No live-agent traces were created.
+- No evidence gate was rerun with fake live artifacts.
+- `tests/fixtures/live_agent/skillsbench_tiny` was not used as real evidence.
+- `FakeAgentRunner` and `FakeVerifier` were not used as real evidence.
+- Scorer, matrix, and evidence-gate semantics were not modified.

--- a/configs/v0.3/live-agent.yaml
+++ b/configs/v0.3/live-agent.yaml
@@ -39,6 +39,31 @@ conditions:
   - routed-skill
   - oracle-skill
 
+pilot_preparation:
+  status: missing_real_inputs
+  evidence_label: pilot_non_final
+  task_count: 4
+  trials_per_condition: 1
+  total_runs: 12
+  require_non_fixture_data_root: true
+  reject_fixture_data_root: "tests/fixtures/live_agent/skillsbench_tiny"
+  reject_fake_runner: true
+  reject_fake_verifier: true
+  require_real_runner_preflight: true
+  require_verifier_artifact_hashes:
+    - code
+    - config
+    - input
+  require_oracle_qualification_hashes:
+    - task_hash
+    - verifier_hash
+    - skill_hash
+  require_routed_prediction_metadata:
+    - router_id
+    - config_hash
+    - top_k
+    - global_skill_registry_hash
+
 trials_per_condition: 3
 
 judging:

--- a/configs/v0.3/live-agent.yaml
+++ b/configs/v0.3/live-agent.yaml
@@ -64,7 +64,11 @@ pilot_preparation:
     - top_k
     - global_skill_registry_hash
 
-trials_per_condition: 3
+frozen_live_agent_evaluation:
+  # Future frozen live-agent evaluation only. This is not the Stage 2 pilot.
+  # The Stage 2 pilot shape remains 4 tasks x 3 conditions x 1 trial = 12 runs.
+  status: future_only_after_pilot_acceptance
+  trials_per_condition: 3
 
 judging:
   primary_success_judge: deterministic_verifier

--- a/docs/human-briefs/2026-06-29-prepare-stage2-real-codex-pilot-inputs.html
+++ b/docs/human-briefs/2026-06-29-prepare-stage2-real-codex-pilot-inputs.html
@@ -1,0 +1,110 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Stage 2 Real Codex Pilot Inputs Prep</title>
+  <style>
+    body {
+      margin: 0;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      color: #17202a;
+      background: #f7f8fa;
+      line-height: 1.55;
+    }
+    main {
+      max-width: 980px;
+      margin: 0 auto;
+      padding: 40px 24px 56px;
+    }
+    h1 {
+      margin: 0 0 8px;
+      font-size: 28px;
+      letter-spacing: 0;
+    }
+    h2 {
+      margin-top: 28px;
+      font-size: 18px;
+      letter-spacing: 0;
+    }
+    code {
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      background: #eceff3;
+      padding: 2px 5px;
+      border-radius: 4px;
+    }
+    .status {
+      display: inline-block;
+      margin: 10px 0 22px;
+      padding: 5px 9px;
+      border-radius: 6px;
+      color: #7a3f00;
+      background: #fff1d6;
+      font-weight: 600;
+    }
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+      gap: 12px;
+    }
+    .item {
+      background: #ffffff;
+      border: 1px solid #d9dee7;
+      border-radius: 8px;
+      padding: 14px 16px;
+    }
+    ul {
+      padding-left: 20px;
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>Stage 2 Real Codex Pilot 输入准备</h1>
+    <div class="status">结论：仍然阻塞，未执行 Pilot</div>
+
+    <p>
+      本阶段只做窄口准备：把真实证据模式的失败边界补齐，并写出缺失输入报告。
+      当前没有可用的非 fixture 4 任务 SkillsBench 数据根、确定性 verifier 集成、
+      oracle qualification 和 routed predictions，因此不能冻结计划，也不能运行 Stage 2。
+    </p>
+
+    <h2>本阶段改动</h2>
+    <div class="grid">
+      <div class="item">新增 real evidence mode：拒绝 fixture-only 数据、FakeAgentRunner、FakeVerifier。</div>
+      <div class="item">计划文件记录 task、prompt、verifier、verifier artifacts、oracle、routing 和全局 registry 哈希。</div>
+      <div class="item"><code>skillsbench-matrix</code> 暴露 <code>--runner codex-cli</code> 与 <code>--evidence-mode real</code>。</div>
+      <div class="item">新增缺失输入报告，明确后续需要补齐哪些真实前提。</div>
+    </div>
+
+    <h2>关键文件</h2>
+    <ul>
+      <li><code>src/hermes_skilleval/live_agent_skillsbench.py</code></li>
+      <li><code>src/hermes_skilleval/cli.py</code></li>
+      <li><code>tests/test_skillsbench_live_matrix.py</code></li>
+      <li><code>artifacts/v0.3/skillsbench-pilot/v0.3-stage2-real-codex-pilot-prep-missing-inputs-20260629T053333Z/</code></li>
+    </ul>
+
+    <h2>验证</h2>
+    <p>
+      初始 RED：focused SkillsBench 测试新增 4 个失败；实现后 focused
+      SkillsBench 测试通过。最终完整验证命令以本分支最终总结为准。
+    </p>
+
+    <h2>剩余阻塞</h2>
+    <ul>
+      <li>缺少真实或明确批准的 4 任务数据根。</li>
+      <li>缺少 4 个任务的确定性 verifier code/config/input artifacts。</li>
+      <li>缺少不可伪造的 oracle qualification。</li>
+      <li>缺少基于全局 skill registry 的 routed predictions。</li>
+      <li>缺少可与 CodexCliRunner 配套的确定性 verifier integration。</li>
+    </ul>
+
+    <h2>不能外宣的内容</h2>
+    <p>
+      不能声称 Stage 2 已运行、Codex pilot 已通过、性能有提升、或 fixture/fake
+      证据可代表真实 live-agent evidence。
+    </p>
+  </main>
+</body>
+</html>

--- a/docs/v0.3/runbook-frozen-evidence.md
+++ b/docs/v0.3/runbook-frozen-evidence.md
@@ -166,6 +166,22 @@ this repository. Do not substitute fake-runner artifacts for final evidence.
 Preserve redacted `live-agent.v1` traces and preflight/global capability
 inventory in the pilot artifact directory.
 
+Before this execution step is allowed, the pilot inputs must pass real evidence
+mode preparation checks:
+
+- the data root is not `tests/fixtures/live_agent/skillsbench_tiny` and is
+  explicitly approved for this pilot;
+- exactly 4 selected tasks expand to 12 planned runs;
+- each selected task records source/provenance, prompt hash, task hash,
+  deterministic verifier hash, and verifier code/config/input hashes;
+- oracle qualification records contain matching task/verifier/skill hashes,
+  trials, pass rate, and constraints;
+- routed predictions record router id, config hash, top-k, per-task prediction
+  hash, and global skill registry hash;
+- real matrix execution uses `--evidence-mode real --runner codex-cli` and
+  fails closed if it would use fixture data, `FakeAgentRunner`, `FakeVerifier`,
+  or a runner without final-evidence isolated-home preflight.
+
 ## 5. Run Evidence Gate On Pilot Artifacts
 
 Run the gate with both external and pilot live-agent artifacts:

--- a/src/hermes_skilleval/cli.py
+++ b/src/hermes_skilleval/cli.py
@@ -1247,6 +1247,8 @@ def _run_skillsbench_plan(args: argparse.Namespace) -> None:
 
 def _run_skillsbench_matrix(args: argparse.Namespace) -> None:
     runner = None
+    if args.runner == "codex-cli" and args.evidence_mode != "real":
+        raise ValueError("--runner codex-cli requires --evidence-mode real")
     if args.runner == "codex-cli":
         runner = CodexCliRunner(
             CodexCliRunnerConfig(

--- a/src/hermes_skilleval/cli.py
+++ b/src/hermes_skilleval/cli.py
@@ -57,6 +57,7 @@ from hermes_skilleval.live_agent_skillsbench import (
     run_skillsbench_matrix,
     write_skillsbench_plan,
 )
+from hermes_skilleval.live_agent_runtime import CodexCliRunner, CodexCliRunnerConfig
 from hermes_skilleval.metrics import (
     abstention_rate,
     accepted_count,
@@ -464,6 +465,20 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     skillsbench_matrix_parser.add_argument("--plan", required=True)
     skillsbench_matrix_parser.add_argument("--output", required=True)
+    skillsbench_matrix_parser.add_argument(
+        "--evidence-mode",
+        choices=("fixture", "real"),
+        default="fixture",
+        help="fixture mode may use fake test runner defaults; real mode fails closed",
+    )
+    skillsbench_matrix_parser.add_argument(
+        "--runner",
+        choices=("fake", "codex-cli"),
+        default="fake",
+        help="runner implementation to configure for matrix execution",
+    )
+    skillsbench_matrix_parser.add_argument("--codex-binary", default="codex")
+    skillsbench_matrix_parser.add_argument("--codex-home-base", default=None)
     skillsbench_matrix_parser.set_defaults(handler=_run_skillsbench_matrix)
 
     evidence_gate_parser = subparsers.add_parser(
@@ -1231,7 +1246,20 @@ def _run_skillsbench_plan(args: argparse.Namespace) -> None:
 
 
 def _run_skillsbench_matrix(args: argparse.Namespace) -> None:
-    report = run_skillsbench_matrix(plan_path=args.plan, output_path=args.output)
+    runner = None
+    if args.runner == "codex-cli":
+        runner = CodexCliRunner(
+            CodexCliRunnerConfig(
+                codex_binary=args.codex_binary,
+                codex_home_base=args.codex_home_base,
+            )
+        )
+    report = run_skillsbench_matrix(
+        plan_path=args.plan,
+        output_path=args.output,
+        runner=runner,
+        evidence_mode=args.evidence_mode,
+    )
     print(
         "SkillsBench live-agent matrix "
         f"{report['run_id']}: {args.output} "

--- a/src/hermes_skilleval/live_agent_skillsbench.py
+++ b/src/hermes_skilleval/live_agent_skillsbench.py
@@ -31,8 +31,10 @@ SEED = 20260625
 CONDITIONS = ("no-skill", "routed-skill", "oracle-skill")
 CONTROLLED_NETWORKS = {"none", "controlled"}
 DEFAULT_ROUTER_TOP_K = 3
+EVIDENCE_MODES = {"fixture", "real"}
 COMMIT_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
 LABEL_LEAKAGE_TOKENS = ("oracle", "gold", "source-task", "source_task")
+VERIFIER_ARTIFACT_ROLES = ("code", "config", "input")
 
 
 @dataclass(frozen=True)
@@ -140,6 +142,13 @@ class SkillsBenchAdapter:
                 errors.append(f"empty prompt for task: {task.task_id}")
             if task.verifier.get("type") != "deterministic":
                 errors.append(f"missing deterministic verifier: {task.task_id}")
+            errors.extend(
+                _verifier_artifact_errors(
+                    verifier=task.verifier,
+                    data_root=self.data_root,
+                    task_id=task.task_id,
+                )
+            )
             if task.requires_private_credentials:
                 errors.append(f"task requires private credentials: {task.task_id}")
             if task.network not in CONTROLLED_NETWORKS:
@@ -244,7 +253,10 @@ def write_skillsbench_plan(
     selected_ids = list(selected_task_ids) or sorted(tasks_by_id)
     selected_tasks = [_selected_task(tasks_by_id, task_id) for task_id in selected_ids]
     skills = adapter.load_skills()
-    routed_predictions = _read_predictions(Path(routed_predictions_path))
+    routed_prediction_artifact = _read_routed_prediction_artifact(
+        Path(routed_predictions_path)
+    )
+    routed_predictions = routed_prediction_artifact["predictions"]
     qualifications = (
         _read_oracle_qualification(Path(oracle_qualification_path))
         if oracle_qualification_path
@@ -261,8 +273,10 @@ def write_skillsbench_plan(
     derived = _derive_plan_fields(
         run_id=run_id,
         selected_tasks=selected_tasks,
+        data_root=Path(data_root),
         skills=skills,
         routed_predictions=routed_predictions,
+        routed_prediction_artifact=routed_prediction_artifact,
         qualifications=qualifications,
         router_top_k=router_top_k,
         skillrouter_tasks=_load_skillrouter_tasks(
@@ -296,10 +310,16 @@ def write_skillsbench_plan(
         "validation": validation,
         "selected_tasks": derived["selected_tasks"],
         "global_skill_registry": derived["global_skill_registry"],
+        "global_skill_registry_hash": derived["global_skill_registry_hash"],
         "matrix": derived["matrix"],
         "matrix_output_path": str(matrix_output_path) if matrix_output_path else None,
         "workspace_root": str(workspace_root) if workspace_root else None,
         "oracle_qualification_records": derived["oracle_qualification_records"],
+        "routing_provenance": _routing_provenance(
+            routed_prediction_artifact,
+            router_top_k=router_top_k,
+        ),
+        "routed_prediction_records": derived["routed_prediction_records"],
         "routing_diagnostics": derived["routing_diagnostics"],
         "overlap_report": derived["overlap_report"],
         "leakage_scan": validation["leakage_scan"],
@@ -328,7 +348,9 @@ def run_skillsbench_matrix(
     output_path: Path | str,
     runner: AgentRunner | None = None,
     verifier: AgentVerifier | None = None,
+    evidence_mode: str = "fixture",
 ) -> dict[str, Any]:
+    evidence_mode = _evidence_mode(evidence_mode)
     plan_file = Path(plan_path)
     _verify_plan_digest(plan_file)
     plan = json.loads(plan_file.read_text(encoding="utf-8"))
@@ -336,14 +358,19 @@ def run_skillsbench_matrix(
         raise ValueError("unsupported SkillsBench plan schema")
     _verify_plan_inputs(plan)
     _verify_derived_fields(plan)
+    if evidence_mode == "real":
+        _validate_real_evidence_plan(plan)
     output = Path(output_path)
     if plan.get("matrix_output_path") and str(output) != str(plan["matrix_output_path"]):
         raise ValueError("matrix output path does not match frozen plan")
-    selected_runner = runner or FakeAgentRunner(
-        exit_code=0,
-        events=[{"type": "final", "message": "fixture matrix run"}],
+    selected_runner = _select_runner(
+        runner=runner,
+        evidence_mode=evidence_mode,
     )
-    selected_verifier = verifier or FakeVerifier(pass_=True, details={"mode": "fixture"})
+    selected_verifier = _select_verifier(
+        verifier=verifier,
+        evidence_mode=evidence_mode,
+    )
     tasks_by_id = {task["task_id"]: task for task in plan["selected_tasks"]}
     skills = {
         skill_id: LiveAgentSkill(
@@ -399,6 +426,8 @@ def run_skillsbench_matrix(
             runner=selected_runner,
             verifier=selected_verifier,
         )
+        if evidence_mode == "real":
+            _validate_real_runner_preflight(result.events)
         trace_path = trace_root / f"{entry['workspace_run_id']}.json"
         trace_path.write_text(
             json.dumps(result.to_trace(), indent=2, sort_keys=True) + "\n",
@@ -433,6 +462,7 @@ def run_skillsbench_matrix(
         "benchmark_id": "skillsbench",
         "run_id": plan["run_id"],
         "mode": plan["mode"],
+        "evidence_mode": evidence_mode,
         "plan_path": str(plan_file),
         "skill_inventory": plan["global_skill_registry"],
         "leakage_scan": plan.get("leakage_scan"),
@@ -456,8 +486,10 @@ def _derive_plan_fields(
     *,
     run_id: str,
     selected_tasks: list[SkillsBenchTask],
+    data_root: Path,
     skills: dict[str, LiveAgentSkill],
     routed_predictions: dict[str, list[str]],
+    routed_prediction_artifact: dict[str, Any],
     qualifications: dict[str, dict[str, Any]],
     router_top_k: int,
     skillrouter_tasks: list[ExternalTask] | None,
@@ -490,6 +522,14 @@ def _derive_plan_fields(
         skill_id: _skill_to_plan(skills[skill_id])
         for skill_id in sorted(registry_ids)
     }
+    registry_hash = _canonical_hash(registry)
+    routed_prediction_records = _routed_prediction_records(
+        selected_tasks=selected_tasks,
+        routed_predictions=routed_predictions,
+        routed_prediction_artifact=routed_prediction_artifact,
+        router_top_k=router_top_k,
+        global_skill_registry_hash=registry_hash,
+    )
     matrix = []
     for task in selected_tasks:
         condition_hashes = []
@@ -530,10 +570,14 @@ def _derive_plan_fields(
             raise ValueError(f"prompt hash mismatch for task: {task.task_id}")
 
     return {
-        "selected_tasks": [_task_to_plan(task) for task in selected_tasks],
+        "selected_tasks": [
+            _task_to_plan(task, data_root=data_root) for task in selected_tasks
+        ],
         "global_skill_registry": registry,
+        "global_skill_registry_hash": registry_hash,
         "matrix": matrix,
         "oracle_qualification_records": qualifications,
+        "routed_prediction_records": routed_prediction_records,
         "routing_diagnostics": routing_diagnostics,
         "overlap_report": _overlap_report(selected_tasks, skillrouter_tasks),
     }
@@ -565,8 +609,12 @@ def _verify_derived_fields(plan: dict[str, Any]) -> None:
     expected = _derive_plan_fields(
         run_id=plan["run_id"],
         selected_tasks=selected_tasks,
+        data_root=Path(plan["data_root"]),
         skills=adapter.load_skills(),
         routed_predictions=_read_predictions(Path(plan["routed_predictions"]["path"])),
+        routed_prediction_artifact=_read_routed_prediction_artifact(
+            Path(plan["routed_predictions"]["path"])
+        ),
         qualifications=(
             _read_oracle_qualification(Path(plan["oracle_qualification"]["path"]))
             if plan.get("oracle_qualification")
@@ -580,8 +628,10 @@ def _verify_derived_fields(plan: dict[str, Any]) -> None:
     for key in (
         "selected_tasks",
         "global_skill_registry",
+        "global_skill_registry_hash",
         "matrix",
         "oracle_qualification_records",
+        "routed_prediction_records",
         "routing_diagnostics",
         "overlap_report",
     ):
@@ -604,10 +654,32 @@ def _read_jsonl(path: Path, *, role: str) -> list[dict[str, Any]]:
 
 
 def _read_predictions(path: Path) -> dict[str, list[str]]:
+    return _read_routed_prediction_artifact(path)["predictions"]
+
+
+def _read_routed_prediction_artifact(path: Path) -> dict[str, Any]:
     data = json.loads(path.read_text(encoding="utf-8"))
     if not isinstance(data, dict):
         raise ValueError("routed predictions must be an object")
-    return {str(task_id): _string_list(value, "routed prediction") for task_id, value in data.items()}
+    if isinstance(data.get("predictions"), dict):
+        predictions = data["predictions"]
+        router = data.get("router")
+    else:
+        predictions = data
+        router = {
+            "status": "UNAVAILABLE",
+            "reason": "legacy routed prediction map has no router metadata",
+        }
+    if not isinstance(router, dict):
+        raise ValueError("routed predictions router metadata must be an object")
+    return {
+        "path": str(path),
+        "router": router,
+        "predictions": {
+            str(task_id): _string_list(value, "routed prediction")
+            for task_id, value in predictions.items()
+        },
+    }
 
 
 def _read_oracle_qualification(path: Path) -> dict[str, dict[str, Any]]:
@@ -698,14 +770,25 @@ def _selected_task(tasks_by_id: dict[str, SkillsBenchTask], task_id: str) -> Ski
     return tasks_by_id[task_id]
 
 
-def _task_to_plan(task: SkillsBenchTask) -> dict[str, Any]:
-    return {
+def _task_to_plan(task: SkillsBenchTask, *, data_root: Path) -> dict[str, Any]:
+    base = {
         "task_id": task.task_id,
         "prompt": task.prompt,
         "verifier": task.verifier,
         "oracle_skill_ids": task.oracle_skill_ids,
         "network": task.network,
+        "requires_private_credentials": task.requires_private_credentials,
         "metadata": task.metadata,
+    }
+    return {
+        **base,
+        "prompt_hash": _sha256_text(task.prompt),
+        "task_hash": _canonical_hash(base),
+        "verifier_hash": _canonical_hash(task.verifier),
+        "verifier_artifacts": _verifier_artifact_records(
+            verifier=task.verifier,
+            data_root=data_root,
+        ),
     }
 
 
@@ -718,8 +801,256 @@ def _skill_to_plan(skill: LiveAgentSkill) -> dict[str, Any]:
     }
 
 
+def _routing_provenance(
+    routed_prediction_artifact: dict[str, Any],
+    *,
+    router_top_k: int,
+) -> dict[str, Any]:
+    predictions = routed_prediction_artifact["predictions"]
+    return {
+        "schema_version": "v0.3.skillsbench-routing-provenance.v1",
+        "router": routed_prediction_artifact["router"],
+        "router_top_k": router_top_k,
+        "predictions_hash": _canonical_hash(predictions),
+    }
+
+
+def _routed_prediction_records(
+    *,
+    selected_tasks: list[SkillsBenchTask],
+    routed_predictions: dict[str, list[str]],
+    routed_prediction_artifact: dict[str, Any],
+    router_top_k: int,
+    global_skill_registry_hash: str,
+) -> dict[str, Any]:
+    router = routed_prediction_artifact["router"]
+    router_id = router.get("router_id", "UNAVAILABLE")
+    router_config_hash = router.get("config_hash") or _canonical_hash(
+        router.get("config", {})
+    )
+    records = {}
+    for task in selected_tasks:
+        full_prediction = routed_predictions[task.task_id]
+        deduped = _dedupe(full_prediction)
+        records[task.task_id] = {
+            "task_id": task.task_id,
+            "router_id": router_id,
+            "router_config_hash": router_config_hash,
+            "router_top_k": router_top_k,
+            "global_skill_registry_hash": global_skill_registry_hash,
+            "full_prediction_count": len(full_prediction),
+            "deduped_prediction_count": len(deduped),
+            "mounted_top_k": deduped[:router_top_k],
+            "prediction_hash": _canonical_hash(full_prediction),
+        }
+    return records
+
+
+def _verifier_artifact_records(
+    *,
+    verifier: dict[str, Any],
+    data_root: Path,
+) -> dict[str, dict[str, Any]]:
+    artifacts = verifier.get("artifacts")
+    artifacts = artifacts if isinstance(artifacts, dict) else {}
+    records = {}
+    for role in VERIFIER_ARTIFACT_ROLES:
+        value = artifacts.get(role) or verifier.get(f"{role}_path")
+        if not value:
+            continue
+        path = Path(str(value))
+        if not path.is_absolute():
+            path = data_root / path
+        records[role] = _file_record(path)
+    return records
+
+
+def _verifier_artifact_errors(
+    *,
+    verifier: dict[str, Any],
+    data_root: Path,
+    task_id: str,
+) -> list[str]:
+    artifacts = verifier.get("artifacts")
+    artifacts = artifacts if isinstance(artifacts, dict) else {}
+    errors = []
+    for role in VERIFIER_ARTIFACT_ROLES:
+        value = artifacts.get(role) or verifier.get(f"{role}_path")
+        if not value:
+            continue
+        path = Path(str(value))
+        if not path.is_absolute():
+            path = data_root / path
+        if not path.exists():
+            errors.append(f"missing verifier {role} artifact for task: {task_id}")
+    return errors
+
+
+def _select_runner(
+    *,
+    runner: AgentRunner | None,
+    evidence_mode: str,
+) -> AgentRunner:
+    if runner is None:
+        if evidence_mode == "real":
+            raise ValueError(
+                "real evidence mode requires explicit AgentRunner; "
+                "FakeAgentRunner is fixture-only"
+            )
+        return FakeAgentRunner(
+            exit_code=0,
+            events=[{"type": "final", "message": "fixture matrix run"}],
+        )
+    if evidence_mode == "real" and isinstance(runner, FakeAgentRunner):
+        raise ValueError("FakeAgentRunner cannot be used in real evidence mode")
+    return runner
+
+
+def _select_verifier(
+    *,
+    verifier: AgentVerifier | None,
+    evidence_mode: str,
+) -> AgentVerifier:
+    if verifier is None:
+        if evidence_mode == "real":
+            raise ValueError(
+                "real evidence mode requires explicit deterministic verifier; "
+                "FakeVerifier is fixture-only"
+            )
+        return FakeVerifier(pass_=True, details={"mode": "fixture"})
+    if evidence_mode == "real" and isinstance(verifier, FakeVerifier):
+        raise ValueError("FakeVerifier cannot be used in real evidence mode")
+    return verifier
+
+
+def _validate_real_evidence_plan(plan: dict[str, Any]) -> None:
+    if plan.get("evidence_label") == "fixture-only" or _fixture_path(plan.get("data_root")):
+        raise ValueError("fixture-only SkillsBench data cannot be used in real evidence mode")
+
+    selected_tasks = plan.get("selected_tasks")
+    matrix = plan.get("matrix")
+    if not isinstance(selected_tasks, list) or not isinstance(matrix, list):
+        raise ValueError("real evidence mode requires selected tasks and matrix entries")
+
+    errors: list[str] = []
+    if plan.get("mode") == "pilot":
+        if len(selected_tasks) != 4:
+            errors.append("pilot real evidence mode requires exactly 4 selected tasks")
+        if len(matrix) != 12:
+            errors.append("pilot real evidence mode requires exactly 12 matrix runs")
+        expected_conditions = set(CONDITIONS)
+        for task in selected_tasks:
+            task_conditions = {
+                entry.get("condition")
+                for entry in matrix
+                if entry.get("task_id") == task.get("task_id")
+            }
+            if task_conditions != expected_conditions:
+                errors.append(
+                    f"pilot task does not have all three conditions: {task.get('task_id')}"
+                )
+
+    tasks_by_id = {
+        str(task.get("task_id")): task for task in selected_tasks if isinstance(task, dict)
+    }
+    for task_id, task in tasks_by_id.items():
+        metadata = task.get("metadata")
+        if not isinstance(metadata, dict) or not (
+            metadata.get("source") or metadata.get("provenance")
+        ):
+            errors.append(f"missing task source/provenance: {task_id}")
+        for field in ("prompt_hash", "task_hash", "verifier_hash"):
+            if not isinstance(task.get(field), str) or not task[field]:
+                errors.append(f"missing {field}: {task_id}")
+        artifacts = task.get("verifier_artifacts")
+        if not isinstance(artifacts, dict) or set(artifacts) != set(
+            VERIFIER_ARTIFACT_ROLES
+        ):
+            errors.append(f"missing verifier code/config/input hashes: {task_id}")
+
+    qualifications = plan.get("oracle_qualification_records")
+    if not isinstance(qualifications, dict):
+        errors.append("missing oracle qualification records")
+        qualifications = {}
+    for task_id, task in tasks_by_id.items():
+        record = qualifications.get(task_id)
+        if not isinstance(record, dict):
+            errors.append(f"missing oracle qualification: {task_id}")
+            continue
+        if record.get("verifier_passed") is not True:
+            errors.append(f"oracle qualification did not pass: {task_id}")
+        if record.get("task_hash") != task.get("task_hash"):
+            errors.append(f"oracle qualification task hash mismatch: {task_id}")
+        if record.get("verifier_hash") != task.get("verifier_hash"):
+            errors.append(f"oracle qualification verifier hash mismatch: {task_id}")
+        if not isinstance(record.get("skill_hash"), str) or not record["skill_hash"]:
+            errors.append(f"missing oracle qualification skill hash: {task_id}")
+        if int(record.get("trials", 0)) < 1:
+            errors.append(f"missing oracle qualification trials: {task_id}")
+        if float(record.get("pass_rate", 0.0)) < 1.0:
+            errors.append(f"oracle qualification pass rate below 1.0: {task_id}")
+        if not record.get("constraints"):
+            errors.append(f"missing oracle qualification constraints: {task_id}")
+
+    routing = plan.get("routing_provenance")
+    router = routing.get("router") if isinstance(routing, dict) else None
+    if not isinstance(router, dict) or router.get("status") == "UNAVAILABLE":
+        errors.append("missing routed prediction router metadata")
+    else:
+        if not router.get("router_id"):
+            errors.append("missing router_id for routed predictions")
+        if not router.get("config_hash"):
+            errors.append("missing router config_hash for routed predictions")
+        if int(router.get("top_k", 0)) != int(plan.get("router_top_k", 0)):
+            errors.append("routed prediction router top_k does not match plan")
+
+    registry_hash = plan.get("global_skill_registry_hash")
+    if registry_hash != _canonical_hash(plan.get("global_skill_registry")):
+        errors.append("global skill registry hash mismatch")
+    routed_records = plan.get("routed_prediction_records")
+    if not isinstance(routed_records, dict):
+        errors.append("missing routed prediction records")
+        routed_records = {}
+    for task_id in tasks_by_id:
+        record = routed_records.get(task_id)
+        if not isinstance(record, dict):
+            errors.append(f"missing routed prediction record: {task_id}")
+            continue
+        if record.get("global_skill_registry_hash") != registry_hash:
+            errors.append(f"routed prediction registry hash mismatch: {task_id}")
+        if not record.get("prediction_hash"):
+            errors.append(f"missing routed prediction hash: {task_id}")
+        if not record.get("router_id") or record.get("router_id") == "UNAVAILABLE":
+            errors.append(f"missing routed prediction router id: {task_id}")
+
+    if errors:
+        raise ValueError("real evidence mode prerequisites failed: " + "; ".join(errors))
+
+
+def _validate_real_runner_preflight(events: list[dict[str, Any]]) -> None:
+    preflight = next(
+        (
+            event
+            for event in events
+            if isinstance(event, dict) and event.get("type") == "preflight"
+        ),
+        None,
+    )
+    if preflight is None:
+        raise ValueError("missing real runner preflight")
+    if preflight.get("evidence_mode") != "final-evidence":
+        raise ValueError("real runner preflight is not final-evidence mode")
+    if preflight.get("codex_home_mode") != "isolated":
+        raise ValueError("real runner preflight did not use isolated CODEX_HOME")
+    inventory = preflight.get("global_capability_inventory")
+    if not isinstance(inventory, dict) or inventory.get("home_isolated") is not True:
+        raise ValueError("real runner preflight did not prove isolated HOME")
+
+
 def _routed_ids(plan: dict[str, Any], task_id: str) -> list[str]:
     predictions = json.loads(Path(plan["routed_predictions"]["path"]).read_text(encoding="utf-8"))
+    if isinstance(predictions, dict) and isinstance(predictions.get("predictions"), dict):
+        predictions = predictions["predictions"]
     return _dedupe([str(skill_id) for skill_id in predictions[task_id]])[
         : int(plan.get("router_top_k", DEFAULT_ROUTER_TOP_K))
     ]
@@ -873,14 +1204,22 @@ def _validate_overlap_input_choice(
 
 def _is_fixture_evidence(data_root: Path | str, license_note: str) -> bool:
     path = Path(data_root)
-    return license_note == "fixture-only" and "tests" in path.parts and "fixtures" in path.parts
+    return license_note == "fixture-only" and _fixture_path(path)
+
+
+def _fixture_path(path_value: Any) -> bool:
+    try:
+        parts = Path(str(path_value)).parts
+    except TypeError:
+        return False
+    return "tests" in parts and "fixtures" in parts
 
 
 def _evidence_label(mode: str, allow_fixture_ref: bool) -> str:
     if allow_fixture_ref:
         return "fixture-only"
     if mode == "pilot":
-        return "pilot-non-final"
+        return "pilot_non_final"
     return "frozen-final"
 
 
@@ -898,9 +1237,15 @@ def _derived_hashes(plan: dict[str, Any]) -> dict[str, str]:
     return {
         "selected_tasks": _canonical_hash(plan.get("selected_tasks")),
         "global_skill_registry": _canonical_hash(plan.get("global_skill_registry")),
+        "global_skill_registry_hash": _canonical_hash(
+            plan.get("global_skill_registry_hash")
+        ),
         "matrix": _canonical_hash(plan.get("matrix")),
         "oracle_qualification_records": _canonical_hash(
             plan.get("oracle_qualification_records")
+        ),
+        "routed_prediction_records": _canonical_hash(
+            plan.get("routed_prediction_records")
         ),
         "task_prompt_verifier": _canonical_hash(prompt_verifier),
         "routing_diagnostics": _canonical_hash(plan.get("routing_diagnostics")),
@@ -1004,6 +1349,12 @@ def _mode(value: str) -> str:
     return value
 
 
+def _evidence_mode(value: str) -> str:
+    if value not in EVIDENCE_MODES:
+        raise ValueError("evidence_mode must be fixture or real")
+    return value
+
+
 def _positive_int(value: int, field: str) -> int:
     if int(value) <= 0:
         raise ValueError(f"{field} must be positive")
@@ -1018,3 +1369,7 @@ def _non_empty(value: str, field: str) -> str:
 
 def _safe_run_id(value: str) -> str:
     return "".join(char if char.isalnum() or char in "._-" else "_" for char in value)
+
+
+def _sha256_text(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()

--- a/src/hermes_skilleval/live_agent_skillsbench.py
+++ b/src/hermes_skilleval/live_agent_skillsbench.py
@@ -1043,8 +1043,44 @@ def _validate_real_runner_preflight(events: list[dict[str, Any]]) -> None:
     if preflight.get("codex_home_mode") != "isolated":
         raise ValueError("real runner preflight did not use isolated CODEX_HOME")
     inventory = preflight.get("global_capability_inventory")
-    if not isinstance(inventory, dict) or inventory.get("home_isolated") is not True:
-        raise ValueError("real runner preflight did not prove isolated HOME")
+    if not isinstance(inventory, dict):
+        raise ValueError("real runner preflight missing global_capability_inventory")
+    if inventory.get("home_isolated") is not True:
+        raise ValueError("real runner preflight did not prove home_isolated")
+
+    user_skill_dir = inventory.get("user_skill_dir")
+    if (
+        not isinstance(user_skill_dir, dict)
+        or user_skill_dir.get("status") != "ISOLATED_HOME"
+        or user_skill_dir.get("entry_count") != 0
+    ):
+        raise ValueError("real runner preflight user_skill_dir is not isolated")
+
+    admin_skill_dirs = inventory.get("admin_skill_dirs")
+    if not isinstance(admin_skill_dirs, list):
+        raise ValueError("real runner preflight admin_skill_dirs malformed")
+    for record in admin_skill_dirs:
+        if (
+            not isinstance(record, dict)
+            or record.get("status") not in {"CLEAR", "ABSENT"}
+            or record.get("entry_count") != 0
+        ):
+            raise ValueError("real runner preflight admin_skill_dirs leaked")
+
+    workspace_skill_dirs = inventory.get("workspace_skill_dirs")
+    if not isinstance(workspace_skill_dirs, dict):
+        raise ValueError("real runner preflight workspace_skill_dirs malformed")
+    parent_checked = workspace_skill_dirs.get("parent_skill_dirs_checked")
+    empty_parent = workspace_skill_dirs.get("empty_parent_skill_dirs")
+    mounted_entries = workspace_skill_dirs.get("mounted_entry_count")
+    if (
+        workspace_skill_dirs.get("workspace_status") not in {"CLEAR", "ABSENT"}
+        or not _nonnegative_int(parent_checked)
+        or not _nonnegative_int(empty_parent)
+        or not _nonnegative_int(mounted_entries)
+        or empty_parent > parent_checked
+    ):
+        raise ValueError("real runner preflight workspace_skill_dirs leaked")
 
 
 def _routed_ids(plan: dict[str, Any], task_id: str) -> list[str]:
@@ -1353,6 +1389,10 @@ def _evidence_mode(value: str) -> str:
     if value not in EVIDENCE_MODES:
         raise ValueError("evidence_mode must be fixture or real")
     return value
+
+
+def _nonnegative_int(value: Any) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool) and value >= 0
 
 
 def _positive_int(value: int, field: str) -> int:

--- a/tests/test_skillsbench_live_matrix.py
+++ b/tests/test_skillsbench_live_matrix.py
@@ -8,9 +8,16 @@ import pytest
 import jsonschema
 
 from hermes_skilleval.cli import main
-from hermes_skilleval.live_agent_runtime import FakeAgentRunner, FakeVerifier
+from hermes_skilleval.live_agent_runtime import (
+    AgentRequest,
+    FakeAgentRunner,
+    FakeVerifier,
+    RunnerOutput,
+    VerifierResult,
+)
 from hermes_skilleval.live_agent_skillsbench import (
     SkillsBenchAdapter,
+    _canonical_hash,
     run_skillsbench_matrix,
     write_skillsbench_plan,
 )
@@ -19,6 +26,203 @@ from hermes_skilleval.live_agent_skillsbench import (
 FIXTURE = Path("tests/fixtures/live_agent/skillsbench_tiny")
 SKILLROUTER_FIXTURE = Path("tests/fixtures/external/skillrouter_eval_core_tiny")
 UPSTREAM_SHA = "a" * 40
+
+
+class _RecordingRunner:
+    def __init__(self, *, events: list[dict] | None = None) -> None:
+        self.events = events or [_real_preflight()]
+        self.requests: list[AgentRequest] = []
+
+    def run(self, request: AgentRequest) -> RunnerOutput:
+        self.requests.append(request)
+        return RunnerOutput(
+            exit_code=0,
+            timed_out=False,
+            stdout="",
+            stderr="",
+            events=self.events,
+        )
+
+
+class _PassingDeterministicVerifier:
+    def verify(self, request: AgentRequest, output: RunnerOutput) -> VerifierResult:
+        return VerifierResult(
+            passed=True,
+            details={"source": "unit-test-deterministic-verifier"},
+        )
+
+
+def _real_preflight() -> dict:
+    return {
+        "type": "preflight",
+        "codex_home_mode": "isolated",
+        "evidence_mode": "final-evidence",
+        "global_capability_inventory": {
+            "home_isolated": True,
+            "user_skill_dir": {"status": "ISOLATED_HOME", "entry_count": 0},
+            "admin_skill_dirs": [{"status": "ABSENT", "entry_count": 0}],
+            "workspace_skill_dirs": {
+                "workspace_status": "CLEAR",
+                "mounted_entry_count": 0,
+                "parent_skill_dirs_checked": 1,
+                "empty_parent_skill_dirs": 0,
+            },
+            "bundled_skills": {"status": "SYSTEM_MANAGED_UNKNOWN"},
+        },
+    }
+
+
+def _write_real_like_pilot_inputs(root: Path) -> dict[str, Path]:
+    root.mkdir()
+    verifier_dir = root / "verifiers"
+    verifier_dir.mkdir()
+    (verifier_dir / "check.py").write_text("def verify(): return True\n", encoding="utf-8")
+    (verifier_dir / "config.json").write_text('{"mode":"deterministic"}\n', encoding="utf-8")
+    (verifier_dir / "input.json").write_text('{"fixture":"unit"}\n', encoding="utf-8")
+
+    skills = []
+    tasks = []
+    oracle_records = []
+    predictions: dict[str, list[str]] = {}
+    for index in range(4):
+        task_id = f"sb-real-{index + 1}"
+        skill_id = f"skill/real-{index + 1}"
+        skill = {
+            "skill_id": skill_id,
+            "name": f"Real Pilot Skill {index + 1}",
+            "description": f"Deterministic helper for pilot task {index + 1}.",
+            "body": f"Follow the deterministic procedure for pilot task {index + 1}.",
+        }
+        verifier = {
+            "type": "deterministic",
+            "name": f"real-verifier-{index + 1}",
+            "code_path": "verifiers/check.py",
+            "config_path": "verifiers/config.json",
+            "input_path": "verifiers/input.json",
+        }
+        task = {
+            "task_id": task_id,
+            "prompt": f"Complete the deterministic pilot activity number {index + 1}.",
+            "verifier": verifier,
+            "requires_private_credentials": False,
+            "network": "none",
+            "oracle_skill_ids": [skill_id],
+            "source": "approved-unit-real-pilot-source",
+            "provenance": {"upstream_task_id": f"upstream-{index + 1}"},
+        }
+        metadata = {
+            "source": task["source"],
+            "provenance": task["provenance"],
+        }
+        task_hash = _canonical_hash(
+            {
+                "task_id": task_id,
+                "prompt": task["prompt"],
+                "verifier": verifier,
+                "oracle_skill_ids": [skill_id],
+                "network": "none",
+                "requires_private_credentials": False,
+                "metadata": metadata,
+            }
+        )
+        skill_hash = _canonical_hash(
+            {
+                "skill_id": skill_id,
+                "name": skill["name"],
+                "description": skill["description"],
+                "body": skill["body"],
+            }
+        )
+        oracle_records.append(
+            {
+                "task_id": task_id,
+                "condition": "oracle-skill",
+                "verifier_passed": True,
+                "task_hash": task_hash,
+                "verifier_hash": _canonical_hash(verifier),
+                "skill_hash": skill_hash,
+                "skill_id": skill_id,
+                "trials": 1,
+                "pass_rate": 1.0,
+                "constraints": {
+                    "credentials": "none",
+                    "network": "none",
+                    "verifier": "deterministic",
+                },
+            }
+        )
+        skills.append(skill)
+        tasks.append(task)
+        predictions[task_id] = [skill_id]
+
+    (root / "tasks.jsonl").write_text(
+        "".join(json.dumps(task, sort_keys=True) + "\n" for task in tasks),
+        encoding="utf-8",
+    )
+    (root / "skills.jsonl").write_text(
+        "".join(json.dumps(skill, sort_keys=True) + "\n" for skill in skills),
+        encoding="utf-8",
+    )
+    (root / "manifest.json").write_text(
+        json.dumps(
+            {
+                "dataset": "approved-unit-real-pilot-source",
+                "license_note": "approved-real-pilot-unit",
+                "upstream_ref": UPSTREAM_SHA,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (root / "oracle_qualification.jsonl").write_text(
+        "".join(json.dumps(record, sort_keys=True) + "\n" for record in oracle_records),
+        encoding="utf-8",
+    )
+    (root / "routed_predictions.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "v0.3.routed-predictions.v1",
+                "router": {
+                    "router_id": "unit-router",
+                    "config_hash": "c" * 64,
+                    "top_k": 1,
+                },
+                "predictions": predictions,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return {
+        "data_root": root,
+        "routed_predictions": root / "routed_predictions.json",
+        "oracle_qualification": root / "oracle_qualification.jsonl",
+    }
+
+
+def _write_real_like_pilot_plan(tmp_path: Path) -> tuple[Path, Path]:
+    paths = _write_real_like_pilot_inputs(tmp_path / "skillsbench-real")
+    plan_path = tmp_path / "plan.json"
+    matrix_path = tmp_path / "matrix.json"
+    write_skillsbench_plan(
+        data_root=paths["data_root"],
+        output_path=plan_path,
+        upstream_ref=UPSTREAM_SHA,
+        license_note="approved-real-pilot-unit",
+        run_id="stage2-real-pilot-prep",
+        mode="pilot",
+        selected_task_ids=[f"sb-real-{index}" for index in range(1, 5)],
+        routed_predictions_path=paths["routed_predictions"],
+        oracle_qualification_path=paths["oracle_qualification"],
+        matrix_output_path=matrix_path,
+        workspace_root=tmp_path / "workspaces",
+        router_top_k=1,
+    )
+    return plan_path, matrix_path
 
 
 def _rewrite_plan_digest(plan_path: Path) -> None:
@@ -589,6 +793,114 @@ def test_frozen_upstream_ref_requires_commit_sha_outside_fixture_or_pilot(tmp_pa
         selected_task_ids=["sb-task-login"],
         routed_predictions_path=root / "routed_predictions.json",
     )
+
+
+def test_real_evidence_mode_rejects_fake_runner_and_verifier(tmp_path):
+    plan_path, matrix_path = _write_real_like_pilot_plan(tmp_path)
+
+    with pytest.raises(ValueError, match="FakeAgentRunner"):
+        run_skillsbench_matrix(
+            plan_path=plan_path,
+            output_path=matrix_path,
+            runner=FakeAgentRunner(),
+            verifier=_PassingDeterministicVerifier(),
+            evidence_mode="real",
+        )
+
+    with pytest.raises(ValueError, match="FakeVerifier"):
+        run_skillsbench_matrix(
+            plan_path=plan_path,
+            output_path=matrix_path,
+            runner=_RecordingRunner(),
+            verifier=FakeVerifier(pass_=True),
+            evidence_mode="real",
+        )
+
+
+def test_real_evidence_mode_rejects_fixture_only_skillsbench_data(tmp_path):
+    plan_path = tmp_path / "fixture-plan.json"
+    matrix_path = tmp_path / "fixture-matrix.json"
+    write_skillsbench_plan(
+        data_root=FIXTURE,
+        output_path=plan_path,
+        upstream_ref="fixture-ref",
+        license_note="fixture-only",
+        run_id="fixture-pilot",
+        mode="pilot",
+        selected_task_ids=["sb-task-login", "sb-task-edit"],
+        routed_predictions_path=FIXTURE / "routed_predictions.json",
+        oracle_qualification_path=FIXTURE / "oracle_qualification.jsonl",
+        matrix_output_path=matrix_path,
+    )
+
+    with pytest.raises(ValueError, match="fixture-only SkillsBench data"):
+        run_skillsbench_matrix(
+            plan_path=plan_path,
+            output_path=matrix_path,
+            runner=_RecordingRunner(),
+            verifier=_PassingDeterministicVerifier(),
+            evidence_mode="real",
+        )
+
+
+def test_real_evidence_mode_requires_no_skill_preflight(tmp_path):
+    plan_path, matrix_path = _write_real_like_pilot_plan(tmp_path)
+
+    with pytest.raises(ValueError, match="missing real runner preflight"):
+        run_skillsbench_matrix(
+            plan_path=plan_path,
+            output_path=matrix_path,
+            runner=_RecordingRunner(events=[{"type": "final", "message": "ok"}]),
+            verifier=_PassingDeterministicVerifier(),
+            evidence_mode="real",
+        )
+
+
+def test_stage2_pilot_plan_records_task_verifier_oracle_and_routing_hashes(tmp_path):
+    plan_path, _matrix_path = _write_real_like_pilot_plan(tmp_path)
+    plan = json.loads(plan_path.read_text(encoding="utf-8"))
+
+    assert plan["mode"] == "pilot"
+    assert plan["evidence_label"] == "pilot_non_final"
+    assert len(plan["selected_tasks"]) == 4
+    assert len(plan["matrix"]) == 12
+    assert {entry["condition"] for entry in plan["matrix"]} == {
+        "no-skill",
+        "routed-skill",
+        "oracle-skill",
+    }
+    assert plan["global_skill_registry_hash"] == _canonical_hash(
+        plan["global_skill_registry"]
+    )
+    assert plan["routing_provenance"]["router"]["router_id"] == "unit-router"
+    assert plan["routing_provenance"]["router"]["config_hash"] == "c" * 64
+    assert plan["routing_provenance"]["router"]["top_k"] == 1
+
+    selected_by_id = {task["task_id"]: task for task in plan["selected_tasks"]}
+    assert all(task["prompt_hash"] for task in selected_by_id.values())
+    assert all(task["task_hash"] for task in selected_by_id.values())
+    assert all(task["verifier_hash"] for task in selected_by_id.values())
+    assert all(
+        set(task["verifier_artifacts"]) == {"code", "config", "input"}
+        for task in selected_by_id.values()
+    )
+
+    for task_id, record in plan["oracle_qualification_records"].items():
+        task = selected_by_id[task_id]
+        assert record["task_hash"] == task["task_hash"]
+        assert record["verifier_hash"] == task["verifier_hash"]
+        assert record["skill_hash"]
+        assert record["trials"] == 1
+        assert record["pass_rate"] == 1.0
+        assert record["constraints"]
+
+    for task_id, record in plan["routed_prediction_records"].items():
+        assert task_id in selected_by_id
+        assert record["router_id"] == "unit-router"
+        assert record["router_config_hash"] == "c" * 64
+        assert record["router_top_k"] == 1
+        assert record["global_skill_registry_hash"] == plan["global_skill_registry_hash"]
+        assert record["prediction_hash"]
 
 
 def test_cli_skillsbench_plan_and_matrix_write_outputs(tmp_path):

--- a/tests/test_skillsbench_live_matrix.py
+++ b/tests/test_skillsbench_live_matrix.py
@@ -18,6 +18,7 @@ from hermes_skilleval.live_agent_runtime import (
 from hermes_skilleval.live_agent_skillsbench import (
     SkillsBenchAdapter,
     _canonical_hash,
+    _validate_real_runner_preflight,
     run_skillsbench_matrix,
     write_skillsbench_plan,
 )
@@ -856,6 +857,116 @@ def test_real_evidence_mode_requires_no_skill_preflight(tmp_path):
         )
 
 
+@pytest.mark.parametrize(
+    "events",
+    [
+        [],
+        [{"type": "final", "message": "ok"}],
+        ["malformed"],
+    ],
+)
+def test_real_runner_preflight_requires_preflight_record(events):
+    with pytest.raises(ValueError, match="missing real runner preflight"):
+        _validate_real_runner_preflight(events)
+
+
+@pytest.mark.parametrize(
+    ("mutator", "message"),
+    [
+        (
+            lambda preflight: preflight.__setitem__("evidence_mode", "smoke-only"),
+            "final-evidence",
+        ),
+        (
+            lambda preflight: preflight.__setitem__("codex_home_mode", "inherit"),
+            "isolated CODEX_HOME",
+        ),
+        (
+            lambda preflight: preflight.pop("global_capability_inventory"),
+            "global_capability_inventory",
+        ),
+        (
+            lambda preflight: preflight.__setitem__(
+                "global_capability_inventory",
+                ["malformed"],
+            ),
+            "global_capability_inventory",
+        ),
+        (
+            lambda preflight: preflight["global_capability_inventory"].__setitem__(
+                "home_isolated",
+                False,
+            ),
+            "home_isolated",
+        ),
+        (
+            lambda preflight: preflight["global_capability_inventory"][
+                "user_skill_dir"
+            ].__setitem__("status", "CLEAR"),
+            "user_skill_dir",
+        ),
+        (
+            lambda preflight: preflight["global_capability_inventory"][
+                "user_skill_dir"
+            ].__setitem__("entry_count", 1),
+            "user_skill_dir",
+        ),
+        (
+            lambda preflight: preflight["global_capability_inventory"].__setitem__(
+                "admin_skill_dirs",
+                {"status": "CLEAR", "entry_count": 0},
+            ),
+            "admin_skill_dirs",
+        ),
+        (
+            lambda preflight: preflight["global_capability_inventory"][
+                "admin_skill_dirs"
+            ][0].__setitem__("status", "LEAKED"),
+            "admin_skill_dirs",
+        ),
+        (
+            lambda preflight: preflight["global_capability_inventory"][
+                "admin_skill_dirs"
+            ][0].__setitem__("entry_count", 1),
+            "admin_skill_dirs",
+        ),
+        (
+            lambda preflight: preflight["global_capability_inventory"].pop(
+                "workspace_skill_dirs"
+            ),
+            "workspace_skill_dirs",
+        ),
+        (
+            lambda preflight: preflight["global_capability_inventory"][
+                "workspace_skill_dirs"
+            ].__setitem__("workspace_status", "LEAKED"),
+            "workspace_skill_dirs",
+        ),
+        (
+            lambda preflight: preflight["global_capability_inventory"][
+                "workspace_skill_dirs"
+            ].__setitem__("parent_skill_dirs_checked", "many"),
+            "workspace_skill_dirs",
+        ),
+        (
+            lambda preflight: preflight["global_capability_inventory"][
+                "workspace_skill_dirs"
+            ].__setitem__("empty_parent_skill_dirs", 2),
+            "workspace_skill_dirs",
+        ),
+    ],
+)
+def test_real_runner_preflight_rejects_malformed_or_leaky_records(
+    mutator,
+    message,
+):
+    preflight = json.loads(json.dumps(_real_preflight()))
+    mutator(preflight)
+
+    with pytest.raises(ValueError, match=message):
+        _validate_real_runner_preflight([preflight])
+
+
 def test_stage2_pilot_plan_records_task_verifier_oracle_and_routing_hashes(tmp_path):
     plan_path, _matrix_path = _write_real_like_pilot_plan(tmp_path)
     plan = json.loads(plan_path.read_text(encoding="utf-8"))
@@ -962,3 +1073,21 @@ def test_cli_skillsbench_plan_and_matrix_write_outputs(tmp_path):
     )
     assert matrix_exit == 0
     assert json.loads(matrix_path.read_text(encoding="utf-8"))["run_id"] == "cli-skillsbench-run"
+
+
+def test_cli_codex_cli_runner_requires_real_evidence_mode(tmp_path, capsys):
+    exit_code = main(
+        [
+            "skillsbench-matrix",
+            "--plan",
+            str(tmp_path / "plan.json"),
+            "--output",
+            str(tmp_path / "matrix.json"),
+            "--runner",
+            "codex-cli",
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert exit_code == 2
+    assert "--runner codex-cli requires --evidence-mode real" in captured.err


### PR DESCRIPTION
## Summary
- This is Stage 2 prerequisite preparation and fail-closed hardening.
- The branch records missing real Stage 2 inputs rather than fabricating pilot evidence.
- FakeAgentRunner/FakeVerifier remain fixture-only and are rejected for real evidence mode.

## Boundary
- No Stage 2 pilot was run.
- No Codex run was executed.
- No frozen pilot plan was created.
- No traces were created.
- No performance claims are made.
- FakeAgentRunner/FakeVerifier remain fixture-only and are rejected for real evidence mode.
- --runner codex-cli now requires --evidence-mode real.
- Real runner preflight now validates isolated CODEX_HOME, isolated HOME, global capability inventory, user/admin/workspace skill leakage surfaces.
- The branch records missing real Stage 2 inputs rather than fabricating pilot evidence.

## Validation
- python -m pytest -q tests/test_skillsbench_live_matrix.py -> 45 passed
- python -m pytest -q -> 628 passed
- OPENSPEC_TELEMETRY=0 openspec validate --all --strict -> 23 passed
- release-check -> PASS
- YAML parse check for configs/v0.3/*.yaml -> passed
- JSON parse check for missing-input report -> passed
- git diff --check -> passed