### PR TITLE
ops: record PR13 privacy provenance blocker

### DIFF
--- a/artifacts/v0.3/skillsbench-pilot/v0.3-stage2-input-package-candidate-20260701T010000Z/human-approval-readiness.json
+++ b/artifacts/v0.3/skillsbench-pilot/v0.3-stage2-input-package-candidate-20260701T010000Z/human-approval-readiness.json
@@ -8,8 +8,10 @@
     "human_non_execution_approval_recorded": true,
     "input_package_validator_passed": true,
     "oracle_qualification_complete": true,
-    "privacy_review_required": false,
-    "privacy_review_status": "ACCEPTED_NO_REDACTION_REQUIRED_FOR_NON_EXECUTION_PACKAGE"
+    "privacy_review_required": true,
+    "privacy_review_status": "PRIVACY_ACCEPTANCE_PROVENANCE_MISSING",
+    "explicit_human_privacy_acceptance_found": false,
+    "privacy_acceptance_provenance_required": true
   },
   "approval_decision_items": [
     {
@@ -32,9 +34,10 @@
       "decision": "accept_or_request_redaction_for_privacy_review_items",
       "evidence_refs": [
         "privacy-scan.review-required.json",
-        "privacy-review.accepted-non-execution.json"
+        "privacy-review.accepted-non-execution.json",
+        "privacy-acceptance-provenance.audit.json"
       ],
-      "status": "ACCEPTED_NO_REDACTION_REQUIRED_FOR_NON_EXECUTION_PACKAGE"
+      "status": "PRIVACY_ACCEPTANCE_PROVENANCE_MISSING"
     },
     {
       "decision": "approve_or_request_new_candidate_routed_predictions",
@@ -73,7 +76,8 @@
     "no Stage 2 pilot plan was frozen",
     "no Stage 2 pilot execution was authorized or run",
     "no live-agent traces were created",
-    "no evidence-gate rerun was performed"
+    "no evidence-gate rerun was performed",
+    "privacy acceptance provenance missing"
   ],
   "human_approval_artifact": {
     "name": "human-approval.non-execution-qualification.json",
@@ -90,8 +94,8 @@
   "privacy_review_artifact": {
     "name": "privacy-review.accepted-non-execution.json",
     "path": "privacy-review.accepted-non-execution.json",
-    "sha256": "15d95796a1cd106c4b40efec896dc85fcb357de9d32c04fc2ecd4bcc8db21c81",
-    "size_bytes": 7637
+    "sha256": "84e124326f96fd62b594c960e8c7b307b38627eb0e88e30bf37052dd8d79f2f5",
+    "size_bytes": 8611
   },
   "non_actions": {
     "codex_cli_run": false,
@@ -171,13 +175,15 @@
     "input_package_validator_status": "PASS",
     "non_fixture_source": true,
     "oracle_qualification_status": "QUALIFIED_NO_NETWORK_VERIFIER_PASSED",
-    "post_approval_status": "NON_EXECUTION_ORACLE_QUALIFIED_VALIDATOR_PASSED_PRIVACY_ACCEPTED_NOT_EXECUTED",
-    "privacy_review_status": "ACCEPTED_NO_REDACTION_REQUIRED_FOR_NON_EXECUTION_PACKAGE",
-    "ready_for_human_approval_now": true,
-    "recommended_next_step": "PR #13 can proceed to human review/merge consideration as a non-execution package. Authorize a separate bounded phase before any Codex real-runner preflight or frozen pilot planning; do not run Stage 2 from this C4 privacy closeout.",
+    "post_approval_status": "NON_EXECUTION_ORACLE_QUALIFIED_VALIDATOR_PASSED_PRIVACY_ACCEPTANCE_PROVENANCE_MISSING_NOT_EXECUTED",
+    "privacy_review_status": "PRIVACY_ACCEPTANCE_PROVENANCE_MISSING",
+    "ready_for_human_approval_now": false,
+    "recommended_next_step": "Leave Issue #11 open and request explicit human privacy acceptance or redaction decision. Do not run Stage 2, Codex, freeze a pilot plan, create traces, or rerun the evidence gate from this package.",
     "strict_routed_predictions_status": "EXPORTED_STRICT_PROVENANCE",
     "validation_no_longer_blocked_by_public_network": true,
-    "validation_status": "PASS"
+    "validation_status": "PASS",
+    "execution_readiness": false,
+    "explicit_human_privacy_acceptance_found": false
   },
   "routed_prediction_artifacts": {
     "approved_router_config": {
@@ -211,7 +217,7 @@
     "sha256": "235a48830bc25f324f071582a42ed42a3074342d3b6f6f914d0ea99fb26a8739",
     "size_bytes": 180520
   },
-  "status": "APPROVED_FOR_NON_EXECUTION_QUALIFICATION_ORACLE_QUALIFIED_VALIDATOR_PASSED_PRIVACY_ACCEPTED_NOT_EXECUTED",
+  "status": "APPROVED_FOR_NON_EXECUTION_QUALIFICATION_ORACLE_QUALIFIED_VALIDATOR_PASSED_PRIVACY_ACCEPTANCE_PROVENANCE_MISSING_NOT_EXECUTED",
   "validation_artifacts": {
     "errors": [],
     "public_network_blocker_present": false,
@@ -225,7 +231,7 @@
     "validation_manifest": {
       "name": "manifest.json",
       "path": "validation/manifest.json",
-      "sha256": "7aa2571a6b46787c122aea6bca5a280450e8a61f36cf93c71f17e597ee369aee",
+      "sha256": "c4ef7525b51b5857ba0eda2b1a81b623b56bedc1a5e495c13371c59c45a860ea",
       "size_bytes": 1256
     }
   },
@@ -234,5 +240,11 @@
     "path": "zero-dependency-qualification-20260702T113533Z/manifest.json",
     "sha256": "4b8de75e62567e9cfd25d3cd4b7987e24f5dec67baab7d6aa918bdcb974f778b",
     "size_bytes": 24795
+  },
+  "privacy_acceptance_provenance_artifact": {
+    "name": "privacy-acceptance-provenance.audit.json",
+    "path": "privacy-acceptance-provenance.audit.json",
+    "sha256": "0a79ca797af0e1ec60ba28c1440a5330e10aa3a3e1c21d9cac44cc84d3be5585",
+    "size_bytes": 2665
   }
 }

--- a/artifacts/v0.3/skillsbench-pilot/v0.3-stage2-input-package-candidate-20260701T010000Z/privacy-acceptance-provenance.audit.json
+++ b/artifacts/v0.3/skillsbench-pilot/v0.3-stage2-input-package-candidate-20260701T010000Z/privacy-acceptance-provenance.audit.json
@@ -1,0 +1,60 @@
+{
+  "schema_version": "v0.3.stage2-input-package-privacy-acceptance-provenance-audit.v1",
+  "created_at": "2026-07-04T13:21:09+08:00",
+  "run_id": "v0.3-stage2-input-package-candidate-20260701T010000Z",
+  "status": "PRIVACY_ACCEPTANCE_PROVENANCE_MISSING",
+  "explicit_human_privacy_acceptance_found": false,
+  "audited_repo_commit": "f36f17000dc42a92fc63c4e0be53fc748e0f88f3",
+  "audited_pr": {
+    "number": 13,
+    "merge_commit_sha": "f36f17000dc42a92fc63c4e0be53fc748e0f88f3",
+    "head_commit_sha": "367074509083e44e9cfddaf0011e511b12e4ba4c"
+  },
+  "audited_issue": {
+    "number": 11,
+    "state_at_audit": "OPEN",
+    "latest_comment_observed_stale_relative_to_pr13_merge": true
+  },
+  "audited_sources": [
+    "GitHub PR #13 metadata/body/comments queried read-only",
+    "GitHub Issue #11 metadata/body/comments queried read-only",
+    "git history for privacy-review.accepted-non-execution.json and stage2-real-pilot-input-package-candidate.json",
+    "repo-local privacy review and scan artifacts"
+  ],
+  "prior_repo_local_privacy_decision": {
+    "status": "ACCEPTED_NO_REDACTION_REQUIRED_FOR_NON_EXECUTION_PACKAGE",
+    "artifact": {
+      "name": "privacy-review.accepted-non-execution.json",
+      "path": "privacy-review.accepted-non-execution.json",
+      "sha256": "84e124326f96fd62b594c960e8c7b307b38627eb0e88e30bf37052dd8d79f2f5",
+      "size_bytes": 8611
+    },
+    "note": "This is retained as repo-local classification evidence only; it is not explicit human privacy acceptance."
+  },
+  "reviewed_scan": {
+    "name": "privacy-scan.review-required.json",
+    "path": "privacy-scan.review-required.json",
+    "sha256": "faa3767dc3701a22c34b319cdad6d2246b700bd0e4bd3c78dfe361fc2fb3c827",
+    "size_bytes": 8818,
+    "status": "REVIEW_REQUIRED"
+  },
+  "finding": "No explicit human privacy acceptance wording was found for ACCEPTED_NO_REDACTION_REQUIRED_FOR_NON_EXECUTION_PACKAGE.",
+  "blocker": "PRIVACY_ACCEPTANCE_PROVENANCE_MISSING",
+  "required_human_action": "Keep Issue #11 open or add an explicit human-authored privacy acceptance/redaction decision before closing input sourcing as privacy-accepted.",
+  "readiness_decision": {
+    "can_be_used_as_real_stage2_input_package_now": false,
+    "execution_readiness": false,
+    "privacy_review_status": "PRIVACY_ACCEPTANCE_PROVENANCE_MISSING",
+    "ready_for_human_approval_now": false
+  },
+  "non_actions": {
+    "stage2_pilot_run": false,
+    "codex_cli_run": false,
+    "pilot_plan_frozen": false,
+    "live_agent_traces_created": false,
+    "evidence_gate_rerun": false,
+    "performance_claims": false,
+    "llm_judge_used": false,
+    "process_exit_code_used_as_success": false
+  }
+}

--- a/artifacts/v0.3/skillsbench-pilot/v0.3-stage2-input-package-candidate-20260701T010000Z/privacy-review.accepted-non-execution.json
+++ b/artifacts/v0.3/skillsbench-pilot/v0.3-stage2-input-package-candidate-20260701T010000Z/privacy-review.accepted-non-execution.json
@@ -68,7 +68,7 @@
   "created_at": "2026-07-04T01:22:40+08:00",
   "decision_scope": {
     "can_be_used_as_real_stage2_input_package_now": false,
-    "decision": "Privacy review is accepted for the PR #13 non-execution input-package candidate, with no redaction required under public-upstream benchmark scope.",
+    "decision": "Repo-local privacy review classified the 28 scan findings as no-redaction-required for the non-execution package, but no explicit human privacy acceptance was found in PR #13 or Issue #11 during the provenance audit.",
     "does_not_authorize_codex_run": true,
     "does_not_authorize_evidence_gate_rerun": true,
     "does_not_authorize_live_agent_traces": true,
@@ -77,7 +77,9 @@
     "execution_readiness": false,
     "package_scope": "PR #13 Stage 2 input-package candidate evidence review only",
     "public_upstream_benchmark_scope": true,
-    "redaction_required": false
+    "redaction_required": false,
+    "explicit_human_privacy_acceptance_found": false,
+    "privacy_acceptance_provenance_status": "PRIVACY_ACCEPTANCE_PROVENANCE_MISSING"
   },
   "finding_count": 28,
   "finding_resolution_counts": {
@@ -154,7 +156,8 @@
     "no live-agent traces were created",
     "no evidence-gate rerun was performed",
     "execution_readiness remains false",
-    "can_be_used_as_real_stage2_input_package_now remains false"
+    "can_be_used_as_real_stage2_input_package_now remains false",
+    "privacy acceptance provenance missing"
   ],
   "reviewed_scan": {
     "finding_count": 28,
@@ -172,5 +175,18 @@
     "offer-letter-generator",
     "powerlifting-coef-calc"
   ],
-  "status": "ACCEPTED_NO_REDACTION_REQUIRED_FOR_NON_EXECUTION_PACKAGE"
+  "status": "PRIVACY_ACCEPTANCE_PROVENANCE_MISSING",
+  "acceptance_provenance": {
+    "status": "PRIVACY_ACCEPTANCE_PROVENANCE_MISSING",
+    "audited_at": "2026-07-04T13:21:09+08:00",
+    "explicit_human_privacy_acceptance_found": false,
+    "audited_sources": [
+      "GitHub PR #13 body/comments/merge metadata",
+      "GitHub Issue #11 body/comments",
+      "repo-local privacy-review.accepted-non-execution.json",
+      "repo-local privacy-scan.review-required.json"
+    ],
+    "finding": "The repository contains a Codex-authored privacy review artifact, but no separate human-authored acceptance wording was found.",
+    "required_human_action": "Provide an explicit human privacy acceptance or redaction decision before treating privacy as accepted for PR #13 evidence closeout."
+  }
 }

--- a/artifacts/v0.3/skillsbench-pilot/v0.3-stage2-input-package-candidate-20260701T010000Z/stage2-real-pilot-input-package-candidate.json
+++ b/artifacts/v0.3/skillsbench-pilot/v0.3-stage2-input-package-candidate-20260701T010000Z/stage2-real-pilot-input-package-candidate.json
@@ -4,7 +4,9 @@
     "does_not_freeze_pilot_plan": true,
     "execution_readiness": false,
     "human_approval_packet_ready": true,
-    "status_semantics": "Validator-passed and privacy-accepted means the PR #13 non-execution package is ready for human review or merge consideration; it does not mean Stage 2 execution is allowed."
+    "status_semantics": "Validator-passed plus repo-local privacy classification does not prove explicit human privacy acceptance; the PR #13 package remains non-execution and blocked on privacy acceptance provenance.",
+    "privacy_acceptance_provenance_required": true,
+    "explicit_human_privacy_acceptance_found": false
   },
   "artifacts": {
     "apt_source_diagnostics_manifest": {
@@ -28,14 +30,14 @@
     "candidate-data/tasks.jsonl": {
       "name": "tasks.jsonl",
       "path": "artifacts/v0.3/skillsbench-pilot/v0.3-stage2-input-package-candidate-20260701T010000Z/candidate-data/tasks.jsonl",
-      "sha256": "1058ee34a45808520da8ae55759c9cd88a7fbf767005cfcfcefde671d7b5814c",
-      "size_bytes": 17473
+      "sha256": "6a144ae356ebe84b0a662da37d8f374540f26f8e4eb0cdde5f463600d32bca21",
+      "size_bytes": 18639
     },
     "controlled-local-snapshot-manifest.json": {
       "name": "controlled-local-snapshot-manifest.json",
       "path": "artifacts/v0.3/skillsbench-pilot/v0.3-stage2-input-package-candidate-20260701T010000Z/controlled-local-snapshot-manifest.json",
-      "sha256": "d9b4ef8d207f3c39e6d4910d48e4c7c4defb4a6ac2cc40b717273b9ab1cec11f",
-      "size_bytes": 14323
+      "sha256": "09be1fc1ad4c6f667157eb2f464f261e418f53844a1b14b4afca133c281439ad",
+      "size_bytes": 16797
     },
     "docker_dependency_prep_manifest": {
       "name": "manifest.json",
@@ -46,8 +48,8 @@
     "human-approval-readiness.json": {
       "name": "human-approval-readiness.json",
       "path": "human-approval-readiness.json",
-      "sha256": "54bebda4faebb66ed826a523ce47055ff8cb3cac441b12ee8058ad4a702cf8bf",
-      "size_bytes": 9957
+      "sha256": "cff1f32f1a15fd9244ef2a1ed72190c84c3f3d606a1c8fdea93f6a98a1ebe673",
+      "size_bytes": 10467
     },
     "human-approval.non-execution-qualification.json": {
       "name": "human-approval.non-execution-qualification.json",
@@ -64,14 +66,14 @@
     "human_approval_readiness": {
       "name": "human-approval-readiness.json",
       "path": "human-approval-readiness.json",
-      "sha256": "54bebda4faebb66ed826a523ce47055ff8cb3cac441b12ee8058ad4a702cf8bf",
-      "size_bytes": 9957
+      "sha256": "cff1f32f1a15fd9244ef2a1ed72190c84c3f3d606a1c8fdea93f6a98a1ebe673",
+      "size_bytes": 10467
     },
     "input-package-validator.blocked.json": {
       "name": "input-package-validator.blocked.json",
       "path": "artifacts/v0.3/skillsbench-pilot/v0.3-stage2-input-package-candidate-20260701T010000Z/input-package-validator.blocked.json",
-      "sha256": "8952ee03a9307dafb5ba702eb674ced13b90d3b08468d4969a04c2b63bf6afc3",
-      "size_bytes": 2726
+      "sha256": "5334911273dae96cfe351c30abc9c9da7a1cc30b48628c6f137cad7a5bf72754",
+      "size_bytes": 3605
     },
     "input-package-validator.passed.json": {
       "name": "input-package-validator.passed.json",
@@ -82,8 +84,8 @@
     "input_package_validator_blocked": {
       "name": "input-package-validator.blocked.json",
       "path": "input-package-validator.blocked.json",
-      "sha256": "23faaa811b4c1f4655b09d9d19ad9362780ad4bfae22c4565ad9556301aeac9c",
-      "size_bytes": 3581
+      "sha256": "5334911273dae96cfe351c30abc9c9da7a1cc30b48628c6f137cad7a5bf72754",
+      "size_bytes": 3605
     },
     "input_package_validator_passed": {
       "name": "input-package-validator.passed.json",
@@ -165,9 +167,9 @@
     },
     "privacy-review.accepted-non-execution.json": {
       "name": "privacy-review.accepted-non-execution.json",
-      "path": "artifacts/v0.3/skillsbench-pilot/v0.3-stage2-input-package-candidate-20260701T010000Z/privacy-review.accepted-non-execution.json",
-      "sha256": "15d95796a1cd106c4b40efec896dc85fcb357de9d32c04fc2ecd4bcc8db21c81",
-      "size_bytes": 7637
+      "path": "privacy-review.accepted-non-execution.json",
+      "sha256": "84e124326f96fd62b594c960e8c7b307b38627eb0e88e30bf37052dd8d79f2f5",
+      "size_bytes": 8611
     },
     "routed_predictions.candidate.json": {
       "name": "routed_predictions.candidate.json",
@@ -190,8 +192,8 @@
     "routed_predictions.strict.manifest.json": {
       "name": "routed_predictions.strict.manifest.json",
       "path": "artifacts/v0.3/skillsbench-pilot/v0.3-stage2-input-package-candidate-20260701T010000Z/routed_predictions.strict.manifest.json",
-      "sha256": "646764bfdb1b17a2fc6b13dc0815d0a6a92a48837bc145867b045672611bbf6c",
-      "size_bytes": 7883
+      "sha256": "084a8ec222756bc5cc0fc6affbab6a419429ff08a7f80d9b33b5442533a96304",
+      "size_bytes": 15449
     },
     "routed_predictions_strict": {
       "name": "routed_predictions.strict.json",
@@ -202,8 +204,8 @@
     "routed_predictions_strict_manifest": {
       "name": "routed_predictions.strict.manifest.json",
       "path": "routed_predictions.strict.manifest.json",
-      "sha256": "646764bfdb1b17a2fc6b13dc0815d0a6a92a48837bc145867b045672611bbf6c",
-      "size_bytes": 7883
+      "sha256": "084a8ec222756bc5cc0fc6affbab6a419429ff08a7f80d9b33b5442533a96304",
+      "size_bytes": 15449
     },
     "router-config.approved-non-execution.json": {
       "name": "router-config.approved-non-execution.json",
@@ -238,7 +240,7 @@
     "validation/manifest.json": {
       "name": "manifest.json",
       "path": "artifacts/v0.3/skillsbench-pilot/v0.3-stage2-input-package-candidate-20260701T010000Z/validation/manifest.json",
-      "sha256": "55d4dc17a49c07fa1d131a31df1a6b91c6c241dc3e19ddff329987d6f74f81ff",
+      "sha256": "c4ef7525b51b5857ba0eda2b1a81b623b56bedc1a5e495c13371c59c45a860ea",
       "size_bytes": 1256
     },
     "validation/validation.json": {
@@ -250,14 +252,20 @@
     "validation_manifest": {
       "name": "manifest.json",
       "path": "validation/manifest.json",
-      "sha256": "6bad62c376bb280245ec0e5c2cf3f700a1099d0f1c9d5bee896413e993e6ee8e",
+      "sha256": "c4ef7525b51b5857ba0eda2b1a81b623b56bedc1a5e495c13371c59c45a860ea",
       "size_bytes": 1256
     },
     "verifier-artifacts-manifest.json": {
       "name": "verifier-artifacts-manifest.json",
       "path": "artifacts/v0.3/skillsbench-pilot/v0.3-stage2-input-package-candidate-20260701T010000Z/verifier-artifacts-manifest.json",
-      "sha256": "7558b2d01ba927b72a6f6e344c17aaa0cc4f2113739552cbfabb69d76a73530a",
-      "size_bytes": 5028
+      "sha256": "5a29f1c653b8f9095a9f9b3cd5d365b6d24ee2ff1e18e788700d4b6c0e49f854",
+      "size_bytes": 5851
+    },
+    "privacy-acceptance-provenance.audit.json": {
+      "name": "privacy-acceptance-provenance.audit.json",
+      "path": "privacy-acceptance-provenance.audit.json",
+      "sha256": "0a79ca797af0e1ec60ba28c1440a5330e10aa3a3e1c21d9cac44cc84d3be5585",
+      "size_bytes": 2665
     }
   },
   "artifacts_note": "The package summary file intentionally does not include a hash record for itself because self-referential JSON hashes are not stable.",
@@ -311,8 +319,8 @@
     "readiness": {
       "name": "human-approval-readiness.json",
       "path": "human-approval-readiness.json",
-      "sha256": "54bebda4faebb66ed826a523ce47055ff8cb3cac441b12ee8058ad4a702cf8bf",
-      "size_bytes": 9957
+      "sha256": "cff1f32f1a15fd9244ef2a1ed72190c84c3f3d606a1c8fdea93f6a98a1ebe673",
+      "size_bytes": 10467
     }
   },
   "input_package_validator": {
@@ -390,8 +398,8 @@
     "decision_artifact": {
       "name": "privacy-review.accepted-non-execution.json",
       "path": "artifacts/v0.3/skillsbench-pilot/v0.3-stage2-input-package-candidate-20260701T010000Z/privacy-review.accepted-non-execution.json",
-      "sha256": "15d95796a1cd106c4b40efec896dc85fcb357de9d32c04fc2ecd4bcc8db21c81",
-      "size_bytes": 7637
+      "sha256": "84e124326f96fd62b594c960e8c7b307b38627eb0e88e30bf37052dd8d79f2f5",
+      "size_bytes": 8611
     },
     "excluded_task_ids": [],
     "finding_context_counts": {
@@ -415,29 +423,44 @@
       "size_bytes": 8818,
       "status": "REVIEW_REQUIRED"
     },
-    "status": "ACCEPTED_NO_REDACTION_REQUIRED_FOR_NON_EXECUTION_PACKAGE"
+    "status": "PRIVACY_ACCEPTANCE_PROVENANCE_MISSING",
+    "repo_local_decision_status": "ACCEPTED_NO_REDACTION_REQUIRED_FOR_NON_EXECUTION_PACKAGE",
+    "explicit_human_privacy_acceptance_found": false,
+    "privacy_acceptance_provenance": {
+      "status": "PRIVACY_ACCEPTANCE_PROVENANCE_MISSING",
+      "artifact": {
+        "name": "privacy-acceptance-provenance.audit.json",
+        "path": "privacy-acceptance-provenance.audit.json",
+        "sha256": "0a79ca797af0e1ec60ba28c1440a5330e10aa3a3e1c21d9cac44cc84d3be5585",
+        "size_bytes": 2665
+      },
+      "required_human_action": "Provide explicit human privacy acceptance or redaction decision before marking privacy accepted."
+    }
   },
   "readiness_decision": {
     "can_be_used_as_real_stage2_input_package_now": false,
     "non_fixture_source": true,
-    "privacy_review_status": "ACCEPTED_NO_REDACTION_REQUIRED_FOR_NON_EXECUTION_PACKAGE",
-    "ready_for_human_approval_now": true,
+    "privacy_review_status": "PRIVACY_ACCEPTANCE_PROVENANCE_MISSING",
+    "ready_for_human_approval_now": false,
     "reasons": [
       "Human approval for non-execution qualification was recorded for the controlled-local-snapshot candidate.",
       "Strict routed predictions were generated with the approved router config and clean code provenance.",
       "Phase C2 oracle/verifier qualification ran under Docker --network none for all four approved tasks.",
       "All four deterministic verifier outputs produced reward.txt=1 and CTRF tests passed.",
       "Phase C3 reran the PR #10 input-package validator and it passed.",
-      "Phase C4 privacy review accepted the 28 scan findings with no redaction required under public-upstream benchmark scope.",
-      "No Stage 2 pilot, Codex run, frozen plan, traces, or evidence-gate rerun occurred."
+      "No Stage 2 pilot, Codex run, frozen plan, traces, or evidence-gate rerun occurred.",
+      "Phase C4 repo-local privacy review artifact exists, but explicit human privacy acceptance provenance is missing."
     ],
     "recommended_review_questions": [
-      "Review PR #13 for non-execution evidence completeness and merge consideration.",
-      "Open a separate bounded phase for Codex real-runner preflight only with explicit later authorization.",
-      "Open frozen pilot planning only with explicit later authorization; do not run Stage 2 from this C4 privacy closeout."
+      "Keep Issue #11 open until explicit human privacy acceptance or redaction decision is recorded.",
+      "If privacy acceptance is supplied later, update only the privacy provenance artifact and rerun hash/boundary checks.",
+      "Review PR #14 independently; do not treat it as replacing PR #13 privacy provenance.",
+      "Do not freeze a pilot plan or run Stage 2 from this corrective evidence update."
     ],
     "validation_no_longer_blocked_by_public_network": true,
-    "validator_passed": true
+    "validator_passed": true,
+    "execution_readiness": false,
+    "explicit_human_privacy_acceptance_found": false
   },
   "routed_prediction_review": {
     "approved_router_config": "artifacts/v0.3/skillsbench-pilot/v0.3-stage2-input-package-candidate-20260701T010000Z/router-config.approved-non-execution.json",
@@ -472,7 +495,7 @@
   },
   "run_id": "v0.3-stage2-input-package-candidate-20260701T010000Z",
   "schema_version": "v0.3.stage2-real-pilot-input-package-candidate.v1",
-  "status": "APPROVED_FOR_NON_EXECUTION_QUALIFICATION_ORACLE_QUALIFIED_VALIDATOR_PASSED_PRIVACY_ACCEPTED_NOT_EXECUTED",
+  "status": "APPROVED_FOR_NON_EXECUTION_QUALIFICATION_ORACLE_QUALIFIED_VALIDATOR_PASSED_PRIVACY_ACCEPTANCE_PROVENANCE_MISSING_NOT_EXECUTED",
   "validation_summary": {
     "artifact": {
       "name": "validation.json",
@@ -491,7 +514,7 @@
     "manifest": {
       "name": "manifest.json",
       "path": "validation/manifest.json",
-      "sha256": "7aa2571a6b46787c122aea6bca5a280450e8a61f36cf93c71f17e597ee369aee",
+      "sha256": "c4ef7525b51b5857ba0eda2b1a81b623b56bedc1a5e495c13371c59c45a860ea",
       "size_bytes": 1256
     },
     "non_fixture_source": true,

--- a/artifacts/v0.3/skillsbench-pilot/v0.3-stage2-input-package-candidate-20260701T010000Z/validation/manifest.json
+++ b/artifacts/v0.3/skillsbench-pilot/v0.3-stage2-input-package-candidate-20260701T010000Z/validation/manifest.json
@@ -17,8 +17,8 @@
     {
       "name": "manifest.json",
       "path": "artifacts/v0.3/skillsbench-pilot/v0.3-stage2-input-package-candidate-20260701T010000Z/candidate-data/manifest.json",
-      "sha256": "da053a7c48c7ccee0b2dc7c6beb949ecacadf9547c33edcfe6f84b390914d496",
-      "size_bytes": 2141
+      "sha256": "d054fa5ed79ba23c1304d821768818328e79170929b3d41cbee4dae31cc49a81",
+      "size_bytes": 2386
     }
   ],
   "generated_at": "2026-07-02T12:04:37.339540Z",

--- a/docs/human-briefs/2026-07-04-pr13-provenance-corrective.html
+++ b/docs/human-briefs/2026-07-04-pr13-provenance-corrective.html
@@ -1,0 +1,61 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8" />
+  <title>PR #13 provenance corrective</title>
+  <style>
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; margin: 32px; line-height: 1.55; color: #17202a; }
+    h1 { font-size: 24px; margin-bottom: 8px; }
+    h2 { font-size: 17px; margin-top: 24px; }
+    code { background: #f2f4f7; padding: 2px 5px; border-radius: 4px; }
+    .status { border-left: 4px solid #b45309; padding: 10px 14px; background: #fff7ed; }
+    .ok { border-left-color: #166534; background: #f0fdf4; }
+    ul { padding-left: 22px; }
+  </style>
+</head>
+<body>
+  <h1>Hermes SkillEval PR #13 Provenance Corrective</h1>
+  <p class="status"><strong>结论：</strong>PR #13 input-package 仍是非执行证据包；privacy findings 的 repo-local 分类保留，但当前阻塞项是 <code>PRIVACY_ACCEPTANCE_PROVENANCE_MISSING</code>，不能把它当作 human privacy acceptance 或 Stage 2 readiness。</p>
+
+  <h2>当前状态</h2>
+  <ul>
+    <li><code>APPROVED_FOR_NON_EXECUTION_QUALIFICATION_ORACLE_QUALIFIED_VALIDATOR_PASSED_PRIVACY_ACCEPTANCE_PROVENANCE_MISSING_NOT_EXECUTED</code></li>
+    <li><code>can_be_used_as_real_stage2_input_package_now=false</code></li>
+    <li><code>execution_readiness=false</code></li>
+    <li><code>explicit_human_privacy_acceptance_found=false</code></li>
+  </ul>
+
+  <h2>本阶段变化</h2>
+  <ul>
+    <li>新增 <code>privacy-acceptance-provenance.audit.json</code>，记录 PR #13 / Issue #11 中未找到明确 human privacy acceptance。</li>
+    <li>更新 <code>privacy-review.accepted-non-execution.json</code>：保留 no-redaction 分类，但标记 acceptance provenance missing。</li>
+    <li>更新 <code>human-approval-readiness.json</code> 与 <code>stage2-real-pilot-input-package-candidate.json</code>，移除隐含 privacy accepted 的 readiness 结论。</li>
+    <li>刷新 candidate summary 中若干 stale embedded SHA-256 引用。</li>
+  </ul>
+
+  <h2>关键证据文件</h2>
+  <ul>
+    <li><code>artifacts/v0.3/skillsbench-pilot/v0.3-stage2-input-package-candidate-20260701T010000Z/privacy-acceptance-provenance.audit.json</code></li>
+    <li><code>artifacts/v0.3/skillsbench-pilot/v0.3-stage2-input-package-candidate-20260701T010000Z/privacy-review.accepted-non-execution.json</code></li>
+    <li><code>artifacts/v0.3/skillsbench-pilot/v0.3-stage2-input-package-candidate-20260701T010000Z/human-approval-readiness.json</code></li>
+    <li><code>artifacts/v0.3/skillsbench-pilot/v0.3-stage2-input-package-candidate-20260701T010000Z/stage2-real-pilot-input-package-candidate.json</code></li>
+  </ul>
+
+  <h2>验证结果</h2>
+  <ul>
+    <li><code>jq empty</code> for changed JSON artifacts: PASS.</li>
+    <li>Recursive embedded SHA-256/size reference check for <code>stage2-real-pilot-input-package-candidate.json</code>: PASS, 55/55 refs checked.</li>
+    <li>Readiness/provenance guard and prohibited true-flag scan: PASS.</li>
+    <li><code>PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=src pytest -q</code>: PASS, original validation result 664 passed.</li>
+    <li><code>OPENSPEC_TELEMETRY=0 openspec validate --all --strict</code>: PASS, 23 passed.</li>
+    <li><code>PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=src python -m hermes_skilleval.cli release-check</code>: PASS.</li>
+    <li><code>git diff --check</code>: PASS.</li>
+  </ul>
+
+  <h2>剩余风险</h2>
+  <p class="status">Issue #11 应保持 open，直到有人明确给出 privacy acceptance 或 redaction decision。PR #14 可独立 review，但不能替代 PR #13 的 privacy provenance。</p>
+
+  <h2>禁止过度声明</h2>
+  <p class="status ok">本阶段没有 Stage 2 run、Codex run、pilot plan freeze、traces、evidence-gate rerun、qualification rerun、validator rerun或 performance claim。</p>
+</body>
+</html>

--- a/docs/human-briefs/2026-07-04-stage2-input-package-privacy-review.html
+++ b/docs/human-briefs/2026-07-04-stage2-input-package-privacy-review.html
@@ -15,20 +15,22 @@
 </head>
 <body>
   <h1>Hermes SkillEval PR #13 Phase C4</h1>
-  <p class="status"><strong>结论：</strong>PR #13 的非执行 input-package privacy review 已接受：28 个 scan findings 均不需要 redaction；但 <code>execution_readiness=false</code>，仍不能当作真实 Stage 2 input package 直接运行。</p>
+  <p class="status warn"><strong>Erratum：</strong>后续 provenance audit 未在 PR #13 或 Issue #11 中找到明确 human privacy acceptance。28 个 scan findings 的 repo-local no-redaction 分类保留为历史证据，但当前 privacy 状态应视为 <code>PRIVACY_ACCEPTANCE_PROVENANCE_MISSING</code>，不能当作 human privacy acceptance 或真实 Stage 2 readiness。</p>
 
   <h2>当前状态</h2>
   <ul>
-    <li><code>APPROVED_FOR_NON_EXECUTION_QUALIFICATION_ORACLE_QUALIFIED_VALIDATOR_PASSED_PRIVACY_ACCEPTED_NOT_EXECUTED</code></li>
+    <li><code>APPROVED_FOR_NON_EXECUTION_QUALIFICATION_ORACLE_QUALIFIED_VALIDATOR_PASSED_PRIVACY_ACCEPTANCE_PROVENANCE_MISSING_NOT_EXECUTED</code></li>
     <li><code>can_be_used_as_real_stage2_input_package_now=false</code></li>
-    <li><code>ACCEPTED_NO_REDACTION_REQUIRED_FOR_NON_EXECUTION_PACKAGE</code></li>
+    <li><code>execution_readiness=false</code></li>
+    <li><code>explicit_human_privacy_acceptance_found=false</code></li>
+    <li>本 brief 已被 <code>2026-07-04-pr13-provenance-corrective.html</code> 作为当前 truth surface 修正。</li>
   </ul>
 
   <h2>本阶段变化</h2>
   <ul>
     <li>新增 <code>privacy-review.accepted-non-execution.json</code>，记录 scan hash、28 项分类结论、binary review 与 remaining execution blockers。</li>
-    <li>更新 <code>human-approval-readiness.json</code>：privacy review 不再阻塞 human approval；PR #13 可进入非执行证据 review/merge consideration。</li>
-    <li>更新 <code>stage2-real-pilot-input-package-candidate.json</code>：privacy status 改为 accepted，并保留所有 non-execution 边界。</li>
+    <li>后续 corrective phase 新增 <code>privacy-acceptance-provenance.audit.json</code>，明确没有找到 human-authored privacy acceptance。</li>
+    <li>后续 corrective phase 已更新 <code>human-approval-readiness.json</code> 与 <code>stage2-real-pilot-input-package-candidate.json</code>，不再把 repo-local 分类等同于 privacy accepted。</li>
   </ul>
 
   <h2>Finding 分类</h2>
@@ -57,9 +59,9 @@
   </ul>
 
   <h2>剩余风险</h2>
-  <p class="status warn">Privacy accepted 只移除 PR #13 非执行 review 的 privacy blocker；它不等于 runner preflight、pilot planning 或 Stage 2 执行授权。</p>
+  <p class="status warn">当前 blocker 是 <code>PRIVACY_ACCEPTANCE_PROVENANCE_MISSING</code>。Privacy no-redaction 分类不等于 human acceptance，也不等于 runner preflight、pilot planning 或 Stage 2 执行授权。</p>
 
   <h2>建议下一步</h2>
-  <p>进行 PR #13 human review/merge consideration。若要做 Codex real-runner preflight 或 frozen pilot planning，需要另开明确授权的小阶段。</p>
+  <p>保持 Issue #11 open，直到有人明确给出 privacy acceptance 或 redaction decision。PR #14 可独立 review，但不能替代 PR #13 privacy provenance。</p>
 </body>
 </html>


### PR DESCRIPTION
## Summary

This is a small corrective PR for PR #13 provenance. It records that explicit human privacy acceptance was not found in PR #13 / Issue #11, while preserving the repo-local no-redaction classification as classification evidence only.

Changes:
- Add `privacy-acceptance-provenance.audit.json` with `PRIVACY_ACCEPTANCE_PROVENANCE_MISSING`.
- Update the Stage 2 candidate summary, privacy review artifact, and human approval readiness artifact so the package remains non-execution and privacy-provenance-blocked.
- Keep `can_be_used_as_real_stage2_input_package_now=false`, `execution_readiness=false`, `ready_for_human_approval_now=false`, and `explicit_human_privacy_acceptance_found=false` where applicable.
- Fix the stale `candidate-data/manifest.json` entry in `validation/manifest.json` and refresh embedded SHA-256/size references.
- Add a concise Chinese Human Brief and amend the previous privacy-review brief with an erratum.

Related: #11 remains open until explicit human privacy acceptance or redaction decision is recorded.

## Non-actions / boundaries

This PR does not run Stage 2, Codex real runner, freeze a pilot plan, create traces, rerun the evidence gate, rerun qualification/validator, or make performance claims.

## Validation

- `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=src pytest -q` -> 664 passed
- `OPENSPEC_TELEMETRY=0 openspec validate --all --strict` -> 23 passed, 0 failed
- `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=src python -m hermes_skilleval.cli release-check` -> PASS
- JSON parse checks for changed artifacts -> PASS
- Recursive embedded SHA-256/size reference check over `stage2-real-pilot-input-package-candidate.json` -> 55/55 refs checked, PASS
- Readiness/provenance guard and prohibited true-flag scan -> PASS
- `git diff --check` -> PASS

## Reviewer

Codex Reviewer subagent verdict: Pass; Must Fix: none; Should Fix: none; Re-plan Needed: No.
