### PR TITLE
ops: export Stage 2 pilot routed predictions

### DIFF
--- a/src/hermes_skilleval/cli.py
+++ b/src/hermes_skilleval/cli.py
@@ -55,6 +55,7 @@ from hermes_skilleval.github_action_gate import run_github_action_gate
 from hermes_skilleval.live_agent_skillsbench import (
     SkillsBenchAdapter,
     run_skillsbench_matrix,
+    write_stage2_pilot_routed_prediction_artifacts,
     write_skillsbench_plan,
 )
 from hermes_skilleval.live_agent_runtime import CodexCliRunner, CodexCliRunnerConfig
@@ -438,6 +439,30 @@ def _build_parser() -> argparse.ArgumentParser:
     skillsbench_validate_parser.add_argument("--upstream-ref", required=True)
     skillsbench_validate_parser.add_argument("--license-note", required=True)
     skillsbench_validate_parser.set_defaults(handler=_run_skillsbench_validate)
+
+    skillsbench_export_routed_parser = subparsers.add_parser(
+        "skillsbench-export-routed-predictions",
+        help="export Stage 2 pilot routed predictions without running live agents",
+    )
+    skillsbench_export_routed_parser.add_argument("--tasks-manifest", required=True)
+    skillsbench_export_routed_parser.add_argument("--global-skill-registry", required=True)
+    skillsbench_export_routed_parser.add_argument("--output", required=True)
+    skillsbench_export_routed_parser.add_argument("--manifest-output", required=True)
+    skillsbench_export_routed_parser.add_argument(
+        "--router-id",
+        choices=("keyword", "hybrid", "embedding", "gated"),
+        required=True,
+    )
+    skillsbench_export_routed_parser.add_argument("--config-id", required=True)
+    skillsbench_export_routed_parser.add_argument("--top-k", type=int, required=True)
+    skillsbench_export_routed_parser.add_argument(
+        "--final-evidence",
+        action="store_true",
+        help="fail closed for fixture inputs; does not execute Stage 2",
+    )
+    skillsbench_export_routed_parser.set_defaults(
+        handler=_run_skillsbench_export_routed_predictions
+    )
 
     skillsbench_plan_parser = subparsers.add_parser(
         "skillsbench-plan",
@@ -1219,6 +1244,47 @@ def _run_skillsbench_validate(args: argparse.Namespace) -> None:
     )
     if validation["status"] != "PASS":
         raise ValueError("SkillsBench validation failed")
+
+
+def _run_skillsbench_export_routed_predictions(args: argparse.Namespace) -> None:
+    generation_command = [
+        "python",
+        "-m",
+        "hermes_skilleval.cli",
+        "skillsbench-export-routed-predictions",
+        "--tasks-manifest",
+        args.tasks_manifest,
+        "--global-skill-registry",
+        args.global_skill_registry,
+        "--output",
+        args.output,
+        "--manifest-output",
+        args.manifest_output,
+        "--router-id",
+        args.router_id,
+        "--config-id",
+        args.config_id,
+        "--top-k",
+        str(args.top_k),
+    ]
+    if args.final_evidence:
+        generation_command.append("--final-evidence")
+    export = write_stage2_pilot_routed_prediction_artifacts(
+        tasks_manifest_path=args.tasks_manifest,
+        global_skill_registry_path=args.global_skill_registry,
+        output_path=args.output,
+        manifest_output_path=args.manifest_output,
+        router_id=args.router_id,
+        config_id=args.config_id,
+        top_k=args.top_k,
+        generation_command=generation_command,
+        final_evidence=args.final_evidence,
+    )
+    print(
+        "SkillsBench routed predictions "
+        f"{args.config_id}: {args.output} "
+        f"({export['task_count']} tasks, top_k={args.top_k})"
+    )
 
 
 def _run_skillsbench_plan(args: argparse.Namespace) -> None:

--- a/src/hermes_skilleval/cli.py
+++ b/src/hermes_skilleval/cli.py
@@ -449,6 +449,11 @@ def _build_parser() -> argparse.ArgumentParser:
     skillsbench_export_routed_parser.add_argument("--output", required=True)
     skillsbench_export_routed_parser.add_argument("--manifest-output", required=True)
     skillsbench_export_routed_parser.add_argument(
+        "--approved-router-config",
+        default=None,
+        help="approved frozen router config JSON required for final evidence export",
+    )
+    skillsbench_export_routed_parser.add_argument(
         "--router-id",
         choices=("keyword", "hybrid", "embedding", "gated"),
         required=True,
@@ -1267,6 +1272,13 @@ def _run_skillsbench_export_routed_predictions(args: argparse.Namespace) -> None
         "--top-k",
         str(args.top_k),
     ]
+    if args.approved_router_config:
+        generation_command.extend(
+            [
+                "--approved-router-config",
+                args.approved_router_config,
+            ]
+        )
     if args.final_evidence:
         generation_command.append("--final-evidence")
     export = write_stage2_pilot_routed_prediction_artifacts(
@@ -1277,6 +1289,7 @@ def _run_skillsbench_export_routed_predictions(args: argparse.Namespace) -> None
         router_id=args.router_id,
         config_id=args.config_id,
         top_k=args.top_k,
+        approved_router_config_path=args.approved_router_config,
         generation_command=generation_command,
         final_evidence=args.final_evidence,
     )

--- a/src/hermes_skilleval/live_agent_skillsbench.py
+++ b/src/hermes_skilleval/live_agent_skillsbench.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import hashlib
 import re
+import subprocess
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
@@ -36,6 +37,7 @@ REPORT_SCHEMA = "v0.3.skillsbench-live-matrix-report.v1"
 STAGE2_INPUT_PACKAGE_SCHEMA = "v0.3.stage2-real-pilot-input-package.v1"
 STAGE2_ROUTED_PREDICTIONS_SCHEMA = "v0.3.routed-predictions.v1"
 STAGE2_ROUTED_PREDICTIONS_MANIFEST_SCHEMA = "v0.3.stage2-routed-prediction-export-manifest.v1"
+STAGE2_ROUTED_PREDICTION_CONFIG_SCHEMA = "v0.3.stage2-routed-prediction-router-config.v1"
 SEED = 20260625
 CONDITIONS = ("no-skill", "routed-skill", "oracle-skill")
 CONTROLLED_NETWORKS = {"none", "controlled"}
@@ -47,6 +49,9 @@ LABEL_LEAKAGE_TOKENS = ("oracle", "gold", "source-task", "source_task")
 VERIFIER_ARTIFACT_ROLES = ("code", "config", "input")
 DISALLOWED_ROUTED_LABEL_SOURCES = {"oracle", "manual", "ad_hoc"}
 SUPPORTED_STAGE2_EXPORT_ROUTERS = {"keyword", "hybrid", "embedding", "gated"}
+MODEL_PROVENANCE_ROUTER_IDS = {"embedding", "gated"}
+FINAL_EVIDENCE_SUPPORTED_ROUTER_IDS = {"keyword", "hybrid"}
+FINAL_EVIDENCE_DIRTY_GUARD_PREFIXES = ("src/", "configs/", "tests/")
 
 
 @dataclass(frozen=True)
@@ -535,6 +540,7 @@ def write_stage2_pilot_routed_prediction_artifacts(
     router_id: str,
     config_id: str,
     top_k: int,
+    approved_router_config_path: Path | str | None = None,
     generation_command: Iterable[str] | str | None = None,
     final_evidence: bool = False,
 ) -> dict[str, Any]:
@@ -548,10 +554,16 @@ def write_stage2_pilot_routed_prediction_artifacts(
     config_id = _non_empty(config_id, "config_id").strip()
     top_k = _positive_int(top_k, "top_k")
     router_name = _stage2_export_router_name(router_id)
+    if final_evidence and router_name in MODEL_PROVENANCE_ROUTER_IDS:
+        raise ValueError(
+            f"{router_name} final evidence requires pinned model/checkpoint provenance"
+        )
     router = _stage2_export_router(router_name)
     tasks = _load_stage2_export_tasks(task_path)
     if len(tasks) != 4:
         raise ValueError("Stage 2 pilot routed export requires exactly 4 tasks")
+    if final_evidence:
+        _validate_stage2_final_evidence_task_manifest(task_path)
     skills = _load_stage2_export_registry(registry_path)
     if len(skills) < top_k:
         raise ValueError("stable global skill registry has fewer skills than top_k")
@@ -568,15 +580,35 @@ def write_stage2_pilot_routed_prediction_artifacts(
         for skill in skills
     }
     global_skill_registry_hash = _canonical_hash(dict(sorted(registry_records.items())))
-    frozen_config = {
-        "schema_version": "v0.3.stage2-routed-prediction-router-config.v1",
-        "router_id": router_name,
-        "config_id": config_id,
-        "router_class": type(router).__name__,
-        "top_k": top_k,
-        "global_skill_registry_hash": global_skill_registry_hash,
-    }
-    config_hash = _canonical_hash(frozen_config)
+    code_provenance = _stage2_export_code_provenance()
+    router_config_record: dict[str, Any] | None = None
+    if final_evidence:
+        if router_name not in FINAL_EVIDENCE_SUPPORTED_ROUTER_IDS:
+            raise ValueError(
+                f"{router_name} final evidence requires pinned model/checkpoint provenance"
+            )
+        router_config_record, frozen_config = _stage2_approved_router_config(
+            approved_router_config_path,
+            router_id=router_name,
+            config_id=config_id,
+            top_k=top_k,
+            global_skill_registry_hash=global_skill_registry_hash,
+        )
+        _validate_stage2_final_evidence_clean_code(
+            code_provenance,
+            approved_router_config_path=router_config_record["path"],
+        )
+        config_hash = router_config_record["sha256"]
+    else:
+        frozen_config = {
+            "schema_version": STAGE2_ROUTED_PREDICTION_CONFIG_SCHEMA,
+            "router_id": router_name,
+            "config_id": config_id,
+            "router_class": type(router).__name__,
+            "top_k": top_k,
+            "global_skill_registry_hash": global_skill_registry_hash,
+        }
+        config_hash = _canonical_hash(frozen_config)
     predictions = _stage2_export_predictions(
         router=router,
         tasks=tasks,
@@ -607,6 +639,7 @@ def write_stage2_pilot_routed_prediction_artifacts(
             "config_id": config_id,
             "config_hash": config_hash,
             "config": frozen_config,
+            "router_config": router_config_record,
             "top_k": top_k,
             "global_skill_registry_hash": global_skill_registry_hash,
             "generation_command": command_text,
@@ -634,9 +667,17 @@ def write_stage2_pilot_routed_prediction_artifacts(
             "skill_count": len(skills),
         },
         "router": routed["router"],
+        "router_config": router_config_record,
+        "router_implementation": _stage2_router_implementation_record(router),
+        "code": code_provenance,
+        "generation_command": command_text,
         "output": _file_record(output),
         "per_task_prediction_hashes": per_task_prediction_hashes,
-        "final_evidence": final_evidence,
+        "final_evidence": {
+            "mode": "strict_provenance_only" if final_evidence else "non_final_export",
+            "strict_provenance": final_evidence,
+            "pilot_approved": False,
+        },
         "non_actions": {
             "stage2_pilot_run": False,
             "codex_cli_run": False,
@@ -668,6 +709,169 @@ def write_stage2_pilot_routed_prediction_artifacts(
         "config_hash": config_hash,
         "task_count": len(tasks),
         "skill_count": len(skills),
+    }
+
+
+def _stage2_approved_router_config(
+    path_value: Path | str | None,
+    *,
+    router_id: str,
+    config_id: str,
+    top_k: int,
+    global_skill_registry_hash: str,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    if path_value is None:
+        raise ValueError("approved router config is required for final evidence export")
+    path = Path(path_value)
+    if not path.exists():
+        raise ValueError(f"approved router config is missing: {path}")
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("approved router config must be a JSON object")
+
+    schema_version = _required_string(payload, "schema_version")
+    if schema_version != STAGE2_ROUTED_PREDICTION_CONFIG_SCHEMA:
+        raise ValueError("approved router config schema_version mismatch")
+    approved_config_id = _required_string(payload, "config_id")
+    if approved_config_id != config_id:
+        raise ValueError("router config_id mismatch")
+    approved_router_id = _required_string(payload, "router_id")
+    if approved_router_id != router_id:
+        raise ValueError("router config router_id mismatch")
+    if int(payload.get("top_k", 0)) != top_k:
+        raise ValueError("router config top_k mismatch")
+    approved_registry_hash = _required_string(payload, "global_skill_registry_hash")
+    if not _sha256_hex(approved_registry_hash):
+        raise ValueError("approved router config global_skill_registry_hash is malformed")
+    if approved_registry_hash != global_skill_registry_hash:
+        raise ValueError("approved router config registry hash mismatch")
+
+    return (
+        {
+            **_file_record(path),
+            "schema_version": schema_version,
+            "config_id": approved_config_id,
+        },
+        dict(payload),
+    )
+
+
+def _validate_stage2_final_evidence_task_manifest(path: Path) -> None:
+    records = _read_stage2_export_records(path, record_key="tasks")
+    for record in records:
+        task_id = _required_string(record, "task_id")
+        metadata = record.get("metadata") if isinstance(record.get("metadata"), dict) else {}
+        source = record.get("source") or metadata.get("source")
+        provenance = record.get("provenance") or metadata.get("provenance")
+        if not isinstance(source, str) or not source.strip():
+            raise ValueError(f"final evidence task source/provenance missing: {task_id}")
+        if "fixture" in source.lower():
+            raise ValueError(f"final evidence task source/provenance is fixture-like: {task_id}")
+        if not isinstance(provenance, dict) or not provenance:
+            raise ValueError(f"final evidence task source/provenance missing: {task_id}")
+
+
+def _stage2_export_code_provenance() -> dict[str, Any]:
+    commit = _git_output(["git", "rev-parse", "HEAD"])
+    tag = _git_output(["git", "describe", "--tags", "--exact-match", "HEAD"])
+    dirty_paths = _git_dirty_paths()
+    return {
+        "commit": commit,
+        "tag": tag,
+        "dirty": bool(dirty_paths),
+        "dirty_paths": dirty_paths,
+    }
+
+
+def _git_output(args: list[str]) -> str | None:
+    try:
+        result = subprocess.run(
+            args,
+            cwd=Path.cwd(),
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return None
+    output = result.stdout.strip()
+    return output or None
+
+
+def _git_dirty_paths() -> list[str]:
+    try:
+        result = subprocess.run(
+            ["git", "status", "--porcelain", "--untracked-files=all"],
+            cwd=Path.cwd(),
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return ["<git-status-unavailable>"]
+    paths: list[str] = []
+    for line in result.stdout.splitlines():
+        if not line:
+            continue
+        path = line[3:].strip()
+        if " -> " in path:
+            path = path.split(" -> ", 1)[1].strip()
+        if path:
+            paths.append(path)
+    return sorted(paths)
+
+
+def _validate_stage2_final_evidence_clean_code(
+    code_provenance: dict[str, Any],
+    *,
+    approved_router_config_path: str,
+) -> None:
+    commit = code_provenance.get("commit")
+    if not isinstance(commit, str) or not COMMIT_SHA_RE.fullmatch(commit):
+        raise ValueError("missing code commit provenance for final evidence export")
+    dirty_paths = code_provenance.get("dirty_paths")
+    if not isinstance(dirty_paths, list) or not all(
+        isinstance(path, str) for path in dirty_paths
+    ):
+        raise ValueError("malformed code dirty_paths provenance")
+    approved_config_dirty_paths = [
+        path for path in dirty_paths if _same_dirty_path(path, approved_router_config_path)
+    ]
+    if approved_config_dirty_paths:
+        raise ValueError(
+            "approved router config is dirty: " + ", ".join(approved_config_dirty_paths)
+        )
+    protected_dirty_paths = [
+        path for path in dirty_paths if _stage2_protected_dirty_path(path)
+    ]
+    if protected_dirty_paths:
+        raise ValueError(
+            "dirty source/config/test paths: " + ", ".join(protected_dirty_paths)
+        )
+
+
+def _same_dirty_path(dirty_path: str, path_value: str) -> bool:
+    path = str(path_value)
+    if dirty_path == path:
+        return True
+    if Path(path).is_absolute():
+        return path.endswith(f"/{dirty_path}")
+    return dirty_path.endswith(f"/{path}")
+
+
+def _stage2_protected_dirty_path(path: str) -> bool:
+    normalized = path.strip().lstrip("./")
+    return normalized in {"src", "configs", "tests"} or normalized.startswith(
+        FINAL_EVIDENCE_DIRTY_GUARD_PREFIXES
+    )
+
+
+def _stage2_router_implementation_record(router: SkillRouter) -> dict[str, Any]:
+    return {
+        "module": type(router).__module__,
+        "class": type(router).__name__,
     }
 
 

--- a/src/hermes_skilleval/live_agent_skillsbench.py
+++ b/src/hermes_skilleval/live_agent_skillsbench.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any, Iterable
 
 from hermes_skilleval.external.skillrouter import ExternalTask, SkillRouterAdapter
+from hermes_skilleval.models import BenchmarkTask, Skill
 from hermes_skilleval.live_agent_runtime import (
     AgentRunner,
     AgentRequest,
@@ -23,11 +24,18 @@ from hermes_skilleval.live_agent_runtime import (
 )
 from hermes_skilleval.provenance import _reject_sensitive_values
 from hermes_skilleval.release_manifest import sha256_file
+from hermes_skilleval.routers.base import SkillRouter
+from hermes_skilleval.routers.embedding import EmbeddingRouter
+from hermes_skilleval.routers.gated import VerificationGatedRouter
+from hermes_skilleval.routers.hybrid import HybridRouter
+from hermes_skilleval.routers.keyword import KeywordRouter
 
 
 PLAN_SCHEMA = "v0.3.skillsbench-live-plan.v1"
 REPORT_SCHEMA = "v0.3.skillsbench-live-matrix-report.v1"
 STAGE2_INPUT_PACKAGE_SCHEMA = "v0.3.stage2-real-pilot-input-package.v1"
+STAGE2_ROUTED_PREDICTIONS_SCHEMA = "v0.3.routed-predictions.v1"
+STAGE2_ROUTED_PREDICTIONS_MANIFEST_SCHEMA = "v0.3.stage2-routed-prediction-export-manifest.v1"
 SEED = 20260625
 CONDITIONS = ("no-skill", "routed-skill", "oracle-skill")
 CONTROLLED_NETWORKS = {"none", "controlled"}
@@ -38,6 +46,7 @@ SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
 LABEL_LEAKAGE_TOKENS = ("oracle", "gold", "source-task", "source_task")
 VERIFIER_ARTIFACT_ROLES = ("code", "config", "input")
 DISALLOWED_ROUTED_LABEL_SOURCES = {"oracle", "manual", "ad_hoc"}
+SUPPORTED_STAGE2_EXPORT_ROUTERS = {"keyword", "hybrid", "embedding", "gated"}
 
 
 @dataclass(frozen=True)
@@ -476,6 +485,7 @@ def build_stage2_real_pilot_input_package(
         },
         "routed_predictions_package": {
             "router_id": routed_prediction_artifact["router"].get("router_id"),
+            "config_id": routed_prediction_artifact["router"].get("config_id"),
             "config_hash": routed_prediction_artifact["router"].get("config_hash"),
             "top_k": router_top_k,
             "global_skill_registry_hash": global_registry_hash,
@@ -514,6 +524,330 @@ def build_stage2_real_pilot_input_package(
     }
     _reject_sensitive_values(package)
     return package
+
+
+def write_stage2_pilot_routed_prediction_artifacts(
+    *,
+    tasks_manifest_path: Path | str,
+    global_skill_registry_path: Path | str,
+    output_path: Path | str,
+    manifest_output_path: Path | str,
+    router_id: str,
+    config_id: str,
+    top_k: int,
+    generation_command: Iterable[str] | str | None = None,
+    final_evidence: bool = False,
+) -> dict[str, Any]:
+    """Export Stage 2 pilot routed predictions without running the pilot."""
+
+    task_path = Path(tasks_manifest_path)
+    registry_path = Path(global_skill_registry_path)
+    if final_evidence and (_fixture_path(task_path) or _fixture_path(registry_path)):
+        raise ValueError("fixture routing cannot be exported as final evidence")
+
+    config_id = _non_empty(config_id, "config_id").strip()
+    top_k = _positive_int(top_k, "top_k")
+    router_name = _stage2_export_router_name(router_id)
+    router = _stage2_export_router(router_name)
+    tasks = _load_stage2_export_tasks(task_path)
+    if len(tasks) != 4:
+        raise ValueError("Stage 2 pilot routed export requires exactly 4 tasks")
+    skills = _load_stage2_export_registry(registry_path)
+    if len(skills) < top_k:
+        raise ValueError("stable global skill registry has fewer skills than top_k")
+
+    registry_records = {
+        skill.id: _stage2_skill_registry_record(
+            LiveAgentSkill(
+                skill_id=skill.id,
+                name=skill.name,
+                description=skill.description,
+                body=skill.body,
+            )
+        )
+        for skill in skills
+    }
+    global_skill_registry_hash = _canonical_hash(dict(sorted(registry_records.items())))
+    frozen_config = {
+        "schema_version": "v0.3.stage2-routed-prediction-router-config.v1",
+        "router_id": router_name,
+        "config_id": config_id,
+        "router_class": type(router).__name__,
+        "top_k": top_k,
+        "global_skill_registry_hash": global_skill_registry_hash,
+    }
+    config_hash = _canonical_hash(frozen_config)
+    predictions = _stage2_export_predictions(
+        router=router,
+        tasks=tasks,
+        skills=skills,
+        top_k=top_k,
+    )
+    per_task_prediction_hashes = {
+        task_id: _canonical_hash(prediction)
+        for task_id, prediction in sorted(predictions.items())
+    }
+    generation_artifact_hash = _canonical_hash(
+        {
+            "frozen_config": frozen_config,
+            "predictions": predictions,
+            "per_task_prediction_hashes": per_task_prediction_hashes,
+        }
+    )
+    command_text = _generation_command_text(generation_command)
+    if not command_text:
+        command_text = (
+            "python -m hermes_skilleval.cli skillsbench-export-routed-predictions"
+        )
+
+    routed = {
+        "schema_version": STAGE2_ROUTED_PREDICTIONS_SCHEMA,
+        "router": {
+            "router_id": router_name,
+            "config_id": config_id,
+            "config_hash": config_hash,
+            "config": frozen_config,
+            "top_k": top_k,
+            "global_skill_registry_hash": global_skill_registry_hash,
+            "generation_command": command_text,
+            "generation_artifact_hash": generation_artifact_hash,
+            "oracle_labels_read": False,
+            "label_source": "router_generated",
+            "per_task_prediction_hashes": per_task_prediction_hashes,
+        },
+        "predictions": predictions,
+    }
+    output = Path(output_path)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(
+        json.dumps(routed, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+    manifest = {
+        "schema_version": STAGE2_ROUTED_PREDICTIONS_MANIFEST_SCHEMA,
+        "generated_at": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+        "task_manifest": _file_record(task_path),
+        "global_skill_registry": {
+            **_file_record(registry_path),
+            "global_skill_registry_hash": global_skill_registry_hash,
+            "skill_count": len(skills),
+        },
+        "router": routed["router"],
+        "output": _file_record(output),
+        "per_task_prediction_hashes": per_task_prediction_hashes,
+        "final_evidence": final_evidence,
+        "non_actions": {
+            "stage2_pilot_run": False,
+            "codex_cli_run": False,
+            "pilot_plan_frozen": False,
+            "live_agent_traces_created": False,
+            "evidence_gate_rerun": False,
+            "oracle_labels_read": False,
+        },
+        "scope_guards": {
+            "no_training": True,
+            "no_threshold_tuning": True,
+            "no_new_router_variants": True,
+            "no_scorer_matrix_gate_changes": True,
+            "no_oracle_label_derived_predictions": True,
+        },
+    }
+    manifest_output = Path(manifest_output_path)
+    manifest_output.parent.mkdir(parents=True, exist_ok=True)
+    manifest_output.write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return {
+        "output_path": str(output),
+        "manifest_output_path": str(manifest_output),
+        "output_sha256": sha256_file(output),
+        "manifest_sha256": sha256_file(manifest_output),
+        "global_skill_registry_hash": global_skill_registry_hash,
+        "config_hash": config_hash,
+        "task_count": len(tasks),
+        "skill_count": len(skills),
+    }
+
+
+def _load_stage2_export_tasks(path: Path) -> list[BenchmarkTask]:
+    records = _read_stage2_export_records(path, record_key="tasks")
+    tasks: list[BenchmarkTask] = []
+    seen: set[str] = set()
+    for record in records:
+        task_id = _required_string(record, "task_id")
+        if task_id in seen:
+            raise ValueError(f"duplicate task id: {task_id}")
+        seen.add(task_id)
+        prompt = _required_string(record, "prompt")
+        metadata = record.get("metadata") if isinstance(record.get("metadata"), dict) else {}
+        category = _optional_string(record.get("category")) or _optional_string(
+            metadata.get("category")
+        ) or "skillsbench"
+        difficulty = _optional_string(record.get("difficulty")) or _optional_string(
+            metadata.get("difficulty")
+        ) or "pilot"
+        split = _optional_string(record.get("split")) or "dev"
+        tasks.append(
+            BenchmarkTask(
+                id=task_id,
+                category=category,
+                difficulty=difficulty,
+                prompt=prompt,
+                gold_skills=[],
+                negative_skills=[],
+                verifier="deterministic",
+                split=split if split in {"dev", "test"} else "dev",
+                robustness_tags=["stage2-pilot"],
+            )
+        )
+    return tasks
+
+
+def _load_stage2_export_registry(path: Path) -> list[Skill]:
+    records = _read_stage2_export_records(path, record_key="skills")
+    by_id: dict[str, Skill] = {}
+    canonical_by_id: dict[str, dict[str, Any]] = {}
+    for record in records:
+        skill_id = record.get("skill_id") or record.get("id")
+        if not isinstance(skill_id, str) or not skill_id.strip():
+            raise ValueError("skill registry record missing skill_id")
+        description = _optional_string(record.get("description")) or ""
+        body = _required_string(record, "body")
+        normalized = {
+            "skill_id": skill_id,
+            "name": _required_string(record, "name"),
+            "description": description,
+            "body": body,
+            "category": _optional_string(record.get("category")),
+            "path": _optional_string(record.get("path")) or skill_id,
+            "trigger_terms": _optional_string_list(record.get("trigger_terms")),
+            "token_count_estimate": _token_count_estimate(record, body),
+        }
+        previous = canonical_by_id.get(skill_id)
+        if previous is not None:
+            if previous != normalized:
+                raise ValueError(f"conflicting duplicate skill id: {skill_id}")
+            continue
+        canonical_by_id[skill_id] = normalized
+        by_id[skill_id] = Skill(
+            id=skill_id,
+            name=normalized["name"],
+            path=normalized["path"],
+            category=normalized["category"],
+            description=description,
+            body=body,
+            trigger_terms=normalized["trigger_terms"],
+            token_count_estimate=normalized["token_count_estimate"],
+        )
+    if not by_id:
+        raise ValueError("stable global skill registry is empty")
+    return [by_id[skill_id] for skill_id in sorted(by_id)]
+
+
+def _stage2_export_predictions(
+    *,
+    router: SkillRouter,
+    tasks: list[BenchmarkTask],
+    skills: list[Skill],
+    top_k: int,
+) -> dict[str, list[str]]:
+    skill_ids = {skill.id for skill in skills}
+    predictions: dict[str, list[str]] = {}
+    for task in sorted(tasks, key=lambda item: item.id):
+        result = router.route(task, skills, top_k)
+        deduped = _dedupe(result.selected_skill_ids)
+        if len(deduped) < top_k:
+            raise ValueError(f"insufficient routed top-k for task: {task.id}")
+        unknown = sorted(skill_id for skill_id in deduped if skill_id not in skill_ids)
+        if unknown:
+            raise ValueError(
+                f"unknown routed prediction skill id: {task.id} -> {unknown[0]}"
+            )
+        predictions[task.id] = deduped[:top_k]
+    return predictions
+
+
+def _read_stage2_export_records(path: Path, *, record_key: str) -> list[dict[str, Any]]:
+    if not path.exists():
+        raise ValueError(f"missing {record_key} input: {path}")
+    text = path.read_text(encoding="utf-8")
+    stripped = text.lstrip()
+    if path.suffix == ".jsonl" or not stripped.startswith(("[", "{")):
+        records = [
+            json.loads(line)
+            for line in text.splitlines()
+            if line.strip()
+        ]
+    else:
+        try:
+            payload = json.loads(text)
+        except json.JSONDecodeError:
+            records = [
+                json.loads(line)
+                for line in text.splitlines()
+                if line.strip()
+            ]
+        else:
+            if isinstance(payload, dict):
+                payload = (
+                    payload.get(record_key)
+                    or payload.get("records")
+                    or payload.get("items")
+                )
+            if not isinstance(payload, list):
+                raise ValueError(f"{record_key} JSON input must contain a list")
+            records = payload
+    if not all(isinstance(record, dict) for record in records):
+        raise ValueError(f"{record_key} records must be objects")
+    return list(records)
+
+
+def _stage2_export_router_name(router_id: str) -> str:
+    router_name = _non_empty(router_id, "router_id")
+    if router_name not in SUPPORTED_STAGE2_EXPORT_ROUTERS:
+        raise ValueError(f"unsupported Stage 2 routed prediction router_id: {router_name}")
+    return router_name
+
+
+def _stage2_export_router(router_id: str) -> SkillRouter:
+    if router_id == "keyword":
+        return KeywordRouter()
+    if router_id == "hybrid":
+        return HybridRouter()
+    if router_id == "embedding":
+        return EmbeddingRouter()
+    if router_id == "gated":
+        return VerificationGatedRouter()
+    raise AssertionError("unreachable")
+
+
+def _generation_command_text(command: Iterable[str] | str | None) -> str:
+    if command is None:
+        return ""
+    if isinstance(command, str):
+        return command
+    return " ".join(str(part) for part in command if str(part).strip())
+
+
+def _optional_string(value: Any) -> str | None:
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return None
+
+
+def _optional_string_list(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [item.strip() for item in value if isinstance(item, str) and item.strip()]
+
+
+def _token_count_estimate(record: dict[str, Any], body: str) -> int:
+    value = record.get("token_count_estimate")
+    if isinstance(value, int) and not isinstance(value, bool) and value >= 0:
+        return value
+    return max(1, len(body.split()))
 
 
 def run_skillsbench_matrix(
@@ -1240,6 +1574,8 @@ def _stage2_routed_prediction_records(
     errors: list[str] = []
     if not router.get("router_id"):
         errors.append("missing router_id for routed predictions")
+    if not router.get("config_id"):
+        errors.append("missing router config_id for routed predictions")
     if not router.get("config_hash"):
         errors.append("missing router config_hash for routed predictions")
     elif not _sha256_hex(router.get("config_hash")):
@@ -1257,6 +1593,7 @@ def _stage2_routed_prediction_records(
         records[task.task_id] = {
             "task_id": task.task_id,
             "router_id": router.get("router_id"),
+            "config_id": router.get("config_id"),
             "config_hash": router.get("config_hash"),
             "top_k": router_top_k,
             "global_skill_registry_hash": global_skill_registry_hash,
@@ -1279,6 +1616,8 @@ def _routed_prediction_input_errors(
     errors: list[str] = []
     if not router.get("router_id"):
         errors.append("missing router_id for routed predictions")
+    if not router.get("config_id"):
+        errors.append("missing router config_id for routed predictions")
     if not router.get("config_hash"):
         errors.append("missing router config_hash for routed predictions")
     elif not _sha256_hex(router.get("config_hash")):

--- a/tests/test_skillsbench_live_matrix.py
+++ b/tests/test_skillsbench_live_matrix.py
@@ -19,6 +19,7 @@ from hermes_skilleval.live_agent_runtime import (
 from hermes_skilleval.live_agent_skillsbench import (
     SkillsBenchAdapter,
     build_stage2_real_pilot_input_package,
+    write_stage2_pilot_routed_prediction_artifacts,
     _canonical_hash,
     _validate_real_runner_preflight,
     run_skillsbench_matrix,
@@ -236,6 +237,7 @@ def _write_real_like_pilot_inputs(root: Path) -> dict[str, Path]:
                 "schema_version": "v0.3.routed-predictions.v1",
                 "router": {
                     "router_id": "unit-router",
+                    "config_id": "unit-router-config",
                     "config_hash": "c" * 64,
                     "top_k": 1,
                     "global_skill_registry_hash": registry_hash,
@@ -256,6 +258,24 @@ def _write_real_like_pilot_inputs(root: Path) -> dict[str, Path]:
         "routed_predictions": root / "routed_predictions.json",
         "oracle_qualification": root / "oracle_qualification.jsonl",
     }
+
+
+def _export_stage2_routed_predictions(paths: dict[str, Path], output_dir: Path) -> dict:
+    return write_stage2_pilot_routed_prediction_artifacts(
+        tasks_manifest_path=paths["data_root"] / "tasks.jsonl",
+        global_skill_registry_path=paths["data_root"] / "skills.jsonl",
+        output_path=output_dir / "routed_predictions.json",
+        manifest_output_path=output_dir / "routed_predictions.manifest.json",
+        router_id="keyword",
+        config_id="stage2-keyword-unit",
+        top_k=1,
+        generation_command=[
+            "python",
+            "-m",
+            "hermes_skilleval.cli",
+            "skillsbench-export-routed-predictions",
+        ],
+    )
 
 
 def _write_real_like_pilot_plan(tmp_path: Path) -> tuple[Path, Path]:
@@ -1187,6 +1207,132 @@ def test_stage2_real_pilot_input_package_missing_routing_provenance_fails_closed
         _build_real_like_pilot_input_package(paths)
 
 
+def test_stage2_routed_prediction_exporter_writes_validator_ready_artifacts(tmp_path):
+    paths = _write_real_like_pilot_inputs(tmp_path / "skillsbench-real")
+    export = _export_stage2_routed_predictions(paths, tmp_path / "export")
+    routed_path = Path(export["output_path"])
+    manifest_path = Path(export["manifest_output_path"])
+
+    routed = json.loads(routed_path.read_text(encoding="utf-8"))
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+
+    assert routed["schema_version"] == "v0.3.routed-predictions.v1"
+    assert routed["router"]["router_id"] == "keyword"
+    assert routed["router"]["config_id"] == "stage2-keyword-unit"
+    assert routed["router"]["config_hash"]
+    assert routed["router"]["global_skill_registry_hash"] == _stage2_expected_registry_hash(
+        _read_jsonl_file(paths["data_root"] / "skills.jsonl")
+    )
+    assert routed["router"]["oracle_labels_read"] is False
+    assert routed["router"]["label_source"] == "router_generated"
+    assert routed["router"]["generation_artifact_hash"]
+    assert manifest["output"]["sha256"]
+    assert set(routed["predictions"]) == {f"sb-real-{index}" for index in range(1, 5)}
+    assert all(len(prediction) == 1 for prediction in routed["predictions"].values())
+    assert set(manifest["per_task_prediction_hashes"]) == set(routed["predictions"])
+
+    package = build_stage2_real_pilot_input_package(
+        data_root=paths["data_root"],
+        upstream_ref=UPSTREAM_SHA,
+        license_note="approved-real-pilot-unit",
+        run_id="stage2-real-pilot-input-package-unit",
+        selected_task_ids=[f"sb-real-{index}" for index in range(1, 5)],
+        routed_predictions_path=routed_path,
+        oracle_qualification_path=paths["oracle_qualification"],
+        router_top_k=1,
+    )
+
+    assert package["status"] == "READY_FOR_REVIEW_NOT_EXECUTED"
+    assert package["routed_predictions_package"]["label_source"] == "router_generated"
+    assert package["routed_predictions_package"]["config_id"] == "stage2-keyword-unit"
+
+
+def test_stage2_routed_prediction_exporter_rejects_fixture_final_evidence(tmp_path):
+    with pytest.raises(ValueError, match="fixture routing cannot be exported as final evidence"):
+        write_stage2_pilot_routed_prediction_artifacts(
+            tasks_manifest_path=FIXTURE / "tasks.jsonl",
+            global_skill_registry_path=FIXTURE / "skills.jsonl",
+            output_path=tmp_path / "routed_predictions.json",
+            manifest_output_path=tmp_path / "manifest.json",
+            router_id="keyword",
+            config_id="stage2-keyword-unit",
+            top_k=1,
+            final_evidence=True,
+        )
+
+
+def test_stage2_routed_prediction_exporter_orders_and_dedupes_stably(tmp_path):
+    paths = _write_real_like_pilot_inputs(tmp_path / "skillsbench-real")
+    skills = _read_jsonl_file(paths["data_root"] / "skills.jsonl")
+    skills.append(dict(skills[0]))
+    _write_jsonl_file(paths["data_root"] / "skills-with-duplicate.jsonl", skills)
+
+    first = write_stage2_pilot_routed_prediction_artifacts(
+        tasks_manifest_path=paths["data_root"] / "tasks.jsonl",
+        global_skill_registry_path=paths["data_root"] / "skills-with-duplicate.jsonl",
+        output_path=tmp_path / "first" / "routed_predictions.json",
+        manifest_output_path=tmp_path / "first" / "manifest.json",
+        router_id="keyword",
+        config_id="stage2-keyword-unit",
+        top_k=2,
+    )
+    second = write_stage2_pilot_routed_prediction_artifacts(
+        tasks_manifest_path=paths["data_root"] / "tasks.jsonl",
+        global_skill_registry_path=paths["data_root"] / "skills-with-duplicate.jsonl",
+        output_path=tmp_path / "second" / "routed_predictions.json",
+        manifest_output_path=tmp_path / "second" / "manifest.json",
+        router_id="keyword",
+        config_id="stage2-keyword-unit",
+        top_k=2,
+    )
+
+    assert json.loads(Path(first["output_path"]).read_text(encoding="utf-8"))[
+        "predictions"
+    ] == json.loads(Path(second["output_path"]).read_text(encoding="utf-8"))[
+        "predictions"
+    ]
+    assert all(
+        len(prediction) == len(set(prediction)) == 2
+        for prediction in json.loads(Path(first["output_path"]).read_text(encoding="utf-8"))[
+            "predictions"
+        ].values()
+    )
+
+
+def test_cli_stage2_routed_prediction_exporter_writes_outputs(tmp_path):
+    paths = _write_real_like_pilot_inputs(tmp_path / "skillsbench-real")
+    output_path = tmp_path / "cli" / "routed_predictions.json"
+    manifest_path = tmp_path / "cli" / "manifest.json"
+
+    exit_code = main(
+        [
+            "skillsbench-export-routed-predictions",
+            "--tasks-manifest",
+            str(paths["data_root"] / "tasks.jsonl"),
+            "--global-skill-registry",
+            str(paths["data_root"] / "skills.jsonl"),
+            "--output",
+            str(output_path),
+            "--manifest-output",
+            str(manifest_path),
+            "--router-id",
+            "keyword",
+            "--config-id",
+            "stage2-keyword-unit",
+            "--top-k",
+            "1",
+        ]
+    )
+
+    assert exit_code == 0
+    assert json.loads(output_path.read_text(encoding="utf-8"))["router"][
+        "label_source"
+    ] == "router_generated"
+    assert json.loads(manifest_path.read_text(encoding="utf-8"))["output"]["path"] == str(
+        output_path
+    )
+
+
 @pytest.mark.parametrize(
     ("mutator", "message"),
     [
@@ -1367,6 +1513,7 @@ def test_stage2_real_pilot_input_package_records_required_hashes(tmp_path):
 
     routed = package["routed_predictions_package"]
     assert routed["router_id"] == "unit-router"
+    assert routed["config_id"] == "unit-router-config"
     assert routed["config_hash"] == "c" * 64
     assert routed["top_k"] == 1
     assert routed["global_skill_registry_hash"] == registry["global_skill_registry_hash"]

--- a/tests/test_skillsbench_live_matrix.py
+++ b/tests/test_skillsbench_live_matrix.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import pytest
 import jsonschema
 
+import hermes_skilleval.live_agent_skillsbench as live_agent_skillsbench
 from hermes_skilleval.cli import main
 from hermes_skilleval.live_agent_runtime import (
     AgentRequest,
@@ -30,6 +31,7 @@ from hermes_skilleval.live_agent_skillsbench import (
 FIXTURE = Path("tests/fixtures/live_agent/skillsbench_tiny")
 SKILLROUTER_FIXTURE = Path("tests/fixtures/external/skillrouter_eval_core_tiny")
 UPSTREAM_SHA = "a" * 40
+STAGE2_APPROVED_ROUTER_CONFIG_SCHEMA = "v0.3.stage2-routed-prediction-router-config.v1"
 
 
 class _RecordingRunner:
@@ -78,6 +80,10 @@ def _real_preflight() -> dict:
 
 def _sha256_text(value: str) -> str:
     return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _sha256_file(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
 
 
 def _stage2_expected_registry_hash(skills: list[dict]) -> str:
@@ -275,6 +281,48 @@ def _export_stage2_routed_predictions(paths: dict[str, Path], output_dir: Path) 
             "hermes_skilleval.cli",
             "skillsbench-export-routed-predictions",
         ],
+    )
+
+
+def _write_stage2_approved_router_config(
+    paths: dict[str, Path],
+    output_path: Path,
+    *,
+    router_id: str = "keyword",
+    config_id: str = "stage2-keyword-unit",
+    top_k: int = 1,
+) -> Path:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    skills = _read_jsonl_file(paths["data_root"] / "skills.jsonl")
+    config = {
+        "schema_version": STAGE2_APPROVED_ROUTER_CONFIG_SCHEMA,
+        "config_id": config_id,
+        "router_id": router_id,
+        "top_k": top_k,
+        "global_skill_registry_hash": _stage2_expected_registry_hash(skills),
+        "approval": {
+            "source": "unit-test-approved-router-config",
+            "approved_for": "stage2-routed-prediction-export",
+        },
+    }
+    output_path.write_text(
+        json.dumps(config, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return output_path
+
+
+def _patch_stage2_clean_code_provenance(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        live_agent_skillsbench,
+        "_stage2_export_code_provenance",
+        lambda *args, **kwargs: {
+            "commit": "d" * 40,
+            "tag": "v0.3-test",
+            "dirty": False,
+            "dirty_paths": [],
+        },
+        raising=False,
     )
 
 
@@ -1259,6 +1307,295 @@ def test_stage2_routed_prediction_exporter_rejects_fixture_final_evidence(tmp_pa
             top_k=1,
             final_evidence=True,
         )
+
+
+def test_stage2_routed_prediction_final_evidence_requires_approved_router_config(
+    tmp_path,
+    monkeypatch,
+):
+    _patch_stage2_clean_code_provenance(monkeypatch)
+    paths = _write_real_like_pilot_inputs(tmp_path / "skillsbench-real")
+
+    with pytest.raises(ValueError, match="approved router config is required"):
+        write_stage2_pilot_routed_prediction_artifacts(
+            tasks_manifest_path=paths["data_root"] / "tasks.jsonl",
+            global_skill_registry_path=paths["data_root"] / "skills.jsonl",
+            output_path=tmp_path / "routed_predictions.json",
+            manifest_output_path=tmp_path / "manifest.json",
+            router_id="keyword",
+            config_id="stage2-keyword-unit",
+            top_k=1,
+            final_evidence=True,
+        )
+
+
+def test_stage2_routed_prediction_final_evidence_rejects_config_id_mismatch(
+    tmp_path,
+    monkeypatch,
+):
+    _patch_stage2_clean_code_provenance(monkeypatch)
+    paths = _write_real_like_pilot_inputs(tmp_path / "skillsbench-real")
+    config_path = _write_stage2_approved_router_config(
+        paths,
+        tmp_path / "approved-router-config.json",
+        config_id="different-approved-config",
+    )
+
+    with pytest.raises(ValueError, match="router config_id mismatch"):
+        write_stage2_pilot_routed_prediction_artifacts(
+            tasks_manifest_path=paths["data_root"] / "tasks.jsonl",
+            global_skill_registry_path=paths["data_root"] / "skills.jsonl",
+            output_path=tmp_path / "routed_predictions.json",
+            manifest_output_path=tmp_path / "manifest.json",
+            router_id="keyword",
+            config_id="stage2-keyword-unit",
+            top_k=1,
+            approved_router_config_path=config_path,
+            final_evidence=True,
+        )
+
+
+def test_stage2_routed_prediction_final_evidence_records_config_hash_stably(
+    tmp_path,
+    monkeypatch,
+):
+    _patch_stage2_clean_code_provenance(monkeypatch)
+    paths = _write_real_like_pilot_inputs(tmp_path / "skillsbench-real")
+    config_path = _write_stage2_approved_router_config(
+        paths,
+        tmp_path / "approved-router-config.json",
+    )
+
+    first = write_stage2_pilot_routed_prediction_artifacts(
+        tasks_manifest_path=paths["data_root"] / "tasks.jsonl",
+        global_skill_registry_path=paths["data_root"] / "skills.jsonl",
+        output_path=tmp_path / "first" / "routed_predictions.json",
+        manifest_output_path=tmp_path / "first" / "manifest.json",
+        router_id="keyword",
+        config_id="stage2-keyword-unit",
+        top_k=1,
+        approved_router_config_path=config_path,
+        final_evidence=True,
+    )
+    second = write_stage2_pilot_routed_prediction_artifacts(
+        tasks_manifest_path=paths["data_root"] / "tasks.jsonl",
+        global_skill_registry_path=paths["data_root"] / "skills.jsonl",
+        output_path=tmp_path / "second" / "routed_predictions.json",
+        manifest_output_path=tmp_path / "second" / "manifest.json",
+        router_id="keyword",
+        config_id="stage2-keyword-unit",
+        top_k=1,
+        approved_router_config_path=config_path,
+        final_evidence=True,
+    )
+
+    routed = json.loads(Path(first["output_path"]).read_text(encoding="utf-8"))
+    manifest = json.loads(Path(first["manifest_output_path"]).read_text(encoding="utf-8"))
+    expected_hash = _sha256_file(config_path)
+
+    assert first["config_hash"] == second["config_hash"] == expected_hash
+    assert routed["router"]["config_hash"] == expected_hash
+    assert routed["router"]["router_config"]["sha256"] == expected_hash
+    assert manifest["router_config"] == routed["router"]["router_config"]
+    assert manifest["router_config"]["schema_version"] == STAGE2_APPROVED_ROUTER_CONFIG_SCHEMA
+    assert manifest["router_config"]["config_id"] == "stage2-keyword-unit"
+    assert manifest["router_config"]["size_bytes"] == config_path.stat().st_size
+
+
+@pytest.mark.parametrize("router_id", ["keyword", "hybrid"])
+def test_stage2_routed_prediction_final_evidence_allows_keyword_and_hybrid(
+    tmp_path,
+    monkeypatch,
+    router_id,
+):
+    _patch_stage2_clean_code_provenance(monkeypatch)
+    paths = _write_real_like_pilot_inputs(tmp_path / f"skillsbench-real-{router_id}")
+    config_id = f"stage2-{router_id}-unit"
+    config_path = _write_stage2_approved_router_config(
+        paths,
+        tmp_path / router_id / "approved-router-config.json",
+        router_id=router_id,
+        config_id=config_id,
+    )
+
+    export = write_stage2_pilot_routed_prediction_artifacts(
+        tasks_manifest_path=paths["data_root"] / "tasks.jsonl",
+        global_skill_registry_path=paths["data_root"] / "skills.jsonl",
+        output_path=tmp_path / router_id / "routed_predictions.json",
+        manifest_output_path=tmp_path / router_id / "manifest.json",
+        router_id=router_id,
+        config_id=config_id,
+        top_k=1,
+        approved_router_config_path=config_path,
+        final_evidence=True,
+    )
+
+    manifest = json.loads(Path(export["manifest_output_path"]).read_text(encoding="utf-8"))
+    assert manifest["final_evidence"]["mode"] == "strict_provenance_only"
+    assert manifest["router"]["router_id"] == router_id
+
+
+@pytest.mark.parametrize("router_id", ["embedding", "gated"])
+def test_stage2_routed_prediction_final_evidence_rejects_unpinned_model_routers(
+    tmp_path,
+    monkeypatch,
+    router_id,
+):
+    _patch_stage2_clean_code_provenance(monkeypatch)
+    paths = _write_real_like_pilot_inputs(tmp_path / f"skillsbench-real-{router_id}")
+    config_path = _write_stage2_approved_router_config(
+        paths,
+        tmp_path / router_id / "approved-router-config.json",
+        router_id=router_id,
+        config_id=f"stage2-{router_id}-unit",
+    )
+
+    with pytest.raises(ValueError, match="requires pinned model/checkpoint provenance"):
+        write_stage2_pilot_routed_prediction_artifacts(
+            tasks_manifest_path=paths["data_root"] / "tasks.jsonl",
+            global_skill_registry_path=paths["data_root"] / "skills.jsonl",
+            output_path=tmp_path / router_id / "routed_predictions.json",
+            manifest_output_path=tmp_path / router_id / "manifest.json",
+            router_id=router_id,
+            config_id=f"stage2-{router_id}-unit",
+            top_k=1,
+            approved_router_config_path=config_path,
+            final_evidence=True,
+        )
+
+
+def test_stage2_routed_prediction_final_evidence_records_code_provenance(
+    tmp_path,
+    monkeypatch,
+):
+    _patch_stage2_clean_code_provenance(monkeypatch)
+    paths = _write_real_like_pilot_inputs(tmp_path / "skillsbench-real")
+    config_path = _write_stage2_approved_router_config(
+        paths,
+        tmp_path / "approved-router-config.json",
+    )
+
+    export = write_stage2_pilot_routed_prediction_artifacts(
+        tasks_manifest_path=paths["data_root"] / "tasks.jsonl",
+        global_skill_registry_path=paths["data_root"] / "skills.jsonl",
+        output_path=tmp_path / "routed_predictions.json",
+        manifest_output_path=tmp_path / "manifest.json",
+        router_id="keyword",
+        config_id="stage2-keyword-unit",
+        top_k=1,
+        approved_router_config_path=config_path,
+        generation_command=["skilleval", "skillsbench-export-routed-predictions"],
+        final_evidence=True,
+    )
+
+    manifest = json.loads(Path(export["manifest_output_path"]).read_text(encoding="utf-8"))
+    assert manifest["code"] == {
+        "commit": "d" * 40,
+        "tag": "v0.3-test",
+        "dirty": False,
+        "dirty_paths": [],
+    }
+    assert manifest["router_implementation"] == {
+        "module": "hermes_skilleval.routers.keyword",
+        "class": "KeywordRouter",
+    }
+    assert manifest["generation_command"] == "skilleval skillsbench-export-routed-predictions"
+
+
+def test_stage2_routed_prediction_final_evidence_rejects_dirty_source_config_or_tests(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        live_agent_skillsbench,
+        "_stage2_export_code_provenance",
+        lambda *args, **kwargs: {
+            "commit": "d" * 40,
+            "tag": None,
+            "dirty": True,
+            "dirty_paths": [
+                "artifacts/v0.3/skillsbench-pilot/local-note.json",
+                "src/hermes_skilleval/live_agent_skillsbench.py",
+            ],
+        },
+        raising=False,
+    )
+    paths = _write_real_like_pilot_inputs(tmp_path / "skillsbench-real")
+    config_path = _write_stage2_approved_router_config(
+        paths,
+        tmp_path / "approved-router-config.json",
+    )
+
+    with pytest.raises(ValueError, match="dirty source/config/test paths"):
+        write_stage2_pilot_routed_prediction_artifacts(
+            tasks_manifest_path=paths["data_root"] / "tasks.jsonl",
+            global_skill_registry_path=paths["data_root"] / "skills.jsonl",
+            output_path=tmp_path / "routed_predictions.json",
+            manifest_output_path=tmp_path / "manifest.json",
+            router_id="keyword",
+            config_id="stage2-keyword-unit",
+            top_k=1,
+            approved_router_config_path=config_path,
+            final_evidence=True,
+        )
+
+
+def test_stage2_routed_prediction_final_evidence_rejects_copied_fixture_like_inputs(
+    tmp_path,
+    monkeypatch,
+):
+    _patch_stage2_clean_code_provenance(monkeypatch)
+    paths = _write_real_like_pilot_inputs(tmp_path / "skillsbench-real")
+    tasks = _read_jsonl_file(paths["data_root"] / "tasks.jsonl")
+    tasks[0].pop("source")
+    tasks[0].pop("provenance")
+    _write_jsonl_file(paths["data_root"] / "tasks.jsonl", tasks)
+    config_path = _write_stage2_approved_router_config(
+        paths,
+        tmp_path / "approved-router-config.json",
+    )
+
+    with pytest.raises(ValueError, match="final evidence task source/provenance"):
+        write_stage2_pilot_routed_prediction_artifacts(
+            tasks_manifest_path=paths["data_root"] / "tasks.jsonl",
+            global_skill_registry_path=paths["data_root"] / "skills.jsonl",
+            output_path=tmp_path / "routed_predictions.json",
+            manifest_output_path=tmp_path / "manifest.json",
+            router_id="keyword",
+            config_id="stage2-keyword-unit",
+            top_k=1,
+            approved_router_config_path=config_path,
+            final_evidence=True,
+        )
+
+
+def test_cli_stage2_routed_prediction_final_evidence_requires_approved_config(
+    tmp_path,
+):
+    paths = _write_real_like_pilot_inputs(tmp_path / "skillsbench-real")
+
+    exit_code = main(
+        [
+            "skillsbench-export-routed-predictions",
+            "--tasks-manifest",
+            str(paths["data_root"] / "tasks.jsonl"),
+            "--global-skill-registry",
+            str(paths["data_root"] / "skills.jsonl"),
+            "--output",
+            str(tmp_path / "routed_predictions.json"),
+            "--manifest-output",
+            str(tmp_path / "manifest.json"),
+            "--router-id",
+            "keyword",
+            "--config-id",
+            "stage2-keyword-unit",
+            "--top-k",
+            "1",
+            "--final-evidence",
+        ]
+    )
+
+    assert exit_code == 2
 
 
 def test_stage2_routed_prediction_exporter_orders_and_dedupes_stably(tmp_path):


### PR DESCRIPTION
## Summary
- add an export-only Stage 2 routed prediction artifact writer and CLI command
- record router config/provenance, registry hash, per-task prediction hashes, and non-action guards
- harden 4-task real pilot input package readiness checks around routed prediction provenance

## Validation
- python -m pytest tests/test_skillsbench_live_matrix.py -q
- OPENSPEC_TELEMETRY=0 openspec validate --all --strict
- python -m pytest -q
- git diff --check
- python -m hermes_skilleval.cli release-check

## Boundaries
- no Stage 2 execution
- no Codex execution
- no frozen pilot plan
- no live-agent traces
- no evidence gate rerun
- no fixture/fake evidence used as real evidence
- no performance claims
- no scorer, matrix, or evidence-gate semantic changes

Issue #11 remains the sourcing checklist for approved real 4-task inputs; this PR only supplies the routed-predictions package surface needed by that checklist.