### PR TITLE
ops: record Codex real-runner preflight boundary

### DIFF
--- a/artifacts/v0.3/skillsbench-pilot/v0.3-codex-real-runner-preflight-boundary-20260704T040625Z/codex-real-runner-preflight-boundary.static-precheck.json
+++ b/artifacts/v0.3/skillsbench-pilot/v0.3-codex-real-runner-preflight-boundary-20260704T040625Z/codex-real-runner-preflight-boundary.static-precheck.json
@@ -4,7 +4,7 @@
   "created_at": "2026-07-04T04:06:25Z",
   "source_branch": "ops/codex-real-runner-preflight-boundary",
   "base_branch": "codex/v0.3-pr0-protocol",
-  "source_commit": "f36f17000dc42a92fc63c4e0be53fc748e0f88f3",
+  "source_commit": "22267cc2a87e1720203efb285adfbf15847d0aaf",
   "objective": "Record the non-execution boundary and static readiness checks before any Codex real-runner smoke/preflight phase.",
   "status": "STATIC_PRECHECK_PASSED_FOR_EXPLICIT_SMOKE_AUTHORIZATION_REVIEW_NOT_EXECUTED",
   "decision": {
@@ -14,28 +14,35 @@
     "authorizes_stage2_execution": false,
     "execution_readiness": false,
     "can_be_used_as_real_stage2_input_package_now": false,
-    "decision_summary": "The merged PR #13 package has enough committed non-execution evidence to design or request a later Codex real-runner smoke/preflight phase, but this artifact does not run Codex or make Stage 2 executable."
+    "decision_summary": "The current merged base package, including PR #16 human privacy acceptance provenance, has enough committed non-execution evidence to design or request a later Codex real-runner smoke/preflight phase, but this artifact does not run Codex or make Stage 2 executable."
   },
   "required_inputs": [
     {
       "id": "human_approval_readiness",
       "path": "artifacts/v0.3/skillsbench-pilot/v0.3-stage2-input-package-candidate-20260701T010000Z/human-approval-readiness.json",
-      "sha256": "54bebda4faebb66ed826a523ce47055ff8cb3cac441b12ee8058ad4a702cf8bf",
-      "size_bytes": 9957,
+      "sha256": "db6f7822c0ed83700fdd25755cb26dd37075a7fbaa0687b4e2dd2cbe0c493b98",
+      "size_bytes": 11100,
       "status": "PRESENT_PARSED"
     },
     {
       "id": "stage2_real_pilot_input_package_candidate",
       "path": "artifacts/v0.3/skillsbench-pilot/v0.3-stage2-input-package-candidate-20260701T010000Z/stage2-real-pilot-input-package-candidate.json",
-      "sha256": "a35c930f1599409494d466aaa636d0f3b33f6f82dd0edebdbaf0add2deedc4e9",
-      "size_bytes": 24743,
+      "sha256": "1f7e3515d462a611866bbd3e296ee6581dc075af519dce496606c6e0ee601c41",
+      "size_bytes": 26925,
       "status": "PRESENT_PARSED"
     },
     {
       "id": "privacy_review_accepted_non_execution",
       "path": "artifacts/v0.3/skillsbench-pilot/v0.3-stage2-input-package-candidate-20260701T010000Z/privacy-review.accepted-non-execution.json",
-      "sha256": "15d95796a1cd106c4b40efec896dc85fcb357de9d32c04fc2ecd4bcc8db21c81",
-      "size_bytes": 7637,
+      "sha256": "84e124326f96fd62b594c960e8c7b307b38627eb0e88e30bf37052dd8d79f2f5",
+      "size_bytes": 8611,
+      "status": "PRESENT_PARSED"
+    },
+    {
+      "id": "privacy_review_human_accepted_non_execution",
+      "path": "artifacts/v0.3/skillsbench-pilot/v0.3-stage2-input-package-candidate-20260701T010000Z/privacy-review.human-accepted-non-execution.json",
+      "sha256": "b1d4a08ac99ad32242def96b92817003e87642cf951cae80042526c820fcb4ff",
+      "size_bytes": 5116,
       "status": "PRESENT_PARSED"
     },
     {
@@ -53,13 +60,22 @@
       "status": "PRESENT_INSPECTED"
     }
   ],
-  "package_readiness_from_pr13": {
-    "status": "APPROVED_FOR_NON_EXECUTION_QUALIFICATION_ORACLE_QUALIFIED_VALIDATOR_PASSED_PRIVACY_ACCEPTED_NOT_EXECUTED",
+  "package_readiness_from_current_base": {
+    "base_commit": "22267cc2a87e1720203efb285adfbf15847d0aaf",
+    "source_prs": [
+      "#13",
+      "#15",
+      "#16"
+    ],
+    "status": "APPROVED_FOR_NON_EXECUTION_QUALIFICATION_ORACLE_QUALIFIED_VALIDATOR_PASSED_PRIVACY_HUMAN_ACCEPTED_NOT_EXECUTED",
     "non_fixture_source": true,
     "human_approval_recorded": true,
+    "human_privacy_acceptance_recorded": true,
     "oracle_qualification_status": "QUALIFIED_NO_NETWORK_VERIFIER_PASSED",
     "input_package_validator_status": "PASS",
-    "privacy_review_status": "ACCEPTED_NO_REDACTION_REQUIRED_FOR_NON_EXECUTION_PACKAGE",
+    "privacy_review_status": "HUMAN_ACCEPTED_NO_REDACTION_REQUIRED_FOR_NON_EXECUTION_PACKAGE",
+    "privacy_decision": "ACCEPTED_NO_REDACTION_REQUIRED_FOR_NON_EXECUTION_PACKAGE",
+    "privacy_acceptance_provenance_status": "HUMAN_ACCEPTANCE_RECORDED",
     "validation_status": "PASS",
     "validation_no_longer_blocked_by_public_network": true,
     "effective_network_modes": {

--- a/artifacts/v0.3/skillsbench-pilot/v0.3-codex-real-runner-preflight-boundary-20260704T040625Z/codex-real-runner-preflight-boundary.static-precheck.json
+++ b/artifacts/v0.3/skillsbench-pilot/v0.3-codex-real-runner-preflight-boundary-20260704T040625Z/codex-real-runner-preflight-boundary.static-precheck.json
@@ -1,0 +1,144 @@
+{
+  "schema_version": "v0.3.codex-real-runner-preflight-boundary.static-precheck.v1",
+  "run_id": "v0.3-codex-real-runner-preflight-boundary-20260704T040625Z",
+  "created_at": "2026-07-04T04:06:25Z",
+  "source_branch": "ops/codex-real-runner-preflight-boundary",
+  "base_branch": "codex/v0.3-pr0-protocol",
+  "source_commit": "f36f17000dc42a92fc63c4e0be53fc748e0f88f3",
+  "objective": "Record the non-execution boundary and static readiness checks before any Codex real-runner smoke/preflight phase.",
+  "status": "STATIC_PRECHECK_PASSED_FOR_EXPLICIT_SMOKE_AUTHORIZATION_REVIEW_NOT_EXECUTED",
+  "decision": {
+    "static_precheck_complete": true,
+    "ready_for_explicit_codex_real_runner_smoke_authorization_review": true,
+    "authorizes_codex_cli_run_now": false,
+    "authorizes_stage2_execution": false,
+    "execution_readiness": false,
+    "can_be_used_as_real_stage2_input_package_now": false,
+    "decision_summary": "The merged PR #13 package has enough committed non-execution evidence to design or request a later Codex real-runner smoke/preflight phase, but this artifact does not run Codex or make Stage 2 executable."
+  },
+  "required_inputs": [
+    {
+      "id": "human_approval_readiness",
+      "path": "artifacts/v0.3/skillsbench-pilot/v0.3-stage2-input-package-candidate-20260701T010000Z/human-approval-readiness.json",
+      "sha256": "54bebda4faebb66ed826a523ce47055ff8cb3cac441b12ee8058ad4a702cf8bf",
+      "size_bytes": 9957,
+      "status": "PRESENT_PARSED"
+    },
+    {
+      "id": "stage2_real_pilot_input_package_candidate",
+      "path": "artifacts/v0.3/skillsbench-pilot/v0.3-stage2-input-package-candidate-20260701T010000Z/stage2-real-pilot-input-package-candidate.json",
+      "sha256": "a35c930f1599409494d466aaa636d0f3b33f6f82dd0edebdbaf0add2deedc4e9",
+      "size_bytes": 24743,
+      "status": "PRESENT_PARSED"
+    },
+    {
+      "id": "privacy_review_accepted_non_execution",
+      "path": "artifacts/v0.3/skillsbench-pilot/v0.3-stage2-input-package-candidate-20260701T010000Z/privacy-review.accepted-non-execution.json",
+      "sha256": "15d95796a1cd106c4b40efec896dc85fcb357de9d32c04fc2ecd4bcc8db21c81",
+      "size_bytes": 7637,
+      "status": "PRESENT_PARSED"
+    },
+    {
+      "id": "live_agent_placeholder_config",
+      "path": "configs/v0.3/live-agent.yaml",
+      "sha256": "a0187b7bd69120dc69221460d69686ced9d2025f74c718f38b02ff6edc90e7d4",
+      "size_bytes": 2517,
+      "status": "PRESENT_INSPECTED"
+    },
+    {
+      "id": "codex_cli_runner_contract_source",
+      "path": "src/hermes_skilleval/live_agent_runtime.py",
+      "sha256": "f05e2fef07289e88a6b6006c141c9541aa4332c4e0b9b3bb19a741ef309584e7",
+      "size_bytes": 33350,
+      "status": "PRESENT_INSPECTED"
+    }
+  ],
+  "package_readiness_from_pr13": {
+    "status": "APPROVED_FOR_NON_EXECUTION_QUALIFICATION_ORACLE_QUALIFIED_VALIDATOR_PASSED_PRIVACY_ACCEPTED_NOT_EXECUTED",
+    "non_fixture_source": true,
+    "human_approval_recorded": true,
+    "oracle_qualification_status": "QUALIFIED_NO_NETWORK_VERIFIER_PASSED",
+    "input_package_validator_status": "PASS",
+    "privacy_review_status": "ACCEPTED_NO_REDACTION_REQUIRED_FOR_NON_EXECUTION_PACKAGE",
+    "validation_status": "PASS",
+    "validation_no_longer_blocked_by_public_network": true,
+    "effective_network_modes": {
+      "bike-rebalance": "none",
+      "dialogue-parser": "controlled",
+      "offer-letter-generator": "controlled",
+      "powerlifting-coef-calc": "controlled"
+    }
+  },
+  "runner_contract_static_checks": {
+    "codex_cli_runner_class_present": true,
+    "requires_json_mode": true,
+    "requires_ephemeral_sessions": true,
+    "requires_ignore_user_config": true,
+    "requires_ignore_rules": true,
+    "requires_workspace_write_sandbox": true,
+    "requires_approval_policy_never": true,
+    "rejects_danger_full_access": true,
+    "rejects_runner_controlled_env_overrides": true,
+    "supports_skip_git_repo_check_only_after_help_confirms": true,
+    "live_agent_config_requires_real_runner_preflight": true,
+    "live_agent_config_rejects_fake_runner": true,
+    "live_agent_config_rejects_fake_verifier": true,
+    "raw_traces_in_git": false
+  },
+  "static_precheck_limitations": {
+    "codex_exec_help_invoked": false,
+    "codex_binary_version_checked": false,
+    "subprocess_smoke_invoked": false,
+    "runner_workspace_created": false,
+    "codex_home_created": false,
+    "runtime_skill_inventory_collected": false,
+    "reason": "This phase is boundary design and static precheck only. CLI/help/runtime smoke belongs to a later explicitly authorized phase."
+  },
+  "remaining_execution_blockers": [
+    "no Codex CLI real-runner smoke or preflight command was run",
+    "no installed Codex CLI version/help snapshot was recorded in this phase",
+    "no isolated CODEX_HOME runtime workspace was created",
+    "no Stage 2 pilot plan was frozen",
+    "no Stage 2 pilot execution was authorized or run",
+    "no live-agent traces were created",
+    "no evidence-gate rerun was performed",
+    "execution_readiness remains false",
+    "can_be_used_as_real_stage2_input_package_now remains false"
+  ],
+  "permitted_next_action": {
+    "action": "OPEN_EXPLICIT_CODEX_REAL_RUNNER_SMOKE_PREFLIGHT_PHASE",
+    "description": "A later bounded phase may check the installed Codex CLI version/help and run a minimal isolated smoke/preflight only after explicit authorization.",
+    "must_remain_out_of_scope": [
+      "Stage 2 pilot execution",
+      "frozen pilot planning",
+      "matrix run-order generation",
+      "live-agent trace creation beyond the explicitly authorized smoke scope",
+      "evidence-gate rerun",
+      "router promotion",
+      "release, deploy, archive, or public performance claim"
+    ]
+  },
+  "non_actions": {
+    "codex_cli_run": false,
+    "evidence_gate_rerun": false,
+    "fake_runner_or_verifier_used_as_real_evidence": false,
+    "fixture_data_used_as_real_evidence": false,
+    "live_agent_traces_created": false,
+    "llm_judge_used": false,
+    "manual_routed_predictions_written": false,
+    "oracle_label_derived_predictions": false,
+    "performance_claims": false,
+    "pilot_plan_frozen": false,
+    "process_exit_code_used_as_success": false,
+    "scorer_matrix_or_evidence_gate_semantics_modified": false,
+    "stage2_pilot_run": false,
+    "training_or_tuning_or_new_router_variant": false
+  },
+  "validation_plan": [
+    "python -m json.tool artifacts/v0.3/skillsbench-pilot/v0.3-codex-real-runner-preflight-boundary-20260704T040625Z/codex-real-runner-preflight-boundary.static-precheck.json",
+    "openspec validate --all --strict",
+    "PYTHONPATH=src python -m hermes_skilleval.cli release-check",
+    "git diff --check",
+    "boundary scan for any true execution markers in the new artifact directory"
+  ]
+}

--- a/docs/human-briefs/2026-07-04-codex-real-runner-preflight-boundary.html
+++ b/docs/human-briefs/2026-07-04-codex-real-runner-preflight-boundary.html
@@ -15,7 +15,7 @@
 </head>
 <body>
   <h1>Hermes SkillEval Codex Real-runner Preflight Boundary</h1>
-  <p class="status"><strong>结论：</strong>本阶段完成的是静态边界设计/预检：PR #13 合并后的非执行 input package 足够进入后续 real-runner smoke/preflight 授权评审；但本阶段没有运行 Codex，<code>execution_readiness=false</code>，不能直接执行 Stage 2。</p>
+  <p class="status"><strong>结论：</strong>本阶段完成的是静态边界设计/预检：当前 base 中包含 PR #13 input package、PR #15 provenance blocker 记录和 PR #16 human privacy acceptance 的非执行 package 足够进入后续 real-runner smoke/preflight 授权评审；但本阶段没有运行 Codex，<code>execution_readiness=false</code>，不能直接执行 Stage 2。</p>
 
   <h2>当前状态</h2>
   <ul>
@@ -29,12 +29,12 @@
   <ul>
     <li>新增 OpenSpec change：<code>openspec/changes/codex-real-runner-preflight-boundary/</code>。</li>
     <li>新增静态预检 JSON：<code>artifacts/v0.3/skillsbench-pilot/v0.3-codex-real-runner-preflight-boundary-20260704T040625Z/codex-real-runner-preflight-boundary.static-precheck.json</code>。</li>
-    <li>没有修改 <code>src/hermes_skilleval/**</code>、<code>tests/**</code>、release gate、<code>configs/v0.3/live-agent.yaml</code> 或 PR #13 truth surfaces。</li>
+    <li>没有修改 <code>src/hermes_skilleval/**</code>、<code>tests/**</code>、release gate、<code>configs/v0.3/live-agent.yaml</code> 或 Stage 2 input-package truth surfaces。</li>
   </ul>
 
   <h2>静态预检内容</h2>
   <ul>
-    <li>PR #13 readiness：human approval 已记录，oracle qualification 为 <code>QUALIFIED_NO_NETWORK_VERIFIER_PASSED</code>，input-package validator 为 <code>PASS</code>，privacy review 为 accepted non-execution。</li>
+    <li>Current-base readiness：human approval 已记录，oracle qualification 为 <code>QUALIFIED_NO_NETWORK_VERIFIER_PASSED</code>，input-package validator 为 <code>PASS</code>，privacy provenance 为 <code>HUMAN_ACCEPTANCE_RECORDED</code>，decision 为 <code>ACCEPTED_NO_REDACTION_REQUIRED_FOR_NON_EXECUTION_PACKAGE</code>。</li>
     <li>Runner contract：源码包含 isolated <code>CODEX_HOME</code>、<code>workspace-write</code> sandbox、approval policy <code>never</code>、required <code>codex exec</code> flags、danger bypass 拒绝和 runner-controlled env override 拒绝。</li>
     <li>配置边界：<code>configs/v0.3/live-agent.yaml</code> 仍要求 real-runner preflight，拒绝 fake runner/verifier，并禁止 raw traces 入 Git。</li>
   </ul>

--- a/docs/human-briefs/2026-07-04-codex-real-runner-preflight-boundary.html
+++ b/docs/human-briefs/2026-07-04-codex-real-runner-preflight-boundary.html
@@ -1,0 +1,64 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8" />
+  <title>Codex real-runner preflight boundary</title>
+  <style>
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; margin: 32px; line-height: 1.55; color: #17202a; }
+    h1 { font-size: 24px; margin-bottom: 8px; }
+    h2 { font-size: 17px; margin-top: 24px; }
+    code { background: #f2f4f7; padding: 2px 5px; border-radius: 4px; }
+    .status { border-left: 4px solid #2563eb; padding: 10px 14px; background: #eff6ff; }
+    .warn { border-left-color: #b45309; background: #fff7ed; }
+    ul { padding-left: 22px; }
+  </style>
+</head>
+<body>
+  <h1>Hermes SkillEval Codex Real-runner Preflight Boundary</h1>
+  <p class="status"><strong>结论：</strong>本阶段完成的是静态边界设计/预检：PR #13 合并后的非执行 input package 足够进入后续 real-runner smoke/preflight 授权评审；但本阶段没有运行 Codex，<code>execution_readiness=false</code>，不能直接执行 Stage 2。</p>
+
+  <h2>当前状态</h2>
+  <ul>
+    <li><code>STATIC_PRECHECK_PASSED_FOR_EXPLICIT_SMOKE_AUTHORIZATION_REVIEW_NOT_EXECUTED</code></li>
+    <li><code>ready_for_explicit_codex_real_runner_smoke_authorization_review=true</code></li>
+    <li><code>authorizes_codex_cli_run_now=false</code></li>
+    <li><code>can_be_used_as_real_stage2_input_package_now=false</code></li>
+  </ul>
+
+  <h2>本阶段变化</h2>
+  <ul>
+    <li>新增 OpenSpec change：<code>openspec/changes/codex-real-runner-preflight-boundary/</code>。</li>
+    <li>新增静态预检 JSON：<code>artifacts/v0.3/skillsbench-pilot/v0.3-codex-real-runner-preflight-boundary-20260704T040625Z/codex-real-runner-preflight-boundary.static-precheck.json</code>。</li>
+    <li>没有修改 <code>src/hermes_skilleval/**</code>、<code>tests/**</code>、release gate、<code>configs/v0.3/live-agent.yaml</code> 或 PR #13 truth surfaces。</li>
+  </ul>
+
+  <h2>静态预检内容</h2>
+  <ul>
+    <li>PR #13 readiness：human approval 已记录，oracle qualification 为 <code>QUALIFIED_NO_NETWORK_VERIFIER_PASSED</code>，input-package validator 为 <code>PASS</code>，privacy review 为 accepted non-execution。</li>
+    <li>Runner contract：源码包含 isolated <code>CODEX_HOME</code>、<code>workspace-write</code> sandbox、approval policy <code>never</code>、required <code>codex exec</code> flags、danger bypass 拒绝和 runner-controlled env override 拒绝。</li>
+    <li>配置边界：<code>configs/v0.3/live-agent.yaml</code> 仍要求 real-runner preflight，拒绝 fake runner/verifier，并禁止 raw traces 入 Git。</li>
+  </ul>
+
+  <h2>非动作</h2>
+  <ul>
+    <li>没有调用 <code>codex exec</code>、没有读取真实 <code>codex exec --help</code>、没有创建 isolated runtime workspace。</li>
+    <li>没有 Stage 2 pilot、没有 frozen pilot plan、没有 live-agent traces、没有 evidence-gate rerun。</li>
+    <li>没有 release、deploy、archive、router promotion 或性能结论。</li>
+  </ul>
+
+  <h2>验证命令</h2>
+  <ul>
+    <li><code>python -m json.tool</code> 检查新 static precheck JSON。</li>
+    <li><code>openspec validate --all --strict</code>。</li>
+    <li><code>PYTHONPATH=src python -m hermes_skilleval.cli release-check</code>。</li>
+    <li><code>git diff --check</code>。</li>
+    <li>新 artifact 目录 execution marker boundary scan。</li>
+  </ul>
+
+  <h2>剩余风险</h2>
+  <p class="status warn">本阶段没有证明本机 Codex CLI 当前版本/flags 可用，也没有证明真实 subprocess smoke 能完成；这些只能在后续明确授权的 smoke/preflight phase 中检查。</p>
+
+  <h2>建议下一步</h2>
+  <p>如果继续，开一个更小阶段：只授权检查本机 <code>codex exec --help</code>/<code>--version</code> 与最小 isolated smoke；仍不冻结 pilot plan、不跑 Stage 2 matrix、不提交 raw traces。</p>
+</body>
+</html>

--- a/openspec/changes/codex-real-runner-preflight-boundary/.openspec.yaml
+++ b/openspec/changes/codex-real-runner-preflight-boundary/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-04

--- a/openspec/changes/codex-real-runner-preflight-boundary/design.md
+++ b/openspec/changes/codex-real-runner-preflight-boundary/design.md
@@ -1,0 +1,93 @@
+## Context
+
+PR-5 added the real `CodexCliRunner` subprocess layer and its fail-closed
+preflight contract. PR #13 later merged a non-execution Stage 2 input-package
+candidate whose oracle qualification, input-package validator, and privacy
+review are complete for review purposes, while preserving
+`execution_readiness=false` and explicitly recording that no Codex real-runner
+preflight, Stage 2 pilot, frozen plan, traces, or evidence-gate rerun occurred.
+
+This change is the boundary step between those two facts. It does not exercise
+the runner. It records whether the merged package has enough static evidence to
+justify a later, separately authorized real-runner smoke/preflight phase.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Define a fail-closed boundary for Codex real-runner preflight readiness.
+- Consume existing committed evidence from PR-5/PR-6/PR #13 without rewriting
+  their truth surfaces.
+- Record the current decision as a static JSON artifact and a concise Chinese
+  Human Brief.
+- Keep the next permitted action narrow: a later smoke/preflight design review
+  or explicit smoke run authorization, not Stage 2 execution.
+
+**Non-Goals:**
+
+- No `codex exec` invocation.
+- No live-agent trace creation.
+- No Stage 2 pilot execution, frozen pilot plan, run-order generation, or
+  evidence-gate rerun.
+- No changes to `src/hermes_skilleval/**`, `tests/**`, release logic,
+  `configs/v0.3/live-agent.yaml`, or existing PR #13 artifacts.
+- No release, archive, deploy, or public performance claim.
+
+## Decisions
+
+1. **Static boundary artifact over runner execution.**
+   The preflight packet is a JSON decision artifact built from committed
+   evidence paths and source-file inspection. Alternative considered: run
+   `codex exec --version` or a real `CodexCliRunner` smoke now. That would
+   cross the current phase boundary, create runtime-dependent evidence, and
+   weaken the clear distinction between boundary design and execution.
+
+2. **Three readiness gates.**
+   The artifact separates package readiness, runner-contract readiness, and
+   execution authorization. Package readiness can be positive for non-execution
+   review while execution authorization remains false. This avoids collapsing
+   validator/privacy success into Stage 2 readiness.
+
+3. **Fail closed on missing committed evidence.**
+   Required inputs include the merged PR #13 readiness artifact, stage2 package
+   candidate artifact, privacy decision artifact, `configs/v0.3/live-agent.yaml`,
+   and the PR-5 runner implementation. Missing or unparsable inputs make the
+   boundary decision `BLOCKED_STATIC_PRECHECK`.
+
+4. **No mutation of historical truth surfaces.**
+   This phase writes new artifacts under a new run directory and links back to
+   existing evidence. Existing PR #13 JSON files are not updated, because they
+   correctly describe the C4 closeout state.
+
+5. **Human Brief is explanatory only.**
+   The HTML brief summarizes the same decision for review. It is not a second
+   source of truth and must link back to OpenSpec and artifact paths.
+
+## Risks / Trade-offs
+
+- [Risk] A static pass may be mistaken for a real Codex smoke pass. ->
+  Mitigation: artifact status and brief use `STATIC_PRECHECK_ONLY` and keep
+  `codex_cli_run=false`, `live_agent_traces_created=false`,
+  `stage2_pilot_run=false`, and `execution_readiness=false`.
+- [Risk] CLI flag drift is not detected without invoking Codex. -> Mitigation:
+  record CLI drift as a blocker that the next separately authorized smoke
+  phase must check against `codex exec --help`.
+- [Risk] Existing artifact paths may move in a later cleanup. -> Mitigation:
+  fail closed on missing inputs and keep this phase tied to PR #13 merge state.
+- [Risk] The new capability duplicates completed PR-5/PR-6 deltas. ->
+  Mitigation: define only the boundary decision capability; do not modify the
+  historical runner or matrix capability requirements.
+
+## Migration Plan
+
+This phase is additive. Rollback is deleting
+`openspec/changes/codex-real-runner-preflight-boundary/`, the new static
+preflight artifact directory, and the new Human Brief. No runtime behavior or
+release gate state changes.
+
+## Open Questions
+
+- The exact real smoke command, model, timeout, and isolated `CODEX_HOME` root
+  remain for a later explicitly authorized smoke/preflight phase.
+- Whether the later smoke phase may use inherited Codex config remains
+  unresolved; PR-5 says inherit mode is smoke-only and not final evidence.

--- a/openspec/changes/codex-real-runner-preflight-boundary/design.md
+++ b/openspec/changes/codex-real-runner-preflight-boundary/design.md
@@ -2,10 +2,11 @@
 
 PR-5 added the real `CodexCliRunner` subprocess layer and its fail-closed
 preflight contract. PR #13 later merged a non-execution Stage 2 input-package
-candidate whose oracle qualification, input-package validator, and privacy
-review are complete for review purposes, while preserving
-`execution_readiness=false` and explicitly recording that no Codex real-runner
-preflight, Stage 2 pilot, frozen plan, traces, or evidence-gate rerun occurred.
+candidate whose oracle qualification and input-package validator are complete
+for review purposes, and PR #16 recorded explicit human privacy acceptance.
+The current base still preserves `execution_readiness=false` and explicitly
+records that no Codex real-runner preflight, Stage 2 pilot, frozen plan, traces,
+or evidence-gate rerun occurred.
 
 This change is the boundary step between those two facts. It does not exercise
 the runner. It records whether the merged package has enough static evidence to
@@ -16,8 +17,8 @@ justify a later, separately authorized real-runner smoke/preflight phase.
 **Goals:**
 
 - Define a fail-closed boundary for Codex real-runner preflight readiness.
-- Consume existing committed evidence from PR-5/PR-6/PR #13 without rewriting
-  their truth surfaces.
+- Consume existing committed evidence from PR-5/PR-6/PR #13/PR #16 without
+  rewriting their truth surfaces.
 - Record the current decision as a static JSON artifact and a concise Chinese
   Human Brief.
 - Keep the next permitted action narrow: a later smoke/preflight design review
@@ -30,7 +31,7 @@ justify a later, separately authorized real-runner smoke/preflight phase.
 - No Stage 2 pilot execution, frozen pilot plan, run-order generation, or
   evidence-gate rerun.
 - No changes to `src/hermes_skilleval/**`, `tests/**`, release logic,
-  `configs/v0.3/live-agent.yaml`, or existing PR #13 artifacts.
+  `configs/v0.3/live-agent.yaml`, or existing Stage 2 input-package artifacts.
 - No release, archive, deploy, or public performance claim.
 
 ## Decisions
@@ -49,15 +50,17 @@ justify a later, separately authorized real-runner smoke/preflight phase.
    validator/privacy success into Stage 2 readiness.
 
 3. **Fail closed on missing committed evidence.**
-   Required inputs include the merged PR #13 readiness artifact, stage2 package
-   candidate artifact, privacy decision artifact, `configs/v0.3/live-agent.yaml`,
-   and the PR-5 runner implementation. Missing or unparsable inputs make the
-   boundary decision `BLOCKED_STATIC_PRECHECK`.
+   Required inputs include the current-base readiness artifact, stage2 package
+   candidate artifact, privacy decision artifact, PR #16 human privacy
+   acceptance artifact, `configs/v0.3/live-agent.yaml`, and the PR-5 runner
+   implementation. Missing or unparsable inputs make the boundary decision
+   `BLOCKED_STATIC_PRECHECK`.
 
 4. **No mutation of historical truth surfaces.**
    This phase writes new artifacts under a new run directory and links back to
-   existing evidence. Existing PR #13 JSON files are not updated, because they
-   correctly describe the C4 closeout state.
+   existing evidence. Existing Stage 2 input-package JSON files are not updated
+   by this boundary phase; the current base already records PR #16 privacy
+   acceptance provenance.
 
 5. **Human Brief is explanatory only.**
    The HTML brief summarizes the same decision for review. It is not a second
@@ -73,7 +76,8 @@ justify a later, separately authorized real-runner smoke/preflight phase.
   record CLI drift as a blocker that the next separately authorized smoke
   phase must check against `codex exec --help`.
 - [Risk] Existing artifact paths may move in a later cleanup. -> Mitigation:
-  fail closed on missing inputs and keep this phase tied to PR #13 merge state.
+  fail closed on missing inputs and keep this phase tied to current merged base
+  evidence.
 - [Risk] The new capability duplicates completed PR-5/PR-6 deltas. ->
   Mitigation: define only the boundary decision capability; do not modify the
   historical runner or matrix capability requirements.

--- a/openspec/changes/codex-real-runner-preflight-boundary/proposal.md
+++ b/openspec/changes/codex-real-runner-preflight-boundary/proposal.md
@@ -1,0 +1,44 @@
+## Why
+
+PR #13 merged a non-execution Stage 2 input-package candidate with validator
+and privacy blockers closed, but the truth surface still explicitly says no
+Codex real-runner preflight has run. Before any future smoke run, pilot plan,
+or Stage 2 execution, Hermes needs a small fail-closed boundary packet that
+turns the existing PR-5 runner contract and PR #13 package state into concrete
+preflight criteria without invoking Codex.
+
+## What Changes
+
+- Add an OpenSpec change that defines the Codex real-runner preflight boundary
+  as a separate non-execution phase.
+- Record a static preflight readiness artifact for the merged PR #13 package,
+  including required inputs, current blockers, permitted next action, and
+  explicit non-actions.
+- Add a concise Chinese Human Brief for human review of the boundary decision.
+- Preserve the existing runner implementation, Stage 2 package artifacts,
+  release gates, tests, and historical evidence.
+- Do not run `codex exec`, create live-agent traces, freeze a pilot plan,
+  rerun the evidence gate, or execute the Stage 2 matrix.
+
+## Capabilities
+
+### New Capabilities
+
+- `codex-real-runner-preflight-boundary`: Defines how Hermes records a
+  non-execution readiness decision before any Codex real-runner smoke or
+  live-agent Stage 2 execution is allowed.
+
+### Modified Capabilities
+
+- None.
+
+## Impact
+
+- Affected artifacts:
+  - `openspec/changes/codex-real-runner-preflight-boundary/**`
+  - `artifacts/v0.3/skillsbench-pilot/v0.3-codex-real-runner-preflight-boundary-*/`
+  - `docs/human-briefs/*codex-real-runner-preflight-boundary.html`
+- No changes to `src/hermes_skilleval/**`, `tests/**`, release logic, runner
+  command construction, or committed Stage 2 input-package truth surfaces.
+- Validation remains local/static: JSON parsing, boundary scans, OpenSpec
+  strict validation, and release reproducibility checks.

--- a/openspec/changes/codex-real-runner-preflight-boundary/proposal.md
+++ b/openspec/changes/codex-real-runner-preflight-boundary/proposal.md
@@ -1,19 +1,20 @@
 ## Why
 
 PR #13 merged a non-execution Stage 2 input-package candidate with validator
-and privacy blockers closed, but the truth surface still explicitly says no
-Codex real-runner preflight has run. Before any future smoke run, pilot plan,
-or Stage 2 execution, Hermes needs a small fail-closed boundary packet that
-turns the existing PR-5 runner contract and PR #13 package state into concrete
-preflight criteria without invoking Codex.
+evidence, and PR #16 later recorded explicit human privacy acceptance while
+keeping execution readiness false. The current truth surface still explicitly
+says no Codex real-runner preflight has run. Before any future smoke run, pilot
+plan, or Stage 2 execution, Hermes needs a small fail-closed boundary packet
+that turns the existing PR-5 runner contract and current merged package state
+into concrete preflight criteria without invoking Codex.
 
 ## What Changes
 
 - Add an OpenSpec change that defines the Codex real-runner preflight boundary
   as a separate non-execution phase.
-- Record a static preflight readiness artifact for the merged PR #13 package,
-  including required inputs, current blockers, permitted next action, and
-  explicit non-actions.
+- Record a static preflight readiness artifact for the current merged package
+  state, including PR #16 privacy acceptance provenance, required inputs,
+  current blockers, permitted next action, and explicit non-actions.
 - Add a concise Chinese Human Brief for human review of the boundary decision.
 - Preserve the existing runner implementation, Stage 2 package artifacts,
   release gates, tests, and historical evidence.

--- a/openspec/changes/codex-real-runner-preflight-boundary/specs/codex-real-runner-preflight-boundary/spec.md
+++ b/openspec/changes/codex-real-runner-preflight-boundary/specs/codex-real-runner-preflight-boundary/spec.md
@@ -31,7 +31,7 @@ execution evidence.
   `pilot_plan_frozen=false`, and `evidence_gate_rerun=false`
 - **AND** it MUST keep `execution_readiness=false` unless a later authorized
   real-runner smoke/preflight phase records real runtime evidence
-- **AND** it MUST NOT modify existing PR #13 input-package truth surfaces
+- **AND** it MUST NOT modify existing Stage 2 input-package truth surfaces
 
 ### Requirement: Gate next action narrowly
 

--- a/openspec/changes/codex-real-runner-preflight-boundary/specs/codex-real-runner-preflight-boundary/spec.md
+++ b/openspec/changes/codex-real-runner-preflight-boundary/specs/codex-real-runner-preflight-boundary/spec.md
@@ -1,0 +1,60 @@
+## ADDED Requirements
+
+### Requirement: Record static real-runner preflight boundary
+
+The system SHALL record a static Codex real-runner preflight boundary decision
+before any real `codex exec` smoke, live-agent trace, Stage 2 pilot plan, or
+Stage 2 execution is allowed.
+
+#### Scenario: Static boundary decision is recorded
+
+- **WHEN** a merged non-execution Stage 2 input package is reviewed for the
+  next Codex real-runner step
+- **THEN** the system MUST write a JSON artifact with run ID, source commit,
+  required input paths, parsed readiness fields, blocker state, and permitted
+  next action
+- **AND** the artifact MUST distinguish static package readiness from real
+  runner execution readiness
+- **AND** missing or unparsable required inputs MUST produce a blocked
+  decision instead of an execution-ready decision
+
+### Requirement: Preserve non-execution boundaries
+
+The system SHALL keep Codex real-runner preflight design separate from runtime
+execution evidence.
+
+#### Scenario: Non-actions stay explicit
+
+- **WHEN** the static boundary artifact is written
+- **THEN** it MUST record `codex_cli_run=false`,
+  `live_agent_traces_created=false`, `stage2_pilot_run=false`,
+  `pilot_plan_frozen=false`, and `evidence_gate_rerun=false`
+- **AND** it MUST keep `execution_readiness=false` unless a later authorized
+  real-runner smoke/preflight phase records real runtime evidence
+- **AND** it MUST NOT modify existing PR #13 input-package truth surfaces
+
+### Requirement: Gate next action narrowly
+
+The system SHALL make the next permitted action explicit and bounded.
+
+#### Scenario: Next action is a later authorization gate
+
+- **WHEN** static preflight criteria are satisfied
+- **THEN** the permitted next action MUST be limited to a later explicitly
+  authorized Codex real-runner smoke/preflight phase
+- **AND** it MUST NOT authorize Stage 2 pilot execution, frozen pilot planning,
+  matrix execution, trace creation, release promotion, or deployment
+
+### Requirement: Provide human-review summary
+
+The system SHALL provide a concise human-readable summary for the static
+preflight boundary decision.
+
+#### Scenario: Human Brief mirrors the artifact
+
+- **WHEN** the boundary artifact is created
+- **THEN** a Chinese Human Brief MUST summarize conclusion, current status,
+  changed artifacts, verification commands, non-actions, risks, and
+  recommended next step
+- **AND** the Human Brief MUST link or name the OpenSpec change and JSON
+  artifact as the authoritative sources

--- a/openspec/changes/codex-real-runner-preflight-boundary/tasks.md
+++ b/openspec/changes/codex-real-runner-preflight-boundary/tasks.md
@@ -1,0 +1,26 @@
+## 1. OpenSpec Boundary
+
+- [x] 1.1 Create proposal, design, and capability spec for the static
+  Codex real-runner preflight boundary.
+- [x] 1.2 Keep scope limited to non-execution boundary design; do not modify
+  runtime code, tests, release logic, or PR #13 truth surfaces.
+
+## 2. Static Precheck Artifact
+
+- [x] 2.1 Inspect the merged PR #13 input-package readiness artifacts and the
+  existing PR-5 Codex runner contract.
+- [x] 2.2 Write a static precheck JSON artifact with required inputs, blocker
+  state, allowed next action, and explicit non-actions.
+
+## 3. Human Brief
+
+- [x] 3.1 Generate a concise Chinese Human Brief that mirrors the JSON
+  artifact and OpenSpec boundary.
+
+## 4. Validation
+
+- [x] 4.1 Validate OpenSpec with `openspec validate --all --strict`.
+- [x] 4.2 Validate JSON syntax and boundary fields for the new artifact.
+- [x] 4.3 Run release reproducibility check and `git diff --check`.
+- [x] 4.4 Confirm no Codex run, traces, pilot freeze, Stage 2 run, deploy,
+  archive, or release was produced.

--- a/openspec/changes/codex-real-runner-preflight-boundary/tasks.md
+++ b/openspec/changes/codex-real-runner-preflight-boundary/tasks.md
@@ -3,12 +3,13 @@
 - [x] 1.1 Create proposal, design, and capability spec for the static
   Codex real-runner preflight boundary.
 - [x] 1.2 Keep scope limited to non-execution boundary design; do not modify
-  runtime code, tests, release logic, or PR #13 truth surfaces.
+  runtime code, tests, release logic, or Stage 2 input-package truth surfaces.
 
 ## 2. Static Precheck Artifact
 
-- [x] 2.1 Inspect the merged PR #13 input-package readiness artifacts and the
-  existing PR-5 Codex runner contract.
+- [x] 2.1 Inspect the current merged Stage 2 input-package readiness artifacts,
+  PR #16 privacy acceptance provenance, and the existing PR-5 Codex runner
+  contract.
 - [x] 2.2 Write a static precheck JSON artifact with required inputs, blocker
   state, allowed next action, and explicit non-actions.
 


### PR DESCRIPTION
## Summary

This is a non-execution boundary/preflight documentation PR. It records the Codex real-runner preflight boundary as OpenSpec, static evidence, and a Human Brief only.

This PR was refreshed after PR #16 so the static precheck now points at the current merged base privacy provenance:

- `HUMAN_ACCEPTANCE_RECORDED`
- `ACCEPTED_NO_REDACTION_REQUIRED_FOR_NON_EXECUTION_PACKAGE`
- `privacy-review.human-accepted-non-execution.json`

## Explicit Non-Actions

- No Codex exec was run.
- No Stage 2 pilot was run.
- No traces were created.
- No pilot plan was frozen.
- No evidence gate was rerun.
- No qualification was rerun.
- No performance claim is made.
- This does not approve Stage 2 execution.
- This does not replace the Stage 2 input-package qualification or privacy acceptance artifacts.

## Verification Summary From Latest Push

- Current-base required input hash check: passed
- JSON/JSONL parse checks: passed
- provenance/readiness guard: passed
- prohibited true-flag scan: passed
- execution marker / trace scan: clean
- OPENSPEC_TELEMETRY=0 openspec validate --all --strict: 24 passed, 0 failed
- PYTHONPATH=src python -m hermes_skilleval.cli release-check: PASS
- PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=src python -m pytest -q: 664 passed
- git diff --check: passed
- GitHub Actions: passed

## Boundaries

Hard prohibitions preserved for this PR:

- Do not run Stage 2.
- Do not run Codex.
- Do not freeze pilot plan.
- Do not create traces.
- Do not rerun evidence gate.
- Do not rerun qualification.
- Do not modify Stage 2 input-package artifacts.
- Do not write performance claims.
