### PR TITLE
ops: add Stage 2 real pilot input package gate

### DIFF
--- a/artifacts/v0.3/skillsbench-pilot/v0.3-stage2-real-pilot-input-package-blocked-20260629T112515Z/stage2-real-pilot-input-package-blocked.json
+++ b/artifacts/v0.3/skillsbench-pilot/v0.3-stage2-real-pilot-input-package-blocked-20260629T112515Z/stage2-real-pilot-input-package-blocked.json
@@ -1,0 +1,161 @@
+{
+  "schema_version": "v0.3.stage2-real-pilot-input-package-blocked.v1",
+  "status": "BLOCKED_MISSING_REAL_INPUTS",
+  "run_id": "v0.3-stage2-real-pilot-input-package-blocked-20260629T112515Z",
+  "created_at": "2026-06-29T11:25:15Z",
+  "branch": "ops/stage2-real-pilot-input-package",
+  "base_branch": "codex/v0.3-pr0-protocol",
+  "base_merge_commit": "6d4fbef910f437ca2c508c26d73da49299b96f02",
+  "previous_missing_input_report": "artifacts/v0.3/skillsbench-pilot/v0.3-stage2-real-codex-pilot-prep-missing-inputs-20260629T053333Z/stage2-real-codex-pilot-prep-missing-input-report.json",
+  "requested_pilot_shape": {
+    "task_count": 4,
+    "conditions": [
+      "no-skill",
+      "routed-skill",
+      "oracle-skill"
+    ],
+    "trials_per_condition": 1,
+    "total_runs": 12,
+    "evidence_label": "pilot_non_final"
+  },
+  "inspected_paths": [
+    {
+      "path": "artifacts/v0.3/skillsbench-pilot/v0.3-stage2-real-codex-pilot-prep-missing-inputs-20260629T053333Z/stage2-real-codex-pilot-prep-missing-input-report.json",
+      "finding": "Previous preparation report already records missing non-fixture 4-task data root, deterministic verifier artifacts, oracle qualification, routed predictions, and real verifier integration."
+    },
+    {
+      "path": "docs/v0.3/runbook-frozen-evidence.md",
+      "finding": "Runbook requires a 4-task SkillsBench/Codex pilot with deterministic verifiers and explicitly rejects fake-runner artifacts for final evidence."
+    },
+    {
+      "path": "configs/v0.3/live-agent.yaml",
+      "finding": "Config remains placeholder-only. pilot_preparation.status is missing_real_inputs and no concrete task IDs, verifier artifacts, oracle qualification, routed predictions, or registry manifest are configured."
+    },
+    {
+      "path": "src/hermes_skilleval/live_agent_skillsbench.py",
+      "finding": "Real evidence mode and the new input-package validator fail closed for fixture data, missing verifier hashes, missing oracle qualification, unknown routed skills, and leakage in public prompts or public skill text."
+    },
+    {
+      "path": "src/hermes_skilleval/live_agent_runtime.py",
+      "finding": "CodexCliRunner supports isolated CODEX_HOME/HOME preflight, but no real Codex run is allowed or performed in this branch."
+    }
+  ],
+  "repository_input_search": {
+    "non_fixture_skillsbench_data_root_found": false,
+    "non_fixture_task_files_found": [],
+    "fixture_only_paths_rejected": [
+      "tests/fixtures/live_agent/skillsbench_tiny/tasks.jsonl",
+      "tests/fixtures/live_agent/skillsbench_tiny/skills.jsonl",
+      "tests/fixtures/live_agent/skillsbench_tiny/oracle_qualification.jsonl",
+      "tests/fixtures/live_agent/skillsbench_tiny/routed_predictions.json"
+    ],
+    "blocked_reports_found": [
+      "artifacts/v0.3/skillsbench-pilot/v0.3-stage2-pilot-blocked-20260629T045907Z/stage2-pilot-blocked-report.json",
+      "artifacts/v0.3/skillsbench-pilot/v0.3-stage2-real-codex-pilot-prep-missing-inputs-20260629T053333Z/stage2-real-codex-pilot-prep-missing-input-report.json"
+    ]
+  },
+  "missing_fields": {
+    "non_fixture_four_task_pilot_data_root_or_manifest": {
+      "status": "MISSING",
+      "required_fields": [
+        "exactly 4 selectable task records",
+        "task_id",
+        "source_or_provenance",
+        "prompt text path or prompt hash",
+        "task hash",
+        "prompt hash",
+        "license or source note",
+        "public prompt leakage guard result"
+      ],
+      "why_it_blocks_freeze_plan": "A pilot freeze-plan cannot select real tasks or prove prompt/task provenance without a non-fixture or explicitly approved 4-task data root."
+    },
+    "deterministic_verifier_package": {
+      "status": "MISSING",
+      "required_fields": [
+        "verifier code hash",
+        "verifier config hash",
+        "verifier input hash",
+        "expected output format",
+        "local/network/credential constraints",
+        "deterministic or stability assumptions"
+      ],
+      "rejected_success_sources": [
+        "process exit code",
+        "LLM judge"
+      ],
+      "why_it_blocks_freeze_plan": "The matrix contract requires verifier output as the only task-success source. Without verifier code/config/input hashes, the pilot cannot be frozen for real evidence."
+    },
+    "oracle_qualification_package": {
+      "status": "MISSING",
+      "required_fields": [
+        "task hash",
+        "verifier hash",
+        "skill hash",
+        "trials",
+        "pass rate",
+        "constraints",
+        "qualification command",
+        "output hash"
+      ],
+      "why_it_blocks_freeze_plan": "Oracle-skill runs cannot be interpreted without a non-fabricated qualification record proving the oracle skill passes the deterministic verifier for each selected task."
+    },
+    "routed_predictions_package": {
+      "status": "MISSING",
+      "required_fields": [
+        "router_id",
+        "config_hash",
+        "top_k",
+        "global skill registry hash",
+        "per-task prediction hash",
+        "predicted skill IDs"
+      ],
+      "why_it_blocks_freeze_plan": "Routed-skill runs cannot be frozen from ad hoc labels or oracle labels. Unknown skill IDs must fail closed against the global registry."
+    },
+    "global_skill_registry_package": {
+      "status": "MISSING",
+      "required_fields": [
+        "stable skill IDs",
+        "skill name hash",
+        "skill description hash",
+        "skill body hash",
+        "public skill text leakage guard result"
+      ],
+      "why_it_blocks_freeze_plan": "Routed and oracle mounting need a stable registry hash and leakage-checked public skill text before the 12 pilot runs can be frozen."
+    }
+  },
+  "prepared_fail_closed_checks": [
+    "Fixture-only SkillsBench data roots are rejected for real input packages.",
+    "Exactly 4 selected pilot tasks are required.",
+    "Missing verifier code/config/input hashes fail closed.",
+    "Missing oracle qualification records fail closed.",
+    "Routed predictions containing unknown skill IDs fail closed.",
+    "Prompt, task, verifier, and skill hashes are required in the input package.",
+    "Public prompt and public skill text leakage guards catch task_id, oracle, and gold labels."
+  ],
+  "preflight_readiness_checklist_for_future_execution": {
+    "required_runner": "--runner codex-cli",
+    "required_evidence_mode": "--evidence-mode real",
+    "isolated_home_required": true,
+    "isolated_codex_home_required": true,
+    "final_evidence_preflight_required": true,
+    "clean_user_admin_workspace_skill_inventory_required": true,
+    "codex_execution_allowed_in_this_branch": false
+  },
+  "non_actions": {
+    "stage2_pilot_run": false,
+    "codex_cli_run": false,
+    "pilot_plan_frozen": false,
+    "live_agent_traces_created": false,
+    "evidence_gate_rerun_with_fake_live_artifacts": false,
+    "fixture_data_used_as_real_evidence": false,
+    "fake_runner_or_verifier_used_as_real_evidence": false,
+    "performance_claims": false
+  },
+  "remaining_blockers": [
+    "Provide or approve a non-fixture SkillsBench pilot data root with exactly 4 selectable tasks.",
+    "Provide deterministic verifier code/config/input artifacts and expected output formats for all 4 tasks.",
+    "Run and record non-fabricated oracle qualification for all 4 tasks against the deterministic verifiers.",
+    "Provide routed predictions generated by the approved router/config over the global skill registry.",
+    "Provide a stable global skill registry package with leakage-checked public skill text."
+  ]
+}

--- a/artifacts/v0.3/skillsbench-pilot/v0.3-stage2-real-pilot-input-package-blocked-20260629T112515Z/stage2-real-pilot-input-package-blocked.json
+++ b/artifacts/v0.3/skillsbench-pilot/v0.3-stage2-real-pilot-input-package-blocked-20260629T112515Z/stage2-real-pilot-input-package-blocked.json
@@ -106,6 +106,9 @@
         "config_hash",
         "top_k",
         "global skill registry hash",
+        "generation command or generation artifact hash",
+        "oracle_labels_read false",
+        "non-oracle, non-manual, non-ad-hoc label source",
         "per-task prediction hash",
         "predicted skill IDs"
       ],
@@ -129,6 +132,7 @@
     "Missing verifier code/config/input hashes fail closed.",
     "Missing oracle qualification records fail closed.",
     "Routed predictions containing unknown skill IDs fail closed.",
+    "Routed predictions missing generation provenance, registry hash match, or oracle-label-read exclusion fail closed.",
     "Prompt, task, verifier, and skill hashes are required in the input package.",
     "Public prompt and public skill text leakage guards catch task_id, oracle, and gold labels."
   ],

--- a/src/hermes_skilleval/live_agent_skillsbench.py
+++ b/src/hermes_skilleval/live_agent_skillsbench.py
@@ -27,6 +27,7 @@ from hermes_skilleval.release_manifest import sha256_file
 
 PLAN_SCHEMA = "v0.3.skillsbench-live-plan.v1"
 REPORT_SCHEMA = "v0.3.skillsbench-live-matrix-report.v1"
+STAGE2_INPUT_PACKAGE_SCHEMA = "v0.3.stage2-real-pilot-input-package.v1"
 SEED = 20260625
 CONDITIONS = ("no-skill", "routed-skill", "oracle-skill")
 CONTROLLED_NETWORKS = {"none", "controlled"}
@@ -340,6 +341,165 @@ def write_skillsbench_plan(
     output.write_text(json.dumps(plan, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     _write_plan_digest(output)
     return plan
+
+
+def build_stage2_real_pilot_input_package(
+    *,
+    data_root: Path | str,
+    upstream_ref: str,
+    license_note: str,
+    run_id: str,
+    selected_task_ids: Iterable[str],
+    routed_predictions_path: Path | str,
+    oracle_qualification_path: Path | str,
+    router_top_k: int = 1,
+) -> dict[str, Any]:
+    """Build a reviewable Stage 2 pilot input package without freezing a plan."""
+
+    data_root_path = Path(data_root)
+    if _fixture_path(data_root_path) or license_note == "fixture-only":
+        raise ValueError("fixture-only SkillsBench data cannot be used for real input package")
+
+    selected_ids = list(selected_task_ids)
+    if len(selected_ids) != 4:
+        raise ValueError("stage2 real pilot input package requires exactly 4 selected tasks")
+    if len(set(selected_ids)) != len(selected_ids):
+        raise ValueError("stage2 real pilot input package requires unique selected tasks")
+
+    router_top_k = _positive_int(router_top_k, "router_top_k")
+    adapter = SkillsBenchAdapter(
+        data_root=data_root_path,
+        upstream_ref=upstream_ref,
+        license_note=license_note,
+        allow_non_sha_upstream=True,
+    )
+    validation = adapter.validate()
+    if validation["status"] != "PASS":
+        raise ValueError(
+            "SkillsBench validation failed: " + "; ".join(validation["errors"])
+        )
+
+    tasks_by_id = {task.task_id: task for task in adapter.load_tasks()}
+    selected_tasks = [_selected_task(tasks_by_id, task_id) for task_id in selected_ids]
+    skills = adapter.load_skills()
+    routed_prediction_artifact = _read_routed_prediction_artifact(
+        Path(routed_predictions_path)
+    )
+    routed_predictions = routed_prediction_artifact["predictions"]
+    qualifications = _read_oracle_qualification(Path(oracle_qualification_path))
+
+    errors: list[str] = []
+    errors.extend(_public_skill_text_leakage_errors(selected_tasks, skills.values()))
+    errors.extend(
+        _routed_prediction_input_errors(
+            selected_tasks=selected_tasks,
+            routed_predictions=routed_predictions,
+            router=routed_prediction_artifact["router"],
+            skills=skills,
+            router_top_k=router_top_k,
+        )
+    )
+
+    selected_task_records = [
+        _stage2_input_task_record(
+            task,
+            data_root=data_root_path,
+            license_note=license_note,
+        )
+        for task in selected_tasks
+    ]
+    selected_by_id = {task["task_id"]: task for task in selected_task_records}
+    verifier_records, verifier_errors = _stage2_verifier_package_records(
+        selected_task_records
+    )
+    errors.extend(verifier_errors)
+
+    global_registry = {
+        skill_id: _stage2_skill_registry_record(skill)
+        for skill_id, skill in sorted(skills.items())
+    }
+    global_registry_hash = _canonical_hash(global_registry)
+    oracle_records, oracle_errors = _stage2_oracle_package_records(
+        selected_tasks=selected_tasks,
+        selected_by_id=selected_by_id,
+        skills=skills,
+        qualifications=qualifications,
+    )
+    errors.extend(oracle_errors)
+    routed_records, routed_errors = _stage2_routed_prediction_records(
+        selected_tasks=selected_tasks,
+        routed_prediction_artifact=routed_prediction_artifact,
+        router_top_k=router_top_k,
+        global_skill_registry_hash=global_registry_hash,
+    )
+    errors.extend(routed_errors)
+
+    if errors:
+        raise ValueError(
+            "stage2 real pilot input package prerequisites failed: "
+            + "; ".join(errors)
+        )
+
+    package = {
+        "schema_version": STAGE2_INPUT_PACKAGE_SCHEMA,
+        "status": "READY_FOR_REVIEW_NOT_EXECUTED",
+        "run_id": _non_empty(run_id, "run_id"),
+        "created_at": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+        "evidence_label": "pilot_non_final",
+        "pilot_shape": {
+            "task_count": 4,
+            "conditions": list(CONDITIONS),
+            "trials_per_condition": 1,
+            "total_runs": 12,
+        },
+        "data_root_package": {
+            "data_root": str(data_root_path),
+            "upstream_ref": _non_empty(upstream_ref, "upstream_ref"),
+            "license_note": _non_empty(license_note, "license_note"),
+            "selected_task_ids": selected_ids,
+            "task_count": len(selected_task_records),
+            "adapter_provenance": adapter.provenance(validation),
+            "selected_tasks": selected_task_records,
+        },
+        "deterministic_verifier_package": {
+            "success_source": "deterministic_verifier_output_only",
+            "process_exit_code_success_source": False,
+            "llm_judge_accepted": False,
+            "records": verifier_records,
+        },
+        "oracle_qualification_package": {
+            "records": oracle_records,
+        },
+        "routed_predictions_package": {
+            "router_id": routed_prediction_artifact["router"].get("router_id"),
+            "config_hash": routed_prediction_artifact["router"].get("config_hash"),
+            "top_k": router_top_k,
+            "global_skill_registry_hash": global_registry_hash,
+            "records": routed_records,
+        },
+        "global_skill_registry_package": {
+            "global_skill_registry_hash": global_registry_hash,
+            "skills": global_registry,
+        },
+        "preflight_readiness_checklist": {
+            "runner": "--runner codex-cli",
+            "evidence_mode": "--evidence-mode real",
+            "isolated_home_required": True,
+            "isolated_codex_home_required": True,
+            "final_evidence_preflight_required": True,
+            "clean_user_admin_workspace_skill_inventory_required": True,
+            "codex_execution_allowed_in_this_branch": False,
+        },
+        "non_actions": {
+            "stage2_pilot_run": False,
+            "codex_cli_run": False,
+            "pilot_plan_frozen": False,
+            "live_agent_traces_created": False,
+            "performance_claims": False,
+        },
+    }
+    _reject_sensitive_values(package)
+    return package
 
 
 def run_skillsbench_matrix(
@@ -923,6 +1083,197 @@ def _select_verifier(
     return verifier
 
 
+def _stage2_input_task_record(
+    task: SkillsBenchTask,
+    *,
+    data_root: Path,
+    license_note: str,
+) -> dict[str, Any]:
+    record = _task_to_plan(task, data_root=data_root)
+    source_or_provenance = task.metadata.get("source") or task.metadata.get("provenance")
+    return {
+        **record,
+        "source_or_provenance": source_or_provenance,
+        "license_note": license_note,
+        "public_prompt_leakage_guard": "PASS",
+    }
+
+
+def _stage2_verifier_package_records(
+    selected_task_records: list[dict[str, Any]],
+) -> tuple[dict[str, Any], list[str]]:
+    records: dict[str, Any] = {}
+    errors: list[str] = []
+    for task in selected_task_records:
+        task_id = str(task["task_id"])
+        verifier = task.get("verifier")
+        artifacts = task.get("verifier_artifacts")
+        if not isinstance(verifier, dict):
+            errors.append(f"missing deterministic verifier: {task_id}")
+            continue
+        if verifier.get("type") != "deterministic":
+            errors.append(f"missing deterministic verifier: {task_id}")
+        if not isinstance(artifacts, dict) or set(artifacts) != set(
+            VERIFIER_ARTIFACT_ROLES
+        ):
+            errors.append(f"missing verifier code/config/input hashes: {task_id}")
+            continue
+        for field in (
+            "expected_output_format",
+            "constraints",
+            "deterministic_assumptions",
+        ):
+            if not verifier.get(field):
+                errors.append(f"missing verifier {field}: {task_id}")
+        if verifier.get("success_source") == "process_exit_code":
+            errors.append(f"process exit code cannot be task success source: {task_id}")
+        if verifier.get("judge") == "llm" or verifier.get("llm_judge") is True:
+            errors.append(f"LLM judge cannot be task success source: {task_id}")
+        records[task_id] = {
+            "task_id": task_id,
+            "verifier_hash": task.get("verifier_hash"),
+            "code_hash": artifacts["code"]["sha256"],
+            "config_hash": artifacts["config"]["sha256"],
+            "input_hash": artifacts["input"]["sha256"],
+            "artifacts": artifacts,
+            "expected_output_format": verifier.get("expected_output_format"),
+            "constraints": verifier.get("constraints"),
+            "deterministic_assumptions": verifier.get("deterministic_assumptions"),
+        }
+    return records, errors
+
+
+def _stage2_skill_registry_record(skill: LiveAgentSkill) -> dict[str, Any]:
+    body = skill.body
+    description = skill.description or ""
+    return {
+        "skill_id": skill.skill_id,
+        "name": skill.name,
+        "description": description,
+        "body": body,
+        "skill_hash": _canonical_hash(_skill_to_plan(skill)),
+        "name_hash": _sha256_text(skill.name),
+        "description_hash": _sha256_text(description),
+        "body_hash": _sha256_text(body),
+        "public_skill_text_leakage_guard": "PASS",
+    }
+
+
+def _stage2_oracle_package_records(
+    *,
+    selected_tasks: list[SkillsBenchTask],
+    selected_by_id: dict[str, dict[str, Any]],
+    skills: dict[str, LiveAgentSkill],
+    qualifications: dict[str, dict[str, Any]],
+) -> tuple[dict[str, Any], list[str]]:
+    records: dict[str, Any] = {}
+    errors: list[str] = []
+    for task in selected_tasks:
+        task_record = selected_by_id[task.task_id]
+        record = qualifications.get(task.task_id)
+        if not isinstance(record, dict):
+            errors.append(f"missing oracle qualification: {task.task_id}")
+            continue
+        expected_skill_hash = _oracle_skill_hash(task, skills)
+        if record.get("verifier_passed") is not True:
+            errors.append(f"oracle qualification did not pass: {task.task_id}")
+        if record.get("task_hash") != task_record.get("task_hash"):
+            errors.append(f"oracle qualification task hash mismatch: {task.task_id}")
+        if record.get("verifier_hash") != task_record.get("verifier_hash"):
+            errors.append(f"oracle qualification verifier hash mismatch: {task.task_id}")
+        if record.get("skill_hash") != expected_skill_hash:
+            errors.append(f"oracle qualification skill hash mismatch: {task.task_id}")
+        if int(record.get("trials", 0)) < 1:
+            errors.append(f"missing oracle qualification trials: {task.task_id}")
+        if float(record.get("pass_rate", 0.0)) < 1.0:
+            errors.append(f"oracle qualification pass rate below 1.0: {task.task_id}")
+        if not record.get("constraints"):
+            errors.append(f"missing oracle qualification constraints: {task.task_id}")
+        if not record.get("qualification_command"):
+            errors.append(f"missing oracle qualification command: {task.task_id}")
+        if not record.get("output_hash"):
+            errors.append(f"missing oracle qualification output hash: {task.task_id}")
+        records[task.task_id] = {
+            **record,
+            "expected_skill_hash": expected_skill_hash,
+        }
+    return records, errors
+
+
+def _stage2_routed_prediction_records(
+    *,
+    selected_tasks: list[SkillsBenchTask],
+    routed_prediction_artifact: dict[str, Any],
+    router_top_k: int,
+    global_skill_registry_hash: str,
+) -> tuple[dict[str, Any], list[str]]:
+    router = routed_prediction_artifact["router"]
+    routed_predictions = routed_prediction_artifact["predictions"]
+    records: dict[str, Any] = {}
+    errors: list[str] = []
+    if not router.get("router_id"):
+        errors.append("missing router_id for routed predictions")
+    if not router.get("config_hash"):
+        errors.append("missing router config_hash for routed predictions")
+    if int(router.get("top_k", 0)) != router_top_k:
+        errors.append("routed prediction router top_k does not match package")
+    for task in selected_tasks:
+        full_prediction = routed_predictions.get(task.task_id)
+        if not full_prediction:
+            errors.append(f"missing routed predictions for task: {task.task_id}")
+            continue
+        predicted = _dedupe(full_prediction)
+        records[task.task_id] = {
+            "task_id": task.task_id,
+            "router_id": router.get("router_id"),
+            "config_hash": router.get("config_hash"),
+            "top_k": router_top_k,
+            "global_skill_registry_hash": global_skill_registry_hash,
+            "predicted_skill_ids": predicted,
+            "mounted_top_k": predicted[:router_top_k],
+            "prediction_hash": _canonical_hash(full_prediction),
+        }
+    return records, errors
+
+
+def _routed_prediction_input_errors(
+    *,
+    selected_tasks: list[SkillsBenchTask],
+    routed_predictions: dict[str, list[str]],
+    router: dict[str, Any],
+    skills: dict[str, LiveAgentSkill],
+    router_top_k: int,
+) -> list[str]:
+    errors: list[str] = []
+    if not router.get("router_id"):
+        errors.append("missing router_id for routed predictions")
+    if not router.get("config_hash"):
+        errors.append("missing router config_hash for routed predictions")
+    if int(router.get("top_k", 0)) != router_top_k:
+        errors.append("routed prediction router top_k does not match package")
+    for task in selected_tasks:
+        predictions = routed_predictions.get(task.task_id)
+        if not predictions:
+            errors.append(f"missing routed predictions for task: {task.task_id}")
+            continue
+        for skill_id in _dedupe(predictions):
+            if skill_id not in skills:
+                errors.append(
+                    f"unknown routed prediction skill id: {task.task_id} -> {skill_id}"
+                )
+    return errors
+
+
+def _oracle_skill_hash(
+    task: SkillsBenchTask,
+    skills: dict[str, LiveAgentSkill],
+) -> str:
+    skill_records = [_skill_to_plan(skills[skill_id]) for skill_id in task.oracle_skill_ids]
+    if len(skill_records) == 1:
+        return _canonical_hash(skill_records[0])
+    return _canonical_hash(skill_records)
+
+
 def _validate_real_evidence_plan(plan: dict[str, Any]) -> None:
     if plan.get("evidence_label") == "fixture-only" or _fixture_path(plan.get("data_root")):
         raise ValueError("fixture-only SkillsBench data cannot be used in real evidence mode")
@@ -1346,6 +1697,29 @@ def _skill_leakage_errors(
                 errors.append(
                     f"leakage in public skill metadata for {skill.skill_id}: {token}"
                 )
+    return errors
+
+
+def _public_skill_text_leakage_errors(
+    tasks: list[SkillsBenchTask],
+    skills: Iterable[LiveAgentSkill],
+) -> list[str]:
+    task_ids = {task.task_id.lower() for task in tasks}
+    oracle_skill_ids = {
+        skill_id.lower() for task in tasks for skill_id in task.oracle_skill_ids
+    }
+    errors = []
+    for skill in skills:
+        public = f"{skill.name} {skill.description or ''} {skill.body}".lower()
+        if any(task_id in public for task_id in task_ids):
+            errors.append(f"leakage in public skill text for {skill.skill_id}: task_id")
+        if any(skill_id in public for skill_id in oracle_skill_ids):
+            errors.append(
+                f"leakage in public skill text for {skill.skill_id}: oracle skill id"
+            )
+        for token in LABEL_LEAKAGE_TOKENS:
+            if token in public:
+                errors.append(f"leakage in public skill text for {skill.skill_id}: {token}")
     return errors
 
 

--- a/src/hermes_skilleval/live_agent_skillsbench.py
+++ b/src/hermes_skilleval/live_agent_skillsbench.py
@@ -34,8 +34,10 @@ CONTROLLED_NETWORKS = {"none", "controlled"}
 DEFAULT_ROUTER_TOP_K = 3
 EVIDENCE_MODES = {"fixture", "real"}
 COMMIT_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
 LABEL_LEAKAGE_TOKENS = ("oracle", "gold", "source-task", "source_task")
 VERIFIER_ARTIFACT_ROLES = ("code", "config", "input")
+DISALLOWED_ROUTED_LABEL_SOURCES = {"oracle", "manual", "ad_hoc"}
 
 
 @dataclass(frozen=True)
@@ -390,15 +392,6 @@ def build_stage2_real_pilot_input_package(
 
     errors: list[str] = []
     errors.extend(_public_skill_text_leakage_errors(selected_tasks, skills.values()))
-    errors.extend(
-        _routed_prediction_input_errors(
-            selected_tasks=selected_tasks,
-            routed_predictions=routed_predictions,
-            router=routed_prediction_artifact["router"],
-            skills=skills,
-            router_top_k=router_top_k,
-        )
-    )
 
     selected_task_records = [
         _stage2_input_task_record(
@@ -408,6 +401,7 @@ def build_stage2_real_pilot_input_package(
         )
         for task in selected_tasks
     ]
+    errors.extend(_stage2_task_source_errors(selected_task_records))
     selected_by_id = {task["task_id"]: task for task in selected_task_records}
     verifier_records, verifier_errors = _stage2_verifier_package_records(
         selected_task_records
@@ -419,6 +413,16 @@ def build_stage2_real_pilot_input_package(
         for skill_id, skill in sorted(skills.items())
     }
     global_registry_hash = _canonical_hash(global_registry)
+    errors.extend(
+        _routed_prediction_input_errors(
+            selected_tasks=selected_tasks,
+            routed_predictions=routed_predictions,
+            router=routed_prediction_artifact["router"],
+            skills=skills,
+            router_top_k=router_top_k,
+            global_skill_registry_hash=global_registry_hash,
+        )
+    )
     oracle_records, oracle_errors = _stage2_oracle_package_records(
         selected_tasks=selected_tasks,
         selected_by_id=selected_by_id,
@@ -475,6 +479,16 @@ def build_stage2_real_pilot_input_package(
             "config_hash": routed_prediction_artifact["router"].get("config_hash"),
             "top_k": router_top_k,
             "global_skill_registry_hash": global_registry_hash,
+            "generation_command": routed_prediction_artifact["router"].get(
+                "generation_command"
+            ),
+            "generation_artifact_hash": routed_prediction_artifact["router"].get(
+                "generation_artifact_hash"
+            ),
+            "oracle_labels_read": routed_prediction_artifact["router"].get(
+                "oracle_labels_read"
+            ),
+            "label_source": routed_prediction_artifact["router"].get("label_source"),
             "records": routed_records,
         },
         "global_skill_registry_package": {
@@ -1099,6 +1113,14 @@ def _stage2_input_task_record(
     }
 
 
+def _stage2_task_source_errors(selected_task_records: list[dict[str, Any]]) -> list[str]:
+    errors = []
+    for task in selected_task_records:
+        if not _non_empty_metadata_value(task.get("source_or_provenance")):
+            errors.append(f"missing task source/provenance: {task.get('task_id')}")
+    return errors
+
+
 def _stage2_verifier_package_records(
     selected_task_records: list[dict[str, Any]],
 ) -> tuple[dict[str, Any], list[str]]:
@@ -1118,6 +1140,9 @@ def _stage2_verifier_package_records(
         ):
             errors.append(f"missing verifier code/config/input hashes: {task_id}")
             continue
+        for role in VERIFIER_ARTIFACT_ROLES:
+            if not _sha256_hex(artifacts[role].get("sha256")):
+                errors.append(f"malformed verifier {role} artifact sha256: {task_id}")
         for field in (
             "expected_output_format",
             "constraints",
@@ -1193,6 +1218,8 @@ def _stage2_oracle_package_records(
             errors.append(f"missing oracle qualification command: {task.task_id}")
         if not record.get("output_hash"):
             errors.append(f"missing oracle qualification output hash: {task.task_id}")
+        elif not _sha256_hex(record.get("output_hash")):
+            errors.append(f"malformed oracle qualification output hash: {task.task_id}")
         records[task.task_id] = {
             **record,
             "expected_skill_hash": expected_skill_hash,
@@ -1215,6 +1242,10 @@ def _stage2_routed_prediction_records(
         errors.append("missing router_id for routed predictions")
     if not router.get("config_hash"):
         errors.append("missing router config_hash for routed predictions")
+    elif not _sha256_hex(router.get("config_hash")):
+        errors.append("malformed routed prediction config_hash")
+    if not _sha256_hex(router.get("global_skill_registry_hash")):
+        errors.append("malformed routed prediction global_skill_registry_hash")
     if int(router.get("top_k", 0)) != router_top_k:
         errors.append("routed prediction router top_k does not match package")
     for task in selected_tasks:
@@ -1243,12 +1274,37 @@ def _routed_prediction_input_errors(
     router: dict[str, Any],
     skills: dict[str, LiveAgentSkill],
     router_top_k: int,
+    global_skill_registry_hash: str,
 ) -> list[str]:
     errors: list[str] = []
     if not router.get("router_id"):
         errors.append("missing router_id for routed predictions")
     if not router.get("config_hash"):
         errors.append("missing router config_hash for routed predictions")
+    elif not _sha256_hex(router.get("config_hash")):
+        errors.append("malformed routed prediction config_hash")
+    routed_registry_hash = router.get("global_skill_registry_hash")
+    if not routed_registry_hash:
+        errors.append("missing routed prediction global_skill_registry_hash")
+    elif not _sha256_hex(routed_registry_hash):
+        errors.append("malformed routed prediction global_skill_registry_hash")
+    elif routed_registry_hash != global_skill_registry_hash:
+        errors.append("routed prediction registry hash mismatch")
+    if not (
+        _non_empty_metadata_value(router.get("generation_command"))
+        or _sha256_hex(router.get("generation_artifact_hash"))
+    ):
+        errors.append("missing routed prediction generation provenance")
+    generation_artifact_hash = router.get("generation_artifact_hash")
+    if generation_artifact_hash and not _sha256_hex(generation_artifact_hash):
+        errors.append("malformed routed prediction generation_artifact_hash")
+    if router.get("oracle_labels_read") is not False:
+        errors.append("routed predictions oracle labels were read or not proven unread")
+    label_source = router.get("label_source")
+    if not isinstance(label_source, str) or not label_source.strip():
+        errors.append("missing routed prediction label_source")
+    elif label_source in DISALLOWED_ROUTED_LABEL_SOURCES:
+        errors.append("routed prediction label_source is not allowed")
     if int(router.get("top_k", 0)) != router_top_k:
         errors.append("routed prediction router top_k does not match package")
     for task in selected_tasks:
@@ -1256,7 +1312,10 @@ def _routed_prediction_input_errors(
         if not predictions:
             errors.append(f"missing routed predictions for task: {task.task_id}")
             continue
-        for skill_id in _dedupe(predictions):
+        deduped = _dedupe(predictions)
+        if len(deduped) < router_top_k:
+            errors.append(f"insufficient routed top-k for task: {task.task_id}")
+        for skill_id in deduped:
             if skill_id not in skills:
                 errors.append(
                     f"unknown routed prediction skill id: {task.task_id} -> {skill_id}"
@@ -1779,6 +1838,18 @@ def _non_empty(value: str, field: str) -> str:
     if not isinstance(value, str) or not value.strip():
         raise ValueError(f"{field} must be non-empty")
     return value
+
+
+def _non_empty_metadata_value(value: Any) -> bool:
+    if isinstance(value, str):
+        return bool(value.strip())
+    if isinstance(value, (dict, list, tuple, set)):
+        return bool(value)
+    return value is not None
+
+
+def _sha256_hex(value: Any) -> bool:
+    return isinstance(value, str) and SHA256_RE.fullmatch(value) is not None
 
 
 def _safe_run_id(value: str) -> str:

--- a/tests/test_skillsbench_live_matrix.py
+++ b/tests/test_skillsbench_live_matrix.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import hashlib
 import shutil
 from pathlib import Path
 
@@ -72,6 +73,36 @@ def _real_preflight() -> dict:
             "bundled_skills": {"status": "SYSTEM_MANAGED_UNKNOWN"},
         },
     }
+
+
+def _sha256_text(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _stage2_expected_registry_hash(skills: list[dict]) -> str:
+    records = {}
+    for skill in skills:
+        description = skill["description"]
+        body = skill["body"]
+        records[skill["skill_id"]] = {
+            "skill_id": skill["skill_id"],
+            "name": skill["name"],
+            "description": description,
+            "body": body,
+            "skill_hash": _canonical_hash(
+                {
+                    "skill_id": skill["skill_id"],
+                    "name": skill["name"],
+                    "description": description,
+                    "body": body,
+                }
+            ),
+            "name_hash": _sha256_text(skill["name"]),
+            "description_hash": _sha256_text(description),
+            "body_hash": _sha256_text(body),
+            "public_skill_text_leakage_guard": "PASS",
+        }
+    return _canonical_hash(dict(sorted(records.items())))
 
 
 def _write_real_like_pilot_inputs(root: Path) -> dict[str, Path]:
@@ -198,6 +229,7 @@ def _write_real_like_pilot_inputs(root: Path) -> dict[str, Path]:
         "".join(json.dumps(record, sort_keys=True) + "\n" for record in oracle_records),
         encoding="utf-8",
     )
+    registry_hash = _stage2_expected_registry_hash(skills)
     (root / "routed_predictions.json").write_text(
         json.dumps(
             {
@@ -206,6 +238,10 @@ def _write_real_like_pilot_inputs(root: Path) -> dict[str, Path]:
                     "router_id": "unit-router",
                     "config_hash": "c" * 64,
                     "top_k": 1,
+                    "global_skill_registry_hash": registry_hash,
+                    "generation_command": "python -m hermes_skilleval.cli route-skills",
+                    "oracle_labels_read": False,
+                    "label_source": "router_predictions",
                 },
                 "predictions": predictions,
             },
@@ -1099,6 +1135,19 @@ def test_stage2_real_pilot_input_package_missing_verifier_hashes_fail_closed(tmp
         _build_real_like_pilot_input_package(paths)
 
 
+def test_stage2_real_pilot_input_package_missing_source_provenance_fails_closed(
+    tmp_path,
+):
+    paths = _write_real_like_pilot_inputs(tmp_path / "skillsbench-real")
+    tasks = _read_jsonl_file(paths["data_root"] / "tasks.jsonl")
+    tasks[0].pop("source")
+    tasks[0].pop("provenance")
+    _write_jsonl_file(paths["data_root"] / "tasks.jsonl", tasks)
+
+    with pytest.raises(ValueError, match="missing task source/provenance: sb-real-1"):
+        _build_real_like_pilot_input_package(paths)
+
+
 def test_stage2_real_pilot_input_package_missing_oracle_qualification_fail_closed(
     tmp_path,
 ):
@@ -1120,6 +1169,140 @@ def test_stage2_real_pilot_input_package_unknown_routed_skill_fails_closed(tmp_p
     )
 
     with pytest.raises(ValueError, match="unknown routed prediction skill id"):
+        _build_real_like_pilot_input_package(paths)
+
+
+def test_stage2_real_pilot_input_package_missing_routing_provenance_fails_closed(
+    tmp_path,
+):
+    paths = _write_real_like_pilot_inputs(tmp_path / "skillsbench-real")
+    routed = json.loads(paths["routed_predictions"].read_text(encoding="utf-8"))
+    routed["router"].pop("generation_command")
+    paths["routed_predictions"].write_text(
+        json.dumps(routed, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="missing routed prediction generation provenance"):
+        _build_real_like_pilot_input_package(paths)
+
+
+@pytest.mark.parametrize(
+    ("mutator", "message"),
+    [
+        (
+            lambda router: router.__setitem__("oracle_labels_read", True),
+            "oracle labels were read",
+        ),
+        (
+            lambda router: router.__setitem__("label_source", "oracle"),
+            "routed prediction label_source is not allowed",
+        ),
+        (
+            lambda router: router.__setitem__("label_source", "manual"),
+            "routed prediction label_source is not allowed",
+        ),
+        (
+            lambda router: router.__setitem__("label_source", "ad_hoc"),
+            "routed prediction label_source is not allowed",
+        ),
+    ],
+)
+def test_stage2_real_pilot_input_package_rejects_oracle_or_ad_hoc_routing(
+    tmp_path,
+    mutator,
+    message,
+):
+    paths = _write_real_like_pilot_inputs(tmp_path / "skillsbench-real")
+    routed = json.loads(paths["routed_predictions"].read_text(encoding="utf-8"))
+    mutator(routed["router"])
+    paths["routed_predictions"].write_text(
+        json.dumps(routed, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match=message):
+        _build_real_like_pilot_input_package(paths)
+
+
+def test_stage2_real_pilot_input_package_rejects_registry_hash_mismatch(tmp_path):
+    paths = _write_real_like_pilot_inputs(tmp_path / "skillsbench-real")
+    routed = json.loads(paths["routed_predictions"].read_text(encoding="utf-8"))
+    routed["router"]["global_skill_registry_hash"] = "e" * 64
+    paths["routed_predictions"].write_text(
+        json.dumps(routed, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="routed prediction registry hash mismatch"):
+        _build_real_like_pilot_input_package(paths)
+
+
+def test_stage2_real_pilot_input_package_requires_enough_routed_top_k(tmp_path):
+    paths = _write_real_like_pilot_inputs(tmp_path / "skillsbench-real")
+    routed = json.loads(paths["routed_predictions"].read_text(encoding="utf-8"))
+    routed["router"]["top_k"] = 2
+    routed["predictions"]["sb-real-1"] = ["skill/real-1", "skill/real-1"]
+    paths["routed_predictions"].write_text(
+        json.dumps(routed, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="insufficient routed top-k"):
+        build_stage2_real_pilot_input_package(
+            data_root=paths["data_root"],
+            upstream_ref=UPSTREAM_SHA,
+            license_note="approved-real-pilot-unit",
+            run_id="stage2-real-pilot-input-package-unit",
+            selected_task_ids=[f"sb-real-{index}" for index in range(1, 5)],
+            routed_predictions_path=paths["routed_predictions"],
+            oracle_qualification_path=paths["oracle_qualification"],
+            router_top_k=2,
+        )
+
+
+@pytest.mark.parametrize(
+    ("mutator", "message"),
+    [
+        (
+            lambda routed, oracle: routed["router"].__setitem__(
+                "config_hash",
+                "not-a-sha",
+            ),
+            "malformed routed prediction config_hash",
+        ),
+        (
+            lambda routed, oracle: routed["router"].__setitem__(
+                "global_skill_registry_hash",
+                "not-a-sha",
+            ),
+            "malformed routed prediction global_skill_registry_hash",
+        ),
+        (
+            lambda routed, oracle: oracle[0].__setitem__(
+                "output_hash",
+                "not-a-sha",
+            ),
+            "malformed oracle qualification output hash",
+        ),
+    ],
+)
+def test_stage2_real_pilot_input_package_rejects_malformed_hash_strings(
+    tmp_path,
+    mutator,
+    message,
+):
+    paths = _write_real_like_pilot_inputs(tmp_path / "skillsbench-real")
+    routed = json.loads(paths["routed_predictions"].read_text(encoding="utf-8"))
+    oracle = _read_jsonl_file(paths["oracle_qualification"])
+    mutator(routed, oracle)
+    paths["routed_predictions"].write_text(
+        json.dumps(routed, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    _write_jsonl_file(paths["oracle_qualification"], oracle)
+
+    with pytest.raises(ValueError, match=message):
         _build_real_like_pilot_input_package(paths)
 
 
@@ -1187,6 +1370,9 @@ def test_stage2_real_pilot_input_package_records_required_hashes(tmp_path):
     assert routed["config_hash"] == "c" * 64
     assert routed["top_k"] == 1
     assert routed["global_skill_registry_hash"] == registry["global_skill_registry_hash"]
+    assert routed["generation_command"] == "python -m hermes_skilleval.cli route-skills"
+    assert routed["oracle_labels_read"] is False
+    assert routed["label_source"] == "router_predictions"
     for task_id, record in routed["records"].items():
         assert task_id in selected_by_id
         assert record["prediction_hash"]

--- a/tests/test_skillsbench_live_matrix.py
+++ b/tests/test_skillsbench_live_matrix.py
@@ -17,6 +17,7 @@ from hermes_skilleval.live_agent_runtime import (
 )
 from hermes_skilleval.live_agent_skillsbench import (
     SkillsBenchAdapter,
+    build_stage2_real_pilot_input_package,
     _canonical_hash,
     _validate_real_runner_preflight,
     run_skillsbench_matrix,
@@ -100,6 +101,20 @@ def _write_real_like_pilot_inputs(root: Path) -> dict[str, Path]:
             "code_path": "verifiers/check.py",
             "config_path": "verifiers/config.json",
             "input_path": "verifiers/input.json",
+            "expected_output_format": {
+                "type": "json",
+                "required_fields": ["passed", "details"],
+            },
+            "constraints": {
+                "credentials": "none",
+                "network": "none",
+                "local_execution": True,
+            },
+            "deterministic_assumptions": {
+                "network": "disabled",
+                "clock": "not_used",
+                "randomness": "not_used",
+            },
         }
         task = {
             "task_id": task_id,
@@ -150,6 +165,8 @@ def _write_real_like_pilot_inputs(root: Path) -> dict[str, Path]:
                     "network": "none",
                     "verifier": "deterministic",
                 },
+                "qualification_command": "python verifiers/check.py --qualification",
+                "output_hash": "d" * 64,
             }
         )
         skills.append(skill)
@@ -241,6 +258,34 @@ def _mutate_plan(plan_path: Path, mutator) -> None:
     mutator(plan)
     plan_path.write_text(json.dumps(plan, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     _rewrite_plan_digest(plan_path)
+
+
+def _read_jsonl_file(path: Path) -> list[dict]:
+    return [
+        json.loads(line)
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+
+def _write_jsonl_file(path: Path, records: list[dict]) -> None:
+    path.write_text(
+        "".join(json.dumps(record, sort_keys=True) + "\n" for record in records),
+        encoding="utf-8",
+    )
+
+
+def _build_real_like_pilot_input_package(paths: dict[str, Path]) -> dict:
+    return build_stage2_real_pilot_input_package(
+        data_root=paths["data_root"],
+        upstream_ref=UPSTREAM_SHA,
+        license_note="approved-real-pilot-unit",
+        run_id="stage2-real-pilot-input-package-unit",
+        selected_task_ids=[f"sb-real-{index}" for index in range(1, 5)],
+        routed_predictions_path=paths["routed_predictions"],
+        oracle_qualification_path=paths["oracle_qualification"],
+        router_top_k=1,
+    )
 
 
 def test_skillsbench_adapter_validates_tiny_fixture():
@@ -1012,6 +1057,160 @@ def test_stage2_pilot_plan_records_task_verifier_oracle_and_routing_hashes(tmp_p
         assert record["router_top_k"] == 1
         assert record["global_skill_registry_hash"] == plan["global_skill_registry_hash"]
         assert record["prediction_hash"]
+
+
+def test_stage2_real_pilot_input_package_rejects_fixture_only_data_root():
+    with pytest.raises(ValueError, match="fixture-only SkillsBench data"):
+        build_stage2_real_pilot_input_package(
+            data_root=FIXTURE,
+            upstream_ref="fixture-ref",
+            license_note="fixture-only",
+            run_id="stage2-real-pilot-input-package-unit",
+            selected_task_ids=["sb-task-login", "sb-task-edit"],
+            routed_predictions_path=FIXTURE / "routed_predictions.json",
+            oracle_qualification_path=FIXTURE / "oracle_qualification.jsonl",
+            router_top_k=1,
+        )
+
+
+def test_stage2_real_pilot_input_package_requires_exactly_four_tasks(tmp_path):
+    paths = _write_real_like_pilot_inputs(tmp_path / "skillsbench-real")
+
+    with pytest.raises(ValueError, match="exactly 4 selected tasks"):
+        build_stage2_real_pilot_input_package(
+            data_root=paths["data_root"],
+            upstream_ref=UPSTREAM_SHA,
+            license_note="approved-real-pilot-unit",
+            run_id="stage2-real-pilot-input-package-unit",
+            selected_task_ids=["sb-real-1", "sb-real-2", "sb-real-3"],
+            routed_predictions_path=paths["routed_predictions"],
+            oracle_qualification_path=paths["oracle_qualification"],
+            router_top_k=1,
+        )
+
+
+def test_stage2_real_pilot_input_package_missing_verifier_hashes_fail_closed(tmp_path):
+    paths = _write_real_like_pilot_inputs(tmp_path / "skillsbench-real")
+    tasks = _read_jsonl_file(paths["data_root"] / "tasks.jsonl")
+    tasks[0]["verifier"].pop("code_path")
+    _write_jsonl_file(paths["data_root"] / "tasks.jsonl", tasks)
+
+    with pytest.raises(ValueError, match="missing verifier code/config/input hashes"):
+        _build_real_like_pilot_input_package(paths)
+
+
+def test_stage2_real_pilot_input_package_missing_oracle_qualification_fail_closed(
+    tmp_path,
+):
+    paths = _write_real_like_pilot_inputs(tmp_path / "skillsbench-real")
+    records = _read_jsonl_file(paths["oracle_qualification"])
+    _write_jsonl_file(paths["oracle_qualification"], records[:-1])
+
+    with pytest.raises(ValueError, match="missing oracle qualification: sb-real-4"):
+        _build_real_like_pilot_input_package(paths)
+
+
+def test_stage2_real_pilot_input_package_unknown_routed_skill_fails_closed(tmp_path):
+    paths = _write_real_like_pilot_inputs(tmp_path / "skillsbench-real")
+    predictions = json.loads(paths["routed_predictions"].read_text(encoding="utf-8"))
+    predictions["predictions"]["sb-real-2"] = ["skill/unknown"]
+    paths["routed_predictions"].write_text(
+        json.dumps(predictions, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="unknown routed prediction skill id"):
+        _build_real_like_pilot_input_package(paths)
+
+
+def test_stage2_real_pilot_input_package_records_required_hashes(tmp_path):
+    paths = _write_real_like_pilot_inputs(tmp_path / "skillsbench-real")
+
+    package = _build_real_like_pilot_input_package(paths)
+
+    assert package["schema_version"] == "v0.3.stage2-real-pilot-input-package.v1"
+    assert package["status"] == "READY_FOR_REVIEW_NOT_EXECUTED"
+    assert package["pilot_shape"] == {
+        "task_count": 4,
+        "conditions": ["no-skill", "routed-skill", "oracle-skill"],
+        "trials_per_condition": 1,
+        "total_runs": 12,
+    }
+    assert package["non_actions"]["stage2_pilot_run"] is False
+    assert package["deterministic_verifier_package"]["success_source"] == (
+        "deterministic_verifier_output_only"
+    )
+    assert package["deterministic_verifier_package"]["process_exit_code_success_source"] is False
+    assert package["deterministic_verifier_package"]["llm_judge_accepted"] is False
+
+    selected_by_id = {
+        task["task_id"]: task
+        for task in package["data_root_package"]["selected_tasks"]
+    }
+    assert set(selected_by_id) == {f"sb-real-{index}" for index in range(1, 5)}
+    for task in selected_by_id.values():
+        assert task["source_or_provenance"]
+        assert task["license_note"] == "approved-real-pilot-unit"
+        assert task["prompt_hash"]
+        assert task["task_hash"]
+        assert set(task["verifier_artifacts"]) == {"code", "config", "input"}
+
+    registry = package["global_skill_registry_package"]
+    assert registry["global_skill_registry_hash"] == _canonical_hash(registry["skills"])
+    assert set(registry["skills"]) == {f"skill/real-{index}" for index in range(1, 5)}
+    assert all(record["body_hash"] for record in registry["skills"].values())
+    assert all(record["name_hash"] for record in registry["skills"].values())
+    assert all(record["description_hash"] for record in registry["skills"].values())
+
+    for task_id, record in package["deterministic_verifier_package"]["records"].items():
+        assert task_id in selected_by_id
+        assert record["verifier_hash"] == selected_by_id[task_id]["verifier_hash"]
+        assert record["code_hash"]
+        assert record["config_hash"]
+        assert record["input_hash"]
+        assert record["expected_output_format"]
+        assert record["constraints"]
+        assert record["deterministic_assumptions"]
+
+    for task_id, record in package["oracle_qualification_package"]["records"].items():
+        assert task_id in selected_by_id
+        assert record["task_hash"] == selected_by_id[task_id]["task_hash"]
+        assert record["verifier_hash"] == selected_by_id[task_id]["verifier_hash"]
+        assert record["skill_hash"]
+        assert record["trials"] == 1
+        assert record["pass_rate"] == 1.0
+        assert record["qualification_command"]
+        assert record["output_hash"]
+
+    routed = package["routed_predictions_package"]
+    assert routed["router_id"] == "unit-router"
+    assert routed["config_hash"] == "c" * 64
+    assert routed["top_k"] == 1
+    assert routed["global_skill_registry_hash"] == registry["global_skill_registry_hash"]
+    for task_id, record in routed["records"].items():
+        assert task_id in selected_by_id
+        assert record["prediction_hash"]
+        assert record["predicted_skill_ids"]
+
+
+def test_stage2_real_pilot_input_package_leakage_guard_catches_prompt_and_skill_text(
+    tmp_path,
+):
+    prompt_paths = _write_real_like_pilot_inputs(tmp_path / "prompt-leak")
+    tasks = _read_jsonl_file(prompt_paths["data_root"] / "tasks.jsonl")
+    tasks[0]["prompt"] = "Complete sb-real-1 using the gold oracle label."
+    _write_jsonl_file(prompt_paths["data_root"] / "tasks.jsonl", tasks)
+
+    with pytest.raises(ValueError, match="leakage in prompt"):
+        _build_real_like_pilot_input_package(prompt_paths)
+
+    skill_paths = _write_real_like_pilot_inputs(tmp_path / "skill-leak")
+    skills = _read_jsonl_file(skill_paths["data_root"] / "skills.jsonl")
+    skills[0]["body"] = "This public skill text is the oracle path for sb-real-1."
+    _write_jsonl_file(skill_paths["data_root"] / "skills.jsonl", skills)
+
+    with pytest.raises(ValueError, match="leakage in public skill text"):
+        _build_real_like_pilot_input_package(skill_paths)
 
 
 def test_cli_skillsbench_plan_and_matrix_write_outputs(tmp_path):


### PR DESCRIPTION
This branch does not execute Stage 2.

- No Codex run was executed.
- No frozen pilot plan was created.
- No traces were created.
- No performance claims are made.
- No real 4-task pilot input package exists yet.
- The branch records a precise blocked report and adds a fail-closed validator for future real Stage 2 pilot input packages.
- Fixture-only data roots are rejected for real input package mode.
- Exactly 4 tasks are required.
- Missing task source/provenance fails closed.
- Missing verifier hashes fail closed.
- Missing oracle qualification fails closed.
- Unknown routed skill IDs fail closed.
- Routed predictions must record generation provenance, global skill registry hash, oracle_labels_read=false, and non-oracle/non-manual/non-ad-hoc label source.
- Routed prediction registry hash mismatch fails closed.
- Insufficient routed top-k fails closed.
- Malformed critical hashes fail closed.

Validation before merge:

- `python -m pytest -q tests/test_skillsbench_live_matrix.py` -> 63 passed
- `python -m pytest -q` -> 646 passed
- `OPENSPEC_TELEMETRY=0 openspec validate --all --strict` -> 23 passed
- `PYTHONPATH=src python -m hermes_skilleval.cli release-check --phase17-output-dir docs/demo/phase17-calibrated-release-selector --release-output-dir docs/demo/phase18-ci-release-reproducibility` -> Release reproducibility PASS
- YAML/JSON parse checks -> passed
- `git diff --check` -> passed
