### PR TITLE
ops: fix Stage 2 real-run workspace isolation

### DIFF
--- a/docs/human-briefs/2026-07-07-stage2-real-codex-isolated-workspace-resolution.html
+++ b/docs/human-briefs/2026-07-07-stage2-real-codex-isolated-workspace-resolution.html
@@ -1,0 +1,47 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Stage 2 real Codex isolated workspace resolution</title>
+  <style>
+    body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; margin: 32px; line-height: 1.55; color: #1f2937; background: #f8fafc; }
+    main { max-width: 960px; margin: 0 auto; background: #fff; border: 1px solid #e5e7eb; border-radius: 8px; padding: 28px; }
+    h1 { font-size: 24px; margin: 0 0 12px; }
+    h2 { font-size: 16px; margin-top: 24px; border-top: 1px solid #e5e7eb; padding-top: 16px; }
+    code { background: #f3f4f6; padding: 1px 4px; border-radius: 4px; }
+    ul { padding-left: 20px; }
+    .status { background: #f9fafb; border-left: 4px solid #64748b; padding: 12px 14px; }
+  </style>
+</head>
+<body>
+<main>
+  <h1>Stage 2 real Codex isolated workspace resolution</h1>
+  <p class="status"><strong>结论：</strong>本阶段只修复真实 live-agent matrix 的 workspace isolation wiring：real evidence mode 默认使用外部 runtime workspace root，并在显式 workspace root 的父目录链出现 <code>.agents/skills</code> 时 fail-closed。</p>
+
+  <h2>当前状态</h2>
+  <ul>
+    <li>PR #23 记录了 <code>BLOCKED_WORKSPACE_PARENT_SKILL_LEAKAGE_BEFORE_CODEX_EXEC</code> blocker。</li>
+    <li>本阶段不重新执行 Stage 2，不运行 4x3x1 matrix，不调用真实 Codex 12 runs。</li>
+    <li>冻结计划、任务、prompt、verifier、router、scorer 和 evidence-gate semantics 未修改。</li>
+  </ul>
+
+  <h2>本阶段改动</h2>
+  <ul>
+    <li><code>run_skillsbench_matrix(..., evidence_mode="real")</code> 在没有显式 <code>workspace_root</code> 时，默认使用 <code>HERMES_SKILLEVAL_REAL_WORKSPACE_ROOT</code> 或系统临时目录下的外部 workspace root。</li>
+    <li>显式 <code>workspace_root</code> 会先扫描自身和父目录链；如果发现可见 <code>.agents/skills</code>，会在 runner 前 fail-closed。</li>
+    <li><code>preflight</code> event 现在会被 <code>execute_live_agent</code> 保留，供 real runner preflight validator 检查。</li>
+  </ul>
+
+  <h2>验证重点</h2>
+  <ul>
+    <li>新增测试覆盖默认 external runtime workspace root。</li>
+    <li>新增测试覆盖 unsafe parent-chain skill leakage fail-closed。</li>
+    <li>验证仍要求 verifier output 是 task success 的唯一来源；process exit code 和 LLM judge 不作为成功来源。</li>
+  </ul>
+
+  <h2>建议下一步</h2>
+  <p>Review 并合并本小 PR 后，再单独请求继续 Stage 2 real Codex 12-run execution；届时应先确认 workspace root 在外部 runtime 目录，且父目录链没有用户级 skill leakage。</p>
+</main>
+</body>
+</html>

--- a/src/hermes_skilleval/live_agent_runtime.py
+++ b/src/hermes_skilleval/live_agent_runtime.py
@@ -821,6 +821,8 @@ def _parse_events(
             message = _redact(str(raw.get("message", "")))
             final_message = message
             events.append({"type": "final", "message": message})
+        elif event_type == "preflight":
+            events.append({"type": "preflight", **_redact_value(raw)})
         else:
             skill_id = raw.get("skill_id")
             if isinstance(skill_id, str) and skill_id.strip():

--- a/src/hermes_skilleval/live_agent_skillsbench.py
+++ b/src/hermes_skilleval/live_agent_skillsbench.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 import json
 import hashlib
+import os
 import re
 import subprocess
+import tempfile
 from copy import deepcopy
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -20,6 +22,7 @@ from hermes_skilleval.live_agent_runtime import (
     FakeVerifier,
     LiveAgentSkill,
     _redact_value,
+    _visible_child_count,
     build_condition,
     execute_live_agent,
     prepare_live_agent_workspace,
@@ -44,6 +47,7 @@ CONDITIONS = ("no-skill", "routed-skill", "oracle-skill")
 CONTROLLED_NETWORKS = {"none", "controlled"}
 DEFAULT_ROUTER_TOP_K = 3
 EVIDENCE_MODES = {"fixture", "real"}
+REAL_WORKSPACE_ROOT_ENV = "HERMES_SKILLEVAL_REAL_WORKSPACE_ROOT"
 COMMIT_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
 SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
 LABEL_LEAKAGE_TOKENS = ("oracle", "gold", "source-task", "source_task")
@@ -1138,7 +1142,11 @@ def run_skillsbench_matrix(
         )
         for skill_id, record in plan["global_skill_registry"].items()
     }
-    workspace_root = Path(plan.get("workspace_root") or output.parent / "workspaces")
+    workspace_root = _matrix_workspace_root(
+        plan=plan,
+        output=output,
+        evidence_mode=evidence_mode,
+    )
     trace_root = output.parent / "traces"
     trace_root.mkdir(parents=True, exist_ok=True)
     runs = []
@@ -1221,6 +1229,7 @@ def run_skillsbench_matrix(
         "mode": plan["mode"],
         "evidence_mode": evidence_mode,
         "plan_path": str(plan_file),
+        "workspace_root": str(workspace_root),
         "skill_inventory": plan["global_skill_registry"],
         "leakage_scan": plan.get("leakage_scan"),
         "runs": runs,
@@ -1237,6 +1246,43 @@ def run_skillsbench_matrix(
     output.parent.mkdir(parents=True, exist_ok=True)
     output.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     return report
+
+
+def _matrix_workspace_root(
+    *,
+    plan: dict[str, Any],
+    output: Path,
+    evidence_mode: str,
+) -> Path:
+    configured = plan.get("workspace_root")
+    if evidence_mode != "real":
+        return Path(configured or output.parent / "workspaces")
+
+    if configured:
+        root = Path(configured)
+    else:
+        runtime_root = Path(
+            os.environ.get(REAL_WORKSPACE_ROOT_ENV, tempfile.gettempdir())
+        )
+        output_digest = _sha256_text(str(output.resolve()))[:16]
+        root = (
+            runtime_root
+            / "hermes-skilleval-live-agent-workspaces"
+            / f"{_safe_run_id(str(plan['run_id']))}-{output_digest}"
+        )
+    _validate_workspace_parent_skill_free(root)
+    return root
+
+
+def _validate_workspace_parent_skill_free(root: Path) -> None:
+    resolved = root.resolve(strict=False)
+    for parent in (resolved, *resolved.parents):
+        skill_dir = parent / ".agents" / "skills"
+        if _visible_child_count(skill_dir):
+            raise ValueError(
+                "real evidence workspace parent skill leakage detected: "
+                f"{skill_dir}"
+            )
 
 
 def _derive_plan_fields(

--- a/tests/test_skillsbench_live_matrix.py
+++ b/tests/test_skillsbench_live_matrix.py
@@ -1006,6 +1006,57 @@ def test_real_evidence_mode_requires_no_skill_preflight(tmp_path):
         )
 
 
+def test_real_evidence_mode_defaults_workspace_root_outside_output_tree(
+    tmp_path, monkeypatch
+):
+    plan_path, matrix_path = _write_real_like_pilot_plan(tmp_path)
+    _mutate_plan(plan_path, lambda plan: plan.__setitem__("workspace_root", None))
+    runtime_root = tmp_path / "external-runtime"
+    monkeypatch.setenv(
+        "HERMES_SKILLEVAL_REAL_WORKSPACE_ROOT",
+        str(runtime_root),
+    )
+    runner = _RecordingRunner()
+
+    report = run_skillsbench_matrix(
+        plan_path=plan_path,
+        output_path=matrix_path,
+        runner=runner,
+        verifier=_PassingDeterministicVerifier(),
+        evidence_mode="real",
+    )
+
+    assert report["workspace_root"].startswith(str(runtime_root))
+    assert all(
+        request.workspace_path.is_relative_to(runtime_root)
+        for request in runner.requests
+    )
+    assert not (matrix_path.parent / "workspaces").exists()
+
+
+def test_real_evidence_mode_rejects_workspace_parent_skill_leakage(tmp_path):
+    plan_path, matrix_path = _write_real_like_pilot_plan(tmp_path)
+    unsafe_parent = tmp_path / "unsafe-parent"
+    leaked_skill = unsafe_parent / ".agents" / "skills" / "leaked-skill"
+    leaked_skill.mkdir(parents=True)
+    _mutate_plan(
+        plan_path,
+        lambda plan: plan.__setitem__(
+            "workspace_root",
+            str(unsafe_parent / "workspaces"),
+        ),
+    )
+
+    with pytest.raises(ValueError, match="workspace parent skill leakage"):
+        run_skillsbench_matrix(
+            plan_path=plan_path,
+            output_path=matrix_path,
+            runner=_RecordingRunner(),
+            verifier=_PassingDeterministicVerifier(),
+            evidence_mode="real",
+        )
+
+
 @pytest.mark.parametrize(
     "events",
     [


### PR DESCRIPTION
## Summary
- Fixes real evidence live-agent workspace placement so default real-run workspaces are outside the evidence output tree.
- Adds a fail-closed parent-chain `.agents/skills` leakage guard for explicitly configured real-run workspace roots.
- Preserves runner `preflight` events through `execute_live_agent` so real runner preflight validation can inspect the final-evidence isolated CODEX_HOME proof.
- Adds a concise Chinese Human Brief for review.

## Boundary
- This PR does not run Stage 2.
- This PR does not run the 4x3x1 matrix.
- This PR does not run real Codex 12 runs.
- This PR creates no task traces.
- This PR does not rerun the evidence gate.
- This PR does not rerun oracle qualification.
- This PR does not rewrite verifier/oracle evidence.
- This PR does not change routed predictions.
- This PR does not modify task manifests or public prompts.
- This PR does not modify scorer, matrix, router, or evidence-gate semantics.
- This PR makes no performance claim and no router promotion.

## Why
PR #23 recorded a fail-closed blocker before Codex exec: workspace parent chain exposed `/Users/raidriar/.agents/skills/hivemind-memory`. This patch makes the real evidence default avoid that parent-chain class and rejects explicitly unsafe roots before runner invocation.

## Validation
- `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=src python -m pytest -q tests/test_skillsbench_live_matrix.py tests/test_live_agent_runtime.py tests/test_codex_cli_runner.py` -> 140 passed
- `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=src python -m pytest -q` -> 666 passed
- `OPENSPEC_TELEMETRY=0 openspec validate --all --strict` -> 25 passed
- `PYTHONPATH=src python -m hermes_skilleval.cli release-check` -> PASS
- `git diff --check` -> PASS

## Recommended Next Step
After review/merge, request a separate explicit Stage 2 real Codex 12-run execution attempt. That attempt should use the external real workspace root and verify parent-chain skill isolation before invoking Codex.