### PR TITLE
ops: adapt evidence gate for Stage 2 real Codex artifacts

### DIFF
--- a/artifacts/v0.3/skillsbench-pilot/v0.3-stage2-real-codex-evidence-gate-adapter-20260708T032000Z/evidence-gate.stage2-adapter.json
+++ b/artifacts/v0.3/skillsbench-pilot/v0.3-stage2-real-codex-evidence-gate-adapter-20260708T032000Z/evidence-gate.stage2-adapter.json
@@ -1,0 +1,262 @@
+{
+  "artifact_type": "v0.3-evidence-validity-release-gate",
+  "benchmark_validity_gate": {
+    "checks": [
+      {
+        "details": {},
+        "id": "external.available",
+        "severity": "review",
+        "status": "UNAVAILABLE",
+        "summary": "external routing evidence was not provided"
+      },
+      {
+        "details": {
+          "path": "artifacts/v0.3/skillsbench-pilot/v0.3-stage2-pilot-freeze-20260707T025315Z/stage2-pilot-plan.frozen.json"
+        },
+        "id": "live_agent.plan_load",
+        "severity": "info",
+        "status": "PASS",
+        "summary": "JSON artifact loaded"
+      },
+      {
+        "details": {
+          "path": "artifacts/v0.3/skillsbench-pilot/v0.3-stage2-real-codex-12-run-execution-20260707T072652Z/stage2-real-codex-12-run-execution.json"
+        },
+        "id": "live_agent.report_load",
+        "severity": "info",
+        "status": "PASS",
+        "summary": "JSON artifact loaded"
+      },
+      {
+        "details": {
+          "failures": []
+        },
+        "id": "live_agent.stage2_schema_adapter",
+        "severity": "blocking",
+        "status": "PASS",
+        "summary": "Stage 2 real Codex execution schema was adapted for live-agent evidence checks"
+      },
+      {
+        "details": {
+          "duplicate_actual_run_ids": [],
+          "duplicate_expected_run_ids": [],
+          "extra_run_ids": [],
+          "mismatches": [],
+          "missing_run_ids": []
+        },
+        "id": "live_agent.matrix_completeness",
+        "severity": "blocking",
+        "status": "PASS",
+        "summary": "live-agent report contains exactly the frozen matrix runs"
+      },
+      {
+        "details": {
+          "task_ids": []
+        },
+        "id": "live_agent.prompt_hash_equality",
+        "severity": "blocking",
+        "status": "PASS",
+        "summary": "all conditions use the same prompt hash per task"
+      },
+      {
+        "details": {
+          "failures": []
+        },
+        "id": "live_agent.oracle_qualification",
+        "severity": "blocking",
+        "status": "PASS",
+        "summary": "oracle qualification passed for every selected live task"
+      },
+      {
+        "details": {
+          "failures": []
+        },
+        "id": "live_agent.verifier_evidence",
+        "severity": "blocking",
+        "status": "PASS",
+        "summary": "deterministic verifier records are complete and source task success"
+      },
+      {
+        "details": {
+          "failures": []
+        },
+        "id": "live_agent.no_skill_leakage",
+        "severity": "blocking",
+        "status": "PASS",
+        "summary": "no-skill condition mounted no benchmark skills"
+      },
+      {
+        "details": {
+          "failures": [],
+          "inventory_count": 12,
+          "reviews": []
+        },
+        "id": "live_agent.global_capability_inventory",
+        "severity": "info",
+        "status": "PASS",
+        "summary": "global capability inventory has no detected user/admin/repo leakage"
+      },
+      {
+        "details": {
+          "failures": []
+        },
+        "id": "live_agent.trace_completeness",
+        "severity": "blocking",
+        "status": "PASS",
+        "summary": "all live-agent runs have complete trace files"
+      },
+      {
+        "details": {
+          "decision": "UNAVAILABLE",
+          "independent_generalization_claim": false
+        },
+        "id": "live_agent.overlap_status",
+        "severity": "review",
+        "status": "REVIEW",
+        "summary": "overlap report requires caveated generalization claims"
+      },
+      {
+        "details": {
+          "leaks": []
+        },
+        "id": "live_agent.secret_redaction",
+        "severity": "blocking",
+        "status": "PASS",
+        "summary": "live-agent report and traces do not contain obvious secret tokens"
+      },
+      {
+        "details": {
+          "errors": []
+        },
+        "id": "live_agent.timeout_process_errors",
+        "severity": "info",
+        "status": "PASS",
+        "summary": "no live-agent timeout or process errors were reported"
+      },
+      {
+        "details": {
+          "regressions": []
+        },
+        "id": "live_agent.per_task_regressions",
+        "severity": "info",
+        "status": "PASS",
+        "summary": "no routed-skill per-task regressions versus no-skill were reported"
+      }
+    ],
+    "status": "REVIEW_REQUIRED"
+  },
+  "claim_boundaries": {
+    "benchmark_validity_gate_statuses": [
+      "VALID_EVIDENCE",
+      "INVALID_EVIDENCE",
+      "REVIEW_REQUIRED"
+    ],
+    "default_router_promotion_decision": "KEEP_BASELINE",
+    "deterministic_verifier_is_live_agent_success_source": true,
+    "no_new_model_runs": true,
+    "no_training_or_threshold_tuning": true,
+    "promotion_requires_valid_evidence": true,
+    "unavailable_is_field_level_only": true
+  },
+  "external_routing": {
+    "reason": "external routing plan/report paths were not provided",
+    "status": "UNAVAILABLE"
+  },
+  "field_markers": {
+    "external_routing": {
+      "reason": "external routing plan/report paths were not provided",
+      "status": "UNAVAILABLE"
+    },
+    "live_agent": {
+      "status": "PRESENT"
+    }
+  },
+  "generated_at": "2026-07-08T03:24:30.153727Z",
+  "inputs": {
+    "live_plan": {
+      "exists": true,
+      "path": "artifacts/v0.3/skillsbench-pilot/v0.3-stage2-pilot-freeze-20260707T025315Z/stage2-pilot-plan.frozen.json",
+      "sha256": "aaa0f4c4d1939cff9bcba08ce6549284726353ed199d7bedd31614be970f579b",
+      "size_bytes": 20829
+    },
+    "live_report": {
+      "exists": true,
+      "path": "artifacts/v0.3/skillsbench-pilot/v0.3-stage2-real-codex-12-run-execution-20260707T072652Z/stage2-real-codex-12-run-execution.json",
+      "sha256": "70adb8e1e7dd953fcd1efdf541a0174dfae559e8b4efaa194f1641a8f8f6a243",
+      "size_bytes": 120528
+    }
+  },
+  "live_agent": {
+    "condition_summary": {
+      "no-skill": {
+        "process_error_count": 0,
+        "run_count": 4,
+        "task_success_count": 2,
+        "timeout_count": 0,
+        "verifier_pass_count": 2
+      },
+      "oracle-skill": {
+        "process_error_count": 0,
+        "run_count": 4,
+        "task_success_count": 2,
+        "timeout_count": 0,
+        "verifier_pass_count": 2
+      },
+      "routed-skill": {
+        "process_error_count": 0,
+        "run_count": 4,
+        "task_success_count": 2,
+        "timeout_count": 0,
+        "verifier_pass_count": 2
+      }
+    },
+    "mode": "stage2-real-codex",
+    "negative_hit_rate": {
+      "reason": "explicit negative labels are not present for SkillsBench",
+      "status": "UNAVAILABLE"
+    },
+    "oracle_gap": {
+      "routed_minus_oracle_success_delta": 0.0
+    },
+    "overlap_report": {
+      "decision": "UNAVAILABLE",
+      "independent_generalization_claim": false
+    },
+    "per_task_regressions": [],
+    "routed_vs_no_skill_delta": {
+      "task_success_delta": 0.0
+    },
+    "run_id": "20260707T072652Z",
+    "skill_use_evidence": {
+      "DECLARED": 0,
+      "MOUNTED": 0,
+      "MOUNTED_ONLY": 13,
+      "READ": 0,
+      "UNKNOWN": 0
+    },
+    "stage2_schema_adapter": {
+      "source_plan_schema": "v0.3.stage2-pilot-plan-freeze.v1",
+      "source_report_schema": "v0.3.stage2-real-codex-12-run-execution.v1",
+      "status": "PASS"
+    },
+    "status": "PRESENT",
+    "timeout_process_errors": []
+  },
+  "router_promotion_gate": {
+    "baseline_router": {
+      "reason": "no preregistered promotion artifact was provided",
+      "status": "UNAVAILABLE"
+    },
+    "blocked_by_validity": false,
+    "candidate_router": {
+      "reason": "no preregistered promotion artifact was provided",
+      "status": "UNAVAILABLE"
+    },
+    "decision": "KEEP_BASELINE",
+    "evaluated_router_configs": [],
+    "reasons": [
+      "benchmark evidence requires review; promotion defaults to baseline"
+    ]
+  },
+  "schema_version": "v0.3.evidence-decision-report.v1"
+}

--- a/artifacts/v0.3/skillsbench-pilot/v0.3-stage2-real-codex-evidence-gate-adapter-20260708T032000Z/evidence-gate.stage2-adapter.md
+++ b/artifacts/v0.3/skillsbench-pilot/v0.3-stage2-real-codex-evidence-gate-adapter-20260708T032000Z/evidence-gate.stage2-adapter.md
@@ -1,0 +1,28 @@
+# Hermes SkillEval v0.3 Evidence Gate
+
+- Benchmark Validity Gate: REVIEW_REQUIRED
+- Router Promotion Gate: KEEP_BASELINE
+- Invalid evidence blocks promotion: False
+- Blocking failures: 0
+- Review or unavailable fields: 2
+
+## Field Markers
+- external_routing: UNAVAILABLE - external routing plan/report paths were not provided
+- live_agent: PRESENT
+
+## Checks
+- UNAVAILABLE external.available: external routing evidence was not provided
+- PASS live_agent.plan_load: JSON artifact loaded
+- PASS live_agent.report_load: JSON artifact loaded
+- PASS live_agent.stage2_schema_adapter: Stage 2 real Codex execution schema was adapted for live-agent evidence checks
+- PASS live_agent.matrix_completeness: live-agent report contains exactly the frozen matrix runs
+- PASS live_agent.prompt_hash_equality: all conditions use the same prompt hash per task
+- PASS live_agent.oracle_qualification: oracle qualification passed for every selected live task
+- PASS live_agent.verifier_evidence: deterministic verifier records are complete and source task success
+- PASS live_agent.no_skill_leakage: no-skill condition mounted no benchmark skills
+- PASS live_agent.global_capability_inventory: global capability inventory has no detected user/admin/repo leakage
+- PASS live_agent.trace_completeness: all live-agent runs have complete trace files
+- REVIEW live_agent.overlap_status: overlap report requires caveated generalization claims
+- PASS live_agent.secret_redaction: live-agent report and traces do not contain obvious secret tokens
+- PASS live_agent.timeout_process_errors: no live-agent timeout or process errors were reported
+- PASS live_agent.per_task_regressions: no routed-skill per-task regressions versus no-skill were reported

--- a/artifacts/v0.3/skillsbench-pilot/v0.3-stage2-real-codex-evidence-gate-adapter-20260708T032000Z/stage2-real-codex-evidence-gate-adapter.json
+++ b/artifacts/v0.3/skillsbench-pilot/v0.3-stage2-real-codex-evidence-gate-adapter-20260708T032000Z/stage2-real-codex-evidence-gate-adapter.json
@@ -1,0 +1,63 @@
+{
+  "artifact_type": "stage2-real-codex-evidence-gate-adapter-contract",
+  "base": {
+    "branch": "codex/v0.3-pr0-protocol",
+    "head_sha": "ce6210707759cf600788c669ed50c11693b34648",
+    "source_execution_pr": "https://github.com/Raidriar7170/hermes-skilleval/pull/25",
+    "source_fail_closed_gate_review_pr": "https://github.com/Raidriar7170/hermes-skilleval/pull/26"
+  },
+  "boundaries": {
+    "codex_rerun": false,
+    "evidence_gate_rerun": true,
+    "llm_judge_used": false,
+    "performance_claim_made": false,
+    "router_promoted": false,
+    "stage2_rerun": false,
+    "task_traces_created": false
+  },
+  "created_at_utc": "2026-07-08T03:20:00Z",
+  "evidence_gate": {
+    "benchmark_validity_gate_status": "REVIEW_REQUIRED",
+    "blocking_failure_count": 0,
+    "markdown_output": {
+      "path": "artifacts/v0.3/skillsbench-pilot/v0.3-stage2-real-codex-evidence-gate-adapter-20260708T032000Z/evidence-gate.stage2-adapter.md",
+      "sha256": "cc5298fc290e1d9637e196a3195d822bb83b221ccf3c883da4f86b6249a5d6ab"
+    },
+    "output": {
+      "path": "artifacts/v0.3/skillsbench-pilot/v0.3-stage2-real-codex-evidence-gate-adapter-20260708T032000Z/evidence-gate.stage2-adapter.json",
+      "sha256": "0e77ab02397c37e55dbb6a9f505ac5f733049f00ca8906d2c20bdb5609afd929"
+    },
+    "review_or_unavailable_field_count": 2,
+    "router_promotion_gate_decision": "KEEP_BASELINE",
+    "router_promotion_is_blocked_by_validity": false
+  },
+  "inputs": {
+    "stage2_execution_artifact": {
+      "path": "artifacts/v0.3/skillsbench-pilot/v0.3-stage2-real-codex-12-run-execution-20260707T072652Z/stage2-real-codex-12-run-execution.json",
+      "sha256": "70adb8e1e7dd953fcd1efdf541a0174dfae559e8b4efaa194f1641a8f8f6a243"
+    },
+    "stage2_frozen_plan": {
+      "path": "artifacts/v0.3/skillsbench-pilot/v0.3-stage2-pilot-freeze-20260707T025315Z/stage2-pilot-plan.frozen.json",
+      "sha256": "aaa0f4c4d1939cff9bcba08ce6549284726353ed199d7bedd31614be970f579b"
+    }
+  },
+  "review_findings": [
+    {
+      "code": "STAGE2_SCHEMA_ADAPTER_LIVE_AGENT_CHECKS_PASS",
+      "severity": "info",
+      "summary": "The Stage 2 frozen plan and full real Codex execution artifact can now be consumed by the existing live-agent evidence checks."
+    },
+    {
+      "code": "REVIEW_REQUIRED_EXTERNAL_AND_OVERLAP_CAVEATS",
+      "severity": "review",
+      "summary": "The resulting evidence gate remains REVIEW_REQUIRED because no external routing packet was supplied in this adapter smoke and overlap/generalization status is unavailable."
+    },
+    {
+      "code": "ROUTER_PROMOTION_NOT_MADE",
+      "severity": "info",
+      "summary": "The router promotion gate remains KEEP_BASELINE."
+    }
+  ],
+  "schema_version": "v0.3.stage2-real-codex-evidence-gate-adapter-contract.v1",
+  "status": "REVIEW_REQUIRED_KEEP_BASELINE_STAGE2_SCHEMA_ADAPTED"
+}

--- a/docs/human-briefs/2026-07-08-stage2-real-codex-evidence-gate-adapter.html
+++ b/docs/human-briefs/2026-07-08-stage2-real-codex-evidence-gate-adapter.html
@@ -1,0 +1,58 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8">
+  <title>Stage 2 Real Codex Evidence Gate Adapter</title>
+  <style>
+    body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; margin: 32px; color: #1f2933; line-height: 1.55; }
+    main { max-width: 920px; margin: 0 auto; }
+    h1 { font-size: 28px; margin-bottom: 8px; }
+    h2 { font-size: 18px; margin-top: 28px; border-bottom: 1px solid #d8dee4; padding-bottom: 6px; }
+    code { background: #f4f6f8; padding: 2px 5px; border-radius: 4px; }
+    .status { border-left: 4px solid #8250df; background: #f6f2ff; padding: 12px 16px; margin: 18px 0; }
+    .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap: 12px; }
+    .card { border: 1px solid #d8dee4; border-radius: 8px; padding: 12px 14px; background: #fff; }
+    ul { padding-left: 22px; }
+  </style>
+</head>
+<body>
+<main>
+  <h1>Stage 2 Real Codex Evidence Gate Adapter</h1>
+  <p class="status"><strong>结论：</strong>现有 evidence gate 已能消费 Stage 2 real Codex frozen plan + full execution artifact；结果为 <code>REVIEW_REQUIRED</code>，router promotion 仍保持 <code>KEEP_BASELINE</code>。</p>
+
+  <h2>当前状态</h2>
+  <div class="grid">
+    <div class="card"><strong>Base</strong><br><code>ce6210707759cf600788c669ed50c11693b34648</code></div>
+    <div class="card"><strong>Gate status</strong><br><code>REVIEW_REQUIRED</code></div>
+    <div class="card"><strong>Promotion decision</strong><br><code>KEEP_BASELINE</code></div>
+    <div class="card"><strong>Blocking failures</strong><br><code>0</code></div>
+  </div>
+
+  <h2>本阶段做了什么</h2>
+  <ul>
+    <li>为 <code>v0.3-evidence-gate</code> 添加 Stage 2 real Codex schema adapter。</li>
+    <li>复用既有 live-agent checks：matrix completeness、prompt hash、oracle qualification、verifier evidence、no-skill leakage、capability inventory、trace completeness、secret redaction。</li>
+    <li>新增测试覆盖真实 PR #25 frozen plan 和 full execution artifact。</li>
+    <li>没有重新运行 Codex，没有重新运行 Stage 2，没有新增 task traces。</li>
+  </ul>
+
+  <h2>Gate 输出</h2>
+  <ul>
+    <li><code>evidence-gate.stage2-adapter.json</code>: <code>REVIEW_REQUIRED</code></li>
+    <li>live-agent / Stage 2 相关检查全部 PASS。</li>
+    <li>剩余 review 项为 external routing evidence 未提供，以及 overlap/generalization caveat。</li>
+  </ul>
+
+  <h2>不要夸大的结论</h2>
+  <ul>
+    <li>这不是 performance result。</li>
+    <li>这不是 router promotion。</li>
+    <li>这不是 evidence gate 的全量 VALID_EVIDENCE。</li>
+    <li>PR #25 的 6/12 passed 仍是 raw deterministic verifier facts。</li>
+  </ul>
+
+  <h2>推荐下一步</h2>
+  <p>合并后可以单独准备完整 evidence packet review：同时提供可验证的 external routing packet 和 Stage 2 real Codex packet，再由 gate 产出最终 validity 状态。</p>
+</main>
+</body>
+</html>

--- a/openspec/changes/evidence-validity-release-gate/design.md
+++ b/openspec/changes/evidence-validity-release-gate/design.md
@@ -28,7 +28,9 @@ PR-1 through PR-6 created bounded inputs: SkillRouter adapter/provenance, offici
 
 4. **Earlier PR contracts remain source of truth.** PR-7 validates existing plan/report fields and hashes; it does not recompute official metrics, rerun routers, rerun live agents, or mutate evidence artifacts.
 
-5. **Reports are conservative.** Linked-transfer overlap, missing optional diagnostics, and partial evidence are surfaced as caveats or review requirements. Public numeric claims are not generated unless backing artifacts are present.
+5. **Stage 2 real Codex artifacts are adapted, not reinterpreted.** The gate can consume the frozen Stage 2 pilot plan plus the full real Codex execution artifact by normalizing them into the existing live-agent evidence contract. The adapter preserves deterministic verifier output as the only task-success source, keeps process exit code and LLM judge disabled as success sources, and does not change promotion logic.
+
+6. **Reports are conservative.** Linked-transfer overlap, missing optional diagnostics, and partial evidence are surfaced as caveats or review requirements. Public numeric claims are not generated unless backing artifacts are present.
 
 ## Risks / Trade-offs
 

--- a/openspec/changes/evidence-validity-release-gate/proposal.md
+++ b/openspec/changes/evidence-validity-release-gate/proposal.md
@@ -8,6 +8,7 @@ v0.3 now has frozen SkillRouter external artifacts and live-agent artifacts, but
 - Separate Benchmark Validity Gate status from Router Promotion Gate decision.
 - Validate frozen plan hashes, plan digests, derived hashes, scorer/report separation, overlap caveats, prompt-hash equality, oracle qualification, verifier evidence, trace completeness, leakage inventory, and field-level `UNAVAILABLE` markers.
 - Summarize external routing metrics, live-agent verifier outcomes, oracle gap, routed-vs-no-skill delta, timeout/process errors, skill-use evidence, and per-task regressions separately.
+- Accept the Stage 2 real Codex frozen-plan and execution artifact schema through a conservative adapter contract, while preserving the same verifier-only success source and promotion boundaries.
 - Default promotion to `KEEP_BASELINE` and block promotion when validity is `INVALID_EVIDENCE`.
 - Add focused tests, CLI wiring, OpenSpec artifacts, and a concise Chinese Human Brief.
 

--- a/openspec/changes/evidence-validity-release-gate/specs/evidence-validity-release-gate/spec.md
+++ b/openspec/changes/evidence-validity-release-gate/specs/evidence-validity-release-gate/spec.md
@@ -43,3 +43,11 @@ The system SHALL summarize external routing evidence and live-agent evidence in 
 
 - **WHEN** a SkillsBench live-agent matrix report is supplied
 - **THEN** the validator MUST report verifier pass/fail, no-skill/routed/oracle outcomes, oracle gap, routed-vs-no-skill delta, timeout/process errors, skill-use evidence, and per-task regressions separately
+
+#### Scenario: Stage 2 real Codex execution schema is consumable
+
+- **WHEN** a frozen Stage 2 pilot plan and full Stage 2 real Codex execution artifact are supplied as live-agent evidence
+- **THEN** the validator MUST adapt the Stage 2 schema into the live-agent evidence checks without rerunning Codex or Stage 2
+- **AND** deterministic verifier output MUST remain the only task success source
+- **AND** process exit code and LLM judge MUST NOT become task success sources
+- **AND** router promotion MUST remain governed by the existing conservative promotion gate

--- a/openspec/changes/evidence-validity-release-gate/tasks.md
+++ b/openspec/changes/evidence-validity-release-gate/tasks.md
@@ -16,6 +16,7 @@
 - [x] 3.2 Implement external routing evidence validation and summary extraction.
 - [x] 3.3 Implement live-agent evidence validation and summary extraction.
 - [x] 3.4 Implement validity status derivation and conservative promotion gate.
+- [x] 3.5 Add a conservative Stage 2 real Codex schema adapter for frozen-plan and full execution artifacts.
 
 ## 4. CLI And Reporting
 

--- a/src/hermes_skilleval/evidence_gate.py
+++ b/src/hermes_skilleval/evidence_gate.py
@@ -26,6 +26,8 @@ from hermes_skilleval.release_manifest import sha256_file
 
 REPORT_SCHEMA = "v0.3.evidence-decision-report.v1"
 ARTIFACT_TYPE = "v0.3-evidence-validity-release-gate"
+STAGE2_FROZEN_PLAN_SCHEMA = "v0.3.stage2-pilot-plan-freeze.v1"
+STAGE2_REAL_CODEX_EXECUTION_SCHEMA = "v0.3.stage2-real-codex-12-run-execution.v1"
 VALID_EVIDENCE = "VALID_EVIDENCE"
 INVALID_EVIDENCE = "INVALID_EVIDENCE"
 REVIEW_REQUIRED = "REVIEW_REQUIRED"
@@ -295,14 +297,23 @@ def _evaluate_live_agent(
     inputs["live_report"] = _input_record(report_path)
     field_markers["live_agent"] = {"status": PRESENT}
 
+    plan = _read_json_for_gate(checks, "live_agent.plan_load", plan_path)
+    report = _read_json_for_gate(checks, "live_agent.report_load", report_path)
+    if _is_stage2_real_codex_packet(plan, report):
+        return _evaluate_stage2_real_codex_live_agent(
+            plan_path=plan_path,
+            report_path=report_path,
+            plan=plan,
+            report=report,
+            checks=checks,
+        )
+
     _call_check(
         checks,
         "live_agent.plan_digest",
         "SkillsBench plan digest matches its sidecar",
         lambda: _verify_live_plan_digest(plan_path),
     )
-    plan = _read_json_for_gate(checks, "live_agent.plan_load", plan_path)
-    report = _read_json_for_gate(checks, "live_agent.report_load", report_path)
     _schema_check(checks, "live_agent.plan_schema", plan, LIVE_PLAN_SCHEMA)
     _schema_check(checks, "live_agent.report_schema", report, LIVE_REPORT_SCHEMA)
     _call_check(
@@ -363,6 +374,292 @@ def _evaluate_live_agent(
             "reason": "explicit negative labels are not present for SkillsBench",
         },
     }
+
+
+def _is_stage2_real_codex_packet(plan: dict[str, Any], report: dict[str, Any]) -> bool:
+    return (
+        isinstance(plan, dict)
+        and isinstance(report, dict)
+        and plan.get("schema_version") == STAGE2_FROZEN_PLAN_SCHEMA
+        and report.get("schema_version") == STAGE2_REAL_CODEX_EXECUTION_SCHEMA
+    )
+
+
+def _evaluate_stage2_real_codex_live_agent(
+    *,
+    plan_path: Path,
+    report_path: Path,
+    plan: dict[str, Any],
+    report: dict[str, Any],
+    checks: list[dict[str, Any]],
+) -> dict[str, Any]:
+    adapter_failures = _stage2_adapter_failures(plan_path, report_path, plan, report)
+    _check(
+        checks,
+        "live_agent.stage2_schema_adapter",
+        PASS if not adapter_failures else FAIL,
+        BLOCKING,
+        "Stage 2 real Codex execution schema was adapted for live-agent evidence checks"
+        if not adapter_failures
+        else "Stage 2 real Codex execution schema cannot be adapted for live-agent evidence checks",
+        {"failures": adapter_failures},
+    )
+    normalized_plan, normalized_report = _stage2_live_agent_view(
+        plan_path=plan_path,
+        report_path=report_path,
+        plan=plan,
+        report=report,
+    )
+
+    _check_live_matrix_completeness(checks, normalized_plan, normalized_report)
+    _check_prompt_hash_equality(checks, normalized_plan, normalized_report)
+    _check_oracle_qualification(checks, normalized_plan)
+    _check_verifier_evidence(checks, normalized_report)
+    _check_no_skill_leakage(checks, normalized_report)
+    _check_global_capability_inventory(checks, normalized_report, report_path.parent)
+    _check_trace_completeness(checks, normalized_report, report_path.parent)
+    _check_overlap_status(checks, normalized_report)
+    _check_secret_redaction(checks, normalized_report, report_path.parent)
+
+    run_records = normalized_report["runs"]
+    condition_summary = _condition_summary(run_records)
+    no_skill_rate = _success_rate(condition_summary.get("no-skill"))
+    routed_rate = _success_rate(condition_summary.get("routed-skill"))
+    oracle_rate = _success_rate(condition_summary.get("oracle-skill"))
+    timeout_process_errors = _timeout_process_errors(run_records)
+    per_task_regressions = _per_task_regressions(run_records)
+    _check_live_runtime_anomalies(checks, timeout_process_errors)
+    _check_live_task_regressions(checks, per_task_regressions)
+    return {
+        "status": PRESENT,
+        "run_id": normalized_report.get("run_id"),
+        "mode": normalized_report.get("mode"),
+        "condition_summary": condition_summary,
+        "routed_vs_no_skill_delta": {
+            "task_success_delta": _nullable_delta(routed_rate, no_skill_rate),
+        },
+        "oracle_gap": {
+            "routed_minus_oracle_success_delta": _nullable_delta(routed_rate, oracle_rate),
+        },
+        "timeout_process_errors": timeout_process_errors,
+        "skill_use_evidence": _skill_use_summary(run_records),
+        "per_task_regressions": per_task_regressions,
+        "overlap_report": normalized_report.get("overlap_report"),
+        "negative_hit_rate": {
+            "status": UNAVAILABLE,
+            "reason": "explicit negative labels are not present for SkillsBench",
+        },
+        "stage2_schema_adapter": {
+            "status": PASS if not adapter_failures else FAIL,
+            "source_plan_schema": plan.get("schema_version"),
+            "source_report_schema": report.get("schema_version"),
+        },
+    }
+
+
+def _stage2_adapter_failures(
+    plan_path: Path,
+    report_path: Path,
+    plan: dict[str, Any],
+    report: dict[str, Any],
+) -> list[dict[str, Any]]:
+    failures: list[dict[str, Any]] = []
+    expected_runs = plan.get("pilot_shape", {}).get("runs")
+    actual_runs = report.get("run_records")
+    if not isinstance(expected_runs, list):
+        failures.append({"reason": "stage2 frozen plan pilot_shape.runs is missing"})
+        expected_runs = []
+    if not isinstance(actual_runs, list):
+        failures.append({"reason": "stage2 execution run_records is missing"})
+        actual_runs = []
+    expected_ids = [str(run.get("run_id")) for run in expected_runs if isinstance(run, dict)]
+    actual_ids = [str(run.get("run_id")) for run in actual_runs if isinstance(run, dict)]
+    if expected_ids != actual_ids:
+        failures.append(
+            {
+                "reason": "stage2 execution run order does not match frozen plan",
+                "expected_run_ids": expected_ids,
+                "actual_run_ids": actual_ids,
+            }
+        )
+    summary = report.get("summary") if isinstance(report.get("summary"), dict) else {}
+    if summary.get("runs_planned") != len(expected_ids):
+        failures.append({"reason": "runs_planned does not match frozen run count"})
+    if summary.get("runs_completed_with_verifier_output") != len(expected_ids):
+        failures.append({"reason": "not every frozen run has verifier output"})
+    if summary.get("pass_fail_counts_are_verifier_output_facts_only") is not True:
+        failures.append({"reason": "pass/fail counts are not marked as verifier-output facts"})
+    boundaries = report.get("boundaries") if isinstance(report.get("boundaries"), dict) else {}
+    forbidden_true = {
+        "process_exit_code_used_as_task_success",
+        "llm_judge_used",
+        "llm_judge_used_as_task_success",
+        "performance_claim_made",
+        "router_promoted",
+        "evidence_gate_rerun",
+        "oracle_qualification_rerun",
+        "routed_predictions_changed",
+        "verifier_outputs_rewritten",
+        "task_manifests_or_public_prompts_changed",
+        "scorer_matrix_router_evidence_gate_semantics_modified",
+    }
+    for key in sorted(forbidden_true):
+        if boundaries.get(key) is not False:
+            failures.append({"reason": f"stage2 boundary {key} is not false"})
+    input_package = _stage2_input_package(plan)
+    if input_package is None:
+        failures.append({"reason": "stage2 input package cannot be loaded"})
+    for run in actual_runs:
+        if not isinstance(run, dict):
+            failures.append({"reason": "stage2 run record is not an object"})
+            continue
+        verifier = run.get("verifier")
+        if not isinstance(verifier, dict) or not isinstance(verifier.get("passed"), bool):
+            failures.append({"run_id": run.get("run_id"), "reason": "missing verifier.passed"})
+        if run.get("success_source", {}).get("task_success_source") != "deterministic verifier output only":
+            failures.append(
+                {"run_id": run.get("run_id"), "reason": "task success source is not deterministic verifier"}
+            )
+        if run.get("codex", {}).get("process_exit_code_is_task_success") is not False:
+            failures.append(
+                {"run_id": run.get("run_id"), "reason": "Codex process exit code is marked as task success"}
+            )
+        if not isinstance(verifier, dict) or verifier.get("llm_judge_used") is not False:
+            failures.append({"run_id": run.get("run_id"), "reason": "LLM judge use is not false"})
+        trace = run.get("trace") if isinstance(run.get("trace"), dict) else {}
+        trace_path = _stage2_relative_to_report_dir(report_path, trace.get("path"))
+        if trace_path is None:
+            failures.append({"run_id": run.get("run_id"), "reason": "trace path is not under report directory"})
+        reward = verifier.get("reward") if isinstance(verifier, dict) else None
+        ctrf = verifier.get("ctrf") if isinstance(verifier, dict) else None
+        if not isinstance(reward, dict) and not isinstance(ctrf, dict):
+            failures.append({"run_id": run.get("run_id"), "reason": "missing reward or CTRF verifier artifact"})
+    return failures
+
+
+def _stage2_live_agent_view(
+    *,
+    plan_path: Path,
+    report_path: Path,
+    plan: dict[str, Any],
+    report: dict[str, Any],
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    input_package = _stage2_input_package(plan) or {}
+    selected_tasks = input_package.get("data_root_package", {}).get("selected_tasks", [])
+    oracle_records = input_package.get("oracle_qualification_package", {}).get("records", {})
+    run_records = [run for run in report.get("run_records", []) if isinstance(run, dict)]
+    prompt_hashes = {
+        str(run.get("run_id")): run.get("inputs", {}).get("task_prompt_sha256")
+        for run in run_records
+    }
+    matrix = []
+    for entry in plan.get("pilot_shape", {}).get("runs", []):
+        if not isinstance(entry, dict):
+            continue
+        run_id = str(entry.get("run_id"))
+        matching_run = next((run for run in run_records if run.get("run_id") == run_id), {})
+        mounted_skills = matching_run.get("workspace", {}).get("mounted_skills", [])
+        matrix.append(
+            {
+                "run_id": run_id,
+                "task_id": entry.get("task_id"),
+                "condition": entry.get("condition_id"),
+                "prompt_hash": prompt_hashes.get(run_id),
+                "mounted_skill_ids": _skill_ids(mounted_skills),
+            }
+        )
+    normalized_plan = {
+        "schema_version": LIVE_PLAN_SCHEMA,
+        "matrix": matrix,
+        "selected_tasks": selected_tasks,
+        "oracle_qualification_records": oracle_records,
+    }
+    normalized_report = {
+        "schema_version": LIVE_REPORT_SCHEMA,
+        "run_id": report.get("artifact_timestamp"),
+        "mode": "stage2-real-codex",
+        "plan_path": str(plan_path),
+        "summary": {"task_success_source": "verifier_pass_fail"},
+        "overlap_report": {
+            "decision": "UNAVAILABLE",
+            "independent_generalization_claim": False,
+        },
+        "runs": [
+            _stage2_run_view(run, report_path)
+            for run in run_records
+        ],
+    }
+    return normalized_plan, normalized_report
+
+
+def _stage2_input_package(plan: dict[str, Any]) -> dict[str, Any] | None:
+    ref = plan.get("artifact_refs", {}).get("stage2_real_pilot_input_package")
+    if not isinstance(ref, dict):
+        return None
+    path = ref.get("path")
+    if not isinstance(path, str):
+        return None
+    package_path = Path(path)
+    if not package_path.exists():
+        return None
+    if ref.get("sha256") and sha256_file(package_path) != ref.get("sha256"):
+        return None
+    try:
+        payload = _read_json(package_path)
+    except (OSError, json.JSONDecodeError, ValueError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _stage2_run_view(run: dict[str, Any], report_path: Path) -> dict[str, Any]:
+    trace_meta = run.get("trace") if isinstance(run.get("trace"), dict) else {}
+    trace_path = _stage2_relative_to_report_dir(report_path, trace_meta.get("path"))
+    trace_file = report_path.parent / trace_path if trace_path else None
+    trace = _read_json(trace_file) if trace_file is not None and trace_file.exists() else {}
+    mounted_skills = trace.get("mounted_skills") if isinstance(trace.get("mounted_skills"), list) else []
+    skill_use = trace.get("skill_use") if isinstance(trace.get("skill_use"), dict) else {}
+    verifier = run.get("verifier") if isinstance(run.get("verifier"), dict) else {}
+    codex = run.get("codex") if isinstance(run.get("codex"), dict) else {}
+    passed = verifier.get("passed")
+    return {
+        "run_id": run.get("run_id"),
+        "task_id": run.get("task_id"),
+        "condition": run.get("condition"),
+        "prompt_hash": run.get("inputs", {}).get("task_prompt_sha256"),
+        "mounted_skill_ids": _skill_ids(mounted_skills),
+        "mounted_skill_count": len(mounted_skills),
+        "skill_use": skill_use,
+        "process_exit_code": codex.get("process_exit_code"),
+        "timed_out": codex.get("timed_out"),
+        "task_success": passed,
+        "verifier_passed": passed,
+        "verifier": {"passed": passed},
+        "trace_path": str(trace_path) if trace_path else None,
+        "trace_sha256": trace_meta.get("sha256"),
+    }
+
+
+def _stage2_relative_to_report_dir(report_path: Path, raw_path: Any) -> Path | None:
+    if not isinstance(raw_path, str) or not raw_path.strip():
+        return None
+    path = Path(raw_path)
+    if path.is_absolute():
+        return None
+    report_dir = report_path.parent
+    try:
+        return path.resolve().relative_to(report_dir.resolve())
+    except (OSError, ValueError):
+        return None
+
+
+def _skill_ids(records: Any) -> list[str]:
+    if not isinstance(records, list):
+        return []
+    return [
+        str(record.get("skill_id"))
+        for record in records
+        if isinstance(record, dict) and record.get("skill_id")
+    ]
 
 
 def _verify_external_inputs(plan: dict[str, Any]) -> None:

--- a/tests/test_v0_3_evidence_gate.py
+++ b/tests/test_v0_3_evidence_gate.py
@@ -23,6 +23,15 @@ SKILLROUTER_FIXTURE = Path("tests/fixtures/external/skillrouter_eval_core_tiny")
 SKILLROUTER_PREDICTIONS = SKILLROUTER_FIXTURE / "predictions.json"
 SKILLSBENCH_FIXTURE = Path("tests/fixtures/live_agent/skillsbench_tiny")
 UPSTREAM_SHA = "b" * 40
+STAGE2_FROZEN_PLAN = Path(
+    "artifacts/v0.3/skillsbench-pilot/v0.3-stage2-pilot-freeze-20260707T025315Z/"
+    "stage2-pilot-plan.frozen.json"
+)
+STAGE2_REAL_CODEX_EXECUTION = Path(
+    "artifacts/v0.3/skillsbench-pilot/"
+    "v0.3-stage2-real-codex-12-run-execution-20260707T072652Z/"
+    "stage2-real-codex-12-run-execution.json"
+)
 
 
 def test_evidence_gate_validates_full_packet_and_keeps_baseline(tmp_path):
@@ -93,6 +102,36 @@ def test_evidence_gate_promotion_uses_evaluated_configs_not_hardcoded_names(tmp_
     ]
     assert "baseline-minilm" not in json.dumps(report["router_promotion_gate"])
     assert "finetuned-embedding" not in json.dumps(report["router_promotion_gate"])
+
+
+def test_evidence_gate_accepts_stage2_real_codex_execution_schema(tmp_path):
+    report = write_evidence_decision_report(
+        output_path=tmp_path / "evidence.json",
+        live_plan_path=STAGE2_FROZEN_PLAN,
+        live_report_path=STAGE2_REAL_CODEX_EXECUTION,
+    )
+
+    assert report["benchmark_validity_gate"]["status"] == "REVIEW_REQUIRED"
+    assert report["router_promotion_gate"]["decision"] == "KEEP_BASELINE"
+    assert report["router_promotion_gate"]["blocked_by_validity"] is False
+    assert report["live_agent"]["mode"] == "stage2-real-codex"
+    assert report["live_agent"]["condition_summary"]["no-skill"]["run_count"] == 4
+    assert report["live_agent"]["condition_summary"]["routed-skill"]["run_count"] == 4
+    assert report["live_agent"]["condition_summary"]["oracle-skill"]["run_count"] == 4
+    assert report["live_agent"]["condition_summary"]["no-skill"]["verifier_pass_count"] == 2
+    assert report["live_agent"]["condition_summary"]["routed-skill"]["verifier_pass_count"] == 2
+    assert report["live_agent"]["condition_summary"]["oracle-skill"]["verifier_pass_count"] == 2
+
+    live_failures = [
+        check
+        for check in report["benchmark_validity_gate"]["checks"]
+        if check["id"].startswith("live_agent.") and check["status"] == "FAIL"
+    ]
+    assert live_failures == []
+    assert _check_by_id(report, "live_agent.stage2_schema_adapter")["status"] == "PASS"
+    assert _check_by_id(report, "live_agent.verifier_evidence")["status"] == "PASS"
+    assert _check_by_id(report, "live_agent.no_skill_leakage")["status"] == "PASS"
+    assert _check_by_id(report, "live_agent.trace_completeness")["status"] == "PASS"
 
 
 def test_evidence_gate_fails_when_external_report_missing_frozen_configs(tmp_path):


### PR DESCRIPTION
## Summary

This PR adds a narrow adapter/contract path so `v0.3-evidence-gate` can consume the Stage 2 real Codex execution schema directly.

It maps the frozen Stage 2 pilot plan plus the full Stage 2 real Codex execution artifact into the existing live-agent evidence contract, then reuses the existing evidence-gate checks for matrix completeness, prompt hash equality, verifier evidence, no-skill leakage, capability inventory, trace completeness, overlap status, secret redaction, runtime anomalies, and per-task regression review.

## Boundaries

- Adapter/contract PR only.
- No Codex rerun.
- No Stage 2 rerun.
- No new task traces.
- No task manifest or public prompt changes.
- No verifier, scorer, matrix, router, or promotion semantic changes.
- Deterministic verifier output remains the only task success source.
- Process exit code is recorded evidence only and is not task success.
- LLM judge is not used.
- No performance claim is made.
- No router promotion is made.

## Adapter smoke evidence

- Evidence gate output: `REVIEW_REQUIRED`
- Router promotion: `KEEP_BASELINE`
- Blocking failures: `0`
- Remaining review/unavailable fields: external routing evidence was not supplied; overlap/generalization remains caveated.

Artifacts:

- `artifacts/v0.3/skillsbench-pilot/v0.3-stage2-real-codex-evidence-gate-adapter-20260708T032000Z/evidence-gate.stage2-adapter.json`
  - sha256: `0e77ab02397c37e55dbb6a9f505ac5f733049f00ca8906d2c20bdb5609afd929`
- `artifacts/v0.3/skillsbench-pilot/v0.3-stage2-real-codex-evidence-gate-adapter-20260708T032000Z/evidence-gate.stage2-adapter.md`
  - sha256: `cc5298fc290e1d9637e196a3195d822bb83b221ccf3c883da4f86b6249a5d6ab`
- `artifacts/v0.3/skillsbench-pilot/v0.3-stage2-real-codex-evidence-gate-adapter-20260708T032000Z/stage2-real-codex-evidence-gate-adapter.json`
  - sha256: `c773910a631c129f43f8f60e8d2dc8ea2a4746a666df334b5eb7b9aae3f467ce`

## Validation

- `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=src python -m pytest -q`
  - `667 passed`
- `OPENSPEC_TELEMETRY=0 openspec validate --all --strict`
  - `25 passed, 0 failed`
- `PYTHONPATH=src python -m hermes_skilleval.cli release-check`
  - `Release reproducibility PASS`
- `git diff --check origin/codex/v0.3-pr0-protocol...HEAD`
  - pass
- JSON parse/hash checks
  - pass
- Secret/token pattern scan over changed files
  - pass

## Next Step

After this PR is reviewed and merged, the next bounded step is a separate evidence-gate review using the adapter output. Any promotion decision still requires a separate explicit evidence-gate/review step.