### PR TITLE
release: prepare v0.3.0 evidence-chain release

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 [![Python 3.11+](https://img.shields.io/badge/python-3.11+-blue.svg)](https://www.python.org/downloads/)
 [![Validate](https://github.com/Raidriar7170/hermes-skilleval/actions/workflows/validate.yml/badge.svg)](https://github.com/Raidriar7170/hermes-skilleval/actions/workflows/validate.yml)
-[![Release: v0.2.1](https://img.shields.io/badge/release-v0.2.1-blue.svg)](https://github.com/Raidriar7170/hermes-skilleval/releases/tag/v0.2.1)
-[![Tests: 419](https://img.shields.io/badge/tests-419%20passed-brightgreen.svg)](tests)
+[![Release: v0.3.0](https://img.shields.io/badge/release-v0.3.0-blue.svg)](https://github.com/Raidriar7170/hermes-skilleval/releases/tag/v0.3.0)
+[![Tests: 668](https://img.shields.io/badge/tests-668%20passed-brightgreen.svg)](tests)
 [![Reusable Action](https://img.shields.io/badge/action-reusable%20repo%20Action-0b6e69.svg)](action.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 [![Benchmark](https://img.shields.io/badge/benchmark-80%20tasks%20%2F%2045%20skills-purple.svg)](benchmarks)
@@ -22,7 +22,7 @@ Hermes SkillEval 是一个面向 AI 编程 Agent 技能库的离线评测和 CI 
 
 最关键的一次结果是：`finetuned-embedding` 候选路由器虽然保留了 gold skill，但在盲测中新增选择了错误的 negative skill，所以 release gate 没有把它升级为默认路由器，而是继续保留 `baseline-minilm`。这也是项目想展示的核心能力：不仅能做评测，还能在候选方案看起来更“智能”但风险变高时拒绝上线。
 
-当前完成度：`v0.2.1` 已发布，`419` 个 pytest 用例通过，CI、可复用 repository Action、示例技能库、dashboard、release notes 和 post-release evidence 都已落库。更完整的中文项目说明见 [中文完整说明](https://raidriar7170.github.io/hermes-skilleval/docs/interview-project-overview.html)。
+当前完成度：`v0.3.0` release-prep 记录 Stage 2 real Codex pilot evidence-chain closeout，当前测试面为 `668` pytest cases。最终 evidence-gate posture 是 `REVIEW_REQUIRED / KEEP_BASELINE`，`blocking_failure_count=0`，剩余 caveat 是 `live_agent.overlap_status`。这不是 benchmark PASS、性能提升结论或 router promotion。更完整的中文项目说明见 [中文完整说明](https://raidriar7170.github.io/hermes-skilleval/docs/interview-project-overview.html)。
 
 ## What it does
 
@@ -68,7 +68,15 @@ pytest -q
 ```
 
 Expected: the example gate returns `ALLOW_MERGE`, and the current public suite
-has `419 passed` / `419 pytest cases`.
+has `668 passed` / `668 pytest cases`.
+
+## v0.3.0 release-prep status
+
+`v0.3.0` adds Stage 2 real Codex pilot evidence-chain support and records a
+real 4x3x1 Codex pilot closeout. Final gate posture is
+`REVIEW_REQUIRED / KEEP_BASELINE` with `blocking_failure_count=0` and
+`live_agent.overlap_status` remaining as a review caveat. No performance claim
+or router promotion is made. `KEEP_BASELINE` is not a performance conclusion.
 
 For full CLI usage, see [`docs/usage.md`](docs/usage.md). For reviewer
 navigation across release, diagnostic, external validation, CI, OpenSpec, and
@@ -94,7 +102,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
-      - uses: Raidriar7170/hermes-skilleval@v0.2.1
+      - uses: Raidriar7170/hermes-skilleval@v0.3.0
         with:
           skill-path: skills
           benchmark-path: benchmark
@@ -152,10 +160,11 @@ dashboard remaining useful for inspection.
 |---|---|---|
 | Phase 16 blind validation | `REVIEW_REQUIRED`; two regressions and worse negative-hit behavior | [`docs`](docs/phase16.md), [`comparison.md`](docs/demo/phase16-blind-validation/comparison.md) |
 | Phase 17 release selector | `KEEP_BASELINE`; `baseline-minilm` remains default | [`docs`](docs/phase17.md), [`release-decision.json`](docs/demo/phase17-calibrated-release-selector/release-decision.json) |
-| Phase 18 reproducibility pack | `PASS`; release-check reproduces the default-router decision | [`docs`](docs/phase18.md), [`release-manifest.json`](docs/demo/phase18-ci-release-reproducibility/release-manifest.json) |
+| Phase 18 reproducibility pack | release-check reproduces the default-router decision | [`docs`](docs/phase18.md), [`release-manifest.json`](docs/demo/phase18-ci-release-reproducibility/release-manifest.json) |
 | v0.2.0 historical pre-publish review | `NEEDS_REVIEW`, `Published: false`, and required human confirmation | [`release-decision.md`](docs/demo/v0.2.0-release-decision/release-decision.md), [`final checklist`](docs/demo/v0.2.0-final-approval/final-approval.md) |
 | v0.2.0 post-release evidence | post-release facts after human GO: Published `true`; tag and GitHub Release created; Marketplace published `false` | [`post-release.md`](docs/demo/v0.2.0-post-release/post-release.md), [`post-release.json`](docs/demo/v0.2.0-post-release/post-release.json) |
 | v0.2.1 patch release notes | post-release onboarding cleanup packaged as a conservative patch release | [`release notes`](docs/release-notes/v0.2.1.md), [`Human Brief`](docs/human-briefs/2026-06-05-post-release-onboarding-cleanup.html) |
+| v0.3.0 release-prep notes | Stage 2 real Codex pilot evidence-chain release prep; final posture `REVIEW_REQUIRED / KEEP_BASELINE` | [`release notes`](docs/release-notes/v0.3.0.md), [`closeout`](artifacts/v0.3/skillsbench-pilot/v0.3-stage2-real-codex-evidence-gate-closeout-20260708T080414Z/stage2-real-codex-evidence-gate-closeout.json) |
 
 v0.2.0 post-release status: Published: `true`; tag and GitHub Release created `true`;
 Marketplace published `false`.
@@ -190,7 +199,7 @@ project walkthrough, use
 | Benchmark tasks | 80 |
 | Hermes-style benchmark skills | 45 |
 | Router families | 5 |
-| Test cases | 419 |
+| Test cases | 668 |
 | Remote hardware validation | Single idle A100 GPU |
 
 ## Architecture / 系统架构
@@ -303,7 +312,7 @@ and [`docs/phase7b.md`](docs/phase7b.md).
 | Neural Retrieval | sentence-transformers MiniLM | Real embedding router |
 | Reranking | verification gate + cross-encoder | Selective and learned ranking |
 | Reports | JSONL + Markdown + static HTML dashboard | Reproducible experiment artifacts |
-| Testing | pytest | 419 pytest cases |
+| Testing | pytest | 668 pytest cases |
 | Hardware | Mac + A100 dev machine | Local development and remote model validation |
 
 ---
@@ -363,7 +372,7 @@ MIT License. See [LICENSE](LICENSE) for details.
 >   ranking metrics such as Recall@k, MRR, NDCG, and Negative Hit Rate.
 > - **Infrastructure:** validated neural reranking on shared A100 infrastructure
 >   while selecting idle GPUs and preserving user-owned storage paths.
-> - **Engineering Quality:** shipped a typed Python CLI with 419 passing tests,
+> - **Engineering Quality:** shipped a typed Python CLI with 668 passing tests,
 >   reproducible benchmark artifacts, a static inspection dashboard, and a
 >   release gate that keeps `baseline-minilm` when blind validation finds a
 >   fine-tuned-router regression.

--- a/artifacts/v0.3/release/v0.3.0-release-readiness.json
+++ b/artifacts/v0.3/release/v0.3.0-release-readiness.json
@@ -1,0 +1,272 @@
+{
+  "schema_version": "v0.3.release-readiness.v1",
+  "created_at_utc": "2026-07-08T09:33:53Z",
+  "target_release": "v0.3.0",
+  "base_branch": "codex/v0.3-pr0-protocol",
+  "base_head_sha": "361325b82df43c5074c55d4dd5481da5dc8489db",
+  "source_pr_closeout": {
+    "number": 30,
+    "url": "https://github.com/Raidriar7170/hermes-skilleval/pull/30",
+    "merge_commit": "361325b82df43c5074c55d4dd5481da5dc8489db"
+  },
+  "release_type": "stage2_real_codex_pilot_evidence_chain_release",
+  "final_gate_status": {
+    "benchmark_validity_gate_status": "REVIEW_REQUIRED",
+    "router_promotion_gate_decision": "KEEP_BASELINE",
+    "blocking_failure_count": 0,
+    "remaining_caveats": [
+      "live_agent.overlap_status"
+    ]
+  },
+  "non_claims": {
+    "benchmark_pass_claimed": false,
+    "performance_improvement_claimed": false,
+    "router_promotion_claimed": false,
+    "review_required_treated_as_pass": false,
+    "keep_baseline_treated_as_performance_conclusion": false
+  },
+  "raw_stage2_execution_facts": {
+    "planned_runs": 12,
+    "codex_exec_invocations": 12,
+    "verifier_output_records": 12,
+    "verifier_passed_raw_count": 6,
+    "verifier_failed_raw_count": 6,
+    "raw_facts_are_performance_claim": false,
+    "process_exit_code_used_as_task_success": false,
+    "llm_judge_used": false
+  },
+  "source_artifacts": {
+    "stage2_input_package": {
+      "path": "artifacts/v0.3/skillsbench-pilot/v0.3-stage2-input-package-candidate-20260701T010000Z/stage2-real-pilot-input-package.json",
+      "sha256": "235a48830bc25f324f071582a42ed42a3074342d3b6f6f914d0ea99fb26a8739"
+    },
+    "oracle_qualification_jsonl": {
+      "path": "artifacts/v0.3/skillsbench-pilot/v0.3-stage2-input-package-candidate-20260701T010000Z/oracle_qualification.jsonl",
+      "sha256": "5a8bdded8528f39f4515dddbe60d8b353dd1e0a53889cf206aecd6b25b844a27"
+    },
+    "oracle_qualification_report": {
+      "path": "artifacts/v0.3/skillsbench-pilot/v0.3-stage2-input-package-candidate-20260701T010000Z/oracle-qualification.report.json",
+      "sha256": "89e0c75d0bcdd88b360cb09b85e876a2a89f9eb86155b4cc55cf30242d54d21e"
+    },
+    "input_package_validator_passed": {
+      "path": "artifacts/v0.3/skillsbench-pilot/v0.3-stage2-input-package-candidate-20260701T010000Z/input-package-validator.passed.json",
+      "sha256": "de087717fe4fcd36344f1d1b5788898ebff3b512f42c2a1d39686bbc09e843cc"
+    },
+    "routed_predictions_strict": {
+      "path": "artifacts/v0.3/skillsbench-pilot/v0.3-stage2-input-package-candidate-20260701T010000Z/routed_predictions.strict.json",
+      "sha256": "28c4d20f0e535aa8c6a2b1f8603a99df385dffae8794be1abe86c0669feb9ea1"
+    },
+    "routed_predictions_strict_manifest": {
+      "path": "artifacts/v0.3/skillsbench-pilot/v0.3-stage2-input-package-candidate-20260701T010000Z/routed_predictions.strict.manifest.json",
+      "sha256": "084a8ec222756bc5cc0fc6affbab6a419429ff08a7f80d9b33b5442533a96304"
+    },
+    "approved_router_config": {
+      "path": "artifacts/v0.3/skillsbench-pilot/v0.3-stage2-input-package-candidate-20260701T010000Z/router-config.approved-non-execution.json",
+      "sha256": "7227fe9e4642a7f3e5a193008b86a74036091063c0976b3bd0b6d2b1e71fd1ca"
+    },
+    "human_privacy_acceptance": {
+      "path": "artifacts/v0.3/skillsbench-pilot/v0.3-stage2-input-package-candidate-20260701T010000Z/privacy-review.human-accepted-non-execution.json",
+      "sha256": "b1d4a08ac99ad32242def96b92817003e87642cf951cae80042526c820fcb4ff"
+    },
+    "codex_isolated_auth_smoke_preflight": {
+      "path": "artifacts/v0.3/skillsbench-pilot/v0.3-codex-real-runner-isolated-auth-smoke-preflight-20260706T093453Z/codex-real-runner-isolated-auth-smoke-preflight.json",
+      "sha256": "881d47b6a6b667c90a1caf98adae5688f43438006e6c8b218a9ed47afd89f1b7"
+    },
+    "frozen_plan": {
+      "path": "artifacts/v0.3/skillsbench-pilot/v0.3-stage2-pilot-freeze-20260707T025315Z/stage2-pilot-plan.frozen.json",
+      "sha256": "aaa0f4c4d1939cff9bcba08ce6549284726353ed199d7bedd31614be970f579b"
+    },
+    "stage2_execution": {
+      "path": "artifacts/v0.3/skillsbench-pilot/v0.3-stage2-real-codex-12-run-execution-20260707T072652Z/stage2-real-codex-12-run-execution.json",
+      "sha256": "70adb8e1e7dd953fcd1efdf541a0174dfae559e8b4efaa194f1641a8f8f6a243"
+    },
+    "stage2_matrix_report": {
+      "path": "artifacts/v0.3/skillsbench-pilot/v0.3-stage2-real-codex-12-run-execution-20260707T072652Z/stage2-real-codex-12-run-matrix-report.json",
+      "sha256": "4205f8e8f5e141a67afdebb388a7c6927cc7b45f03a1c6966326e5cc5efc8f7f"
+    },
+    "stage2_adapter": {
+      "path": "artifacts/v0.3/skillsbench-pilot/v0.3-stage2-real-codex-evidence-gate-adapter-20260708T032000Z/stage2-real-codex-evidence-gate-adapter.json",
+      "sha256": "c773910a631c129f43f8f60e8d2dc8ea2a4746a666df334b5eb7b9aae3f467ce"
+    },
+    "data_root_provenance_repair": {
+      "path": "artifacts/v0.3/skillsbench-pilot/v0.3-external-matrix-data-root-provenance-repair-20260708T065712Z/external-matrix-data-root-provenance-repair.json",
+      "sha256": "2b2819245a909cbfe7e7da73ce554cb1db3d122b5000c81282b4388cbd880fad"
+    },
+    "evidence_gate_closeout": {
+      "path": "artifacts/v0.3/skillsbench-pilot/v0.3-stage2-real-codex-evidence-gate-closeout-20260708T080414Z/stage2-real-codex-evidence-gate-closeout.json",
+      "sha256": "ac5b7faa337d484461b3424ad8f7f63f311cf19347de1c02b40463b26c95aaf1"
+    }
+  },
+  "source_pr_chain": [
+    {
+      "number": 13,
+      "state": "MERGED",
+      "merge_commit": "f36f17000dc42a92fc63c4e0be53fc748e0f88f3",
+      "reachable_from_base": true,
+      "role": "Stage 2 input package candidate, oracle qualification, validator artifacts"
+    },
+    {
+      "number": 15,
+      "state": "MERGED",
+      "merge_commit": "95c0d43cf5977e9419c17b7ef2d7a32fdc174aad",
+      "reachable_from_base": true,
+      "role": "Privacy provenance blocker record"
+    },
+    {
+      "number": 16,
+      "state": "MERGED",
+      "merge_commit": "22267cc2a87e1720203efb285adfbf15847d0aaf",
+      "reachable_from_base": true,
+      "role": "Human privacy acceptance"
+    },
+    {
+      "number": 18,
+      "state": "MERGED",
+      "merge_commit": "92e831fb58b9094abbcdfc4dd6cc4a4e17ad2e7d",
+      "reachable_from_base": true,
+      "role": "Codex real-runner smoke/preflight auth blocker"
+    },
+    {
+      "number": 19,
+      "state": "MERGED",
+      "merge_commit": "fd5678d9f746ad7171eec0711bde43d50645ba69",
+      "reachable_from_base": true,
+      "role": "Codex real-runner smoke/preflight archive"
+    },
+    {
+      "number": 20,
+      "state": "MERGED",
+      "merge_commit": "e77b4753ba22a996f755c5b5d2fe5dc2751df592",
+      "reachable_from_base": true,
+      "role": "Isolated-auth smoke/preflight reached model"
+    },
+    {
+      "number": 21,
+      "state": "MERGED",
+      "merge_commit": "7c47afb6ee226ac36ace17842e1abb37928d546f",
+      "reachable_from_base": true,
+      "role": "Isolated-auth smoke/preflight archive"
+    },
+    {
+      "number": 22,
+      "state": "MERGED",
+      "merge_commit": "7802182d98055158a8999159ca3b60b489e43043",
+      "reachable_from_base": true,
+      "role": "Frozen 4x3x1 pilot plan"
+    },
+    {
+      "number": 23,
+      "state": "MERGED",
+      "merge_commit": "09b94bf42af71885a1b86186daadcd941919210e",
+      "reachable_from_base": true,
+      "role": "Historical preflight blocker"
+    },
+    {
+      "number": 24,
+      "state": "MERGED",
+      "merge_commit": "82d4414e78459ae7746d00cc0fb5383bb023fa84",
+      "reachable_from_base": true,
+      "role": "Workspace isolation fix"
+    },
+    {
+      "number": 25,
+      "state": "MERGED",
+      "merge_commit": "59d20f1dd44a829a699ace395730ca3823d8f2bc",
+      "reachable_from_base": true,
+      "role": "Stage 2 real Codex 12-run execution"
+    },
+    {
+      "number": 26,
+      "state": "MERGED",
+      "merge_commit": "ce6210707759cf600788c669ed50c11693b34648",
+      "reachable_from_base": true,
+      "role": "Initial evidence-gate fail-closed review"
+    },
+    {
+      "number": 27,
+      "state": "MERGED",
+      "merge_commit": "a17ecf0b753861fc935188f99b9315fc52bb6b96",
+      "reachable_from_base": true,
+      "role": "Stage 2 schema adapter"
+    },
+    {
+      "number": 28,
+      "state": "MERGED",
+      "merge_commit": "a03e0cab77bd86a69fcb12bbe38aba1dc371fc8b",
+      "reachable_from_base": true,
+      "role": "Formal evidence-gate review"
+    },
+    {
+      "number": 29,
+      "state": "MERGED",
+      "merge_commit": "72f9d1b7cbf4685521d5c2ee4d42da7889ce8577",
+      "reachable_from_base": true,
+      "role": "External matrix data-root provenance repair"
+    },
+    {
+      "number": 30,
+      "state": "MERGED",
+      "merge_commit": "361325b82df43c5074c55d4dd5481da5dc8489db",
+      "reachable_from_base": true,
+      "role": "Evidence-gate closeout"
+    }
+  ],
+  "validation_commands": {
+    "planned": [
+      "PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=src python -m pytest -q",
+      "OPENSPEC_TELEMETRY=0 openspec validate --all --strict",
+      "PYTHONPATH=src python -m hermes_skilleval.cli release-check",
+      "git diff --check",
+      "JSON/JSONL parse checks over changed artifacts",
+      "artifact hash-pointer checks",
+      "secret/token scan over changed files",
+      "boundary and overclaim scans"
+    ],
+    "executed": [
+      {
+        "command": "PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=src python -m pytest -q",
+        "status": "PASS",
+        "summary": "668 passed"
+      },
+      {
+        "command": "OPENSPEC_TELEMETRY=0 openspec validate --all --strict",
+        "status": "PASS",
+        "summary": "25 passed, 0 failed"
+      },
+      {
+        "command": "PYTHONPATH=src python -m hermes_skilleval.cli release-check",
+        "status": "PASS",
+        "summary": "release-check completed successfully"
+      },
+      {
+        "command": "git diff --check",
+        "status": "PASS",
+        "summary": "no whitespace errors"
+      },
+      {
+        "command": "JSON/JSONL parse checks over changed artifacts",
+        "status": "PASS",
+        "summary": "changed JSON artifacts parse successfully"
+      },
+      {
+        "command": "artifact hash-pointer checks",
+        "status": "PASS",
+        "summary": "source_artifacts sha256 pointers match repository files"
+      },
+      {
+        "command": "secret/token scan over changed files",
+        "status": "PASS",
+        "summary": "no secret or token patterns found in changed files"
+      },
+      {
+        "command": "boundary and overclaim scans",
+        "status": "PASS",
+        "summary": "no Codex rerun, Stage 2 rerun, new trace, evidence rewrite, benchmark PASS claim, performance claim, or router promotion found"
+      }
+    ]
+  },
+  "release_blockers": [],
+  "remaining_non_blocking_caveats": [
+    "live_agent.overlap_status"
+  ]
+}

--- a/docs/demo-repo-plan.md
+++ b/docs/demo-repo-plan.md
@@ -7,7 +7,7 @@ It does not claim that the repository already exists.
 
 Provide a tiny external consumer repository that copies the public
 `examples/github-action/skills/` and `examples/github-action/benchmark/`
-fixtures, then calls `Raidriar7170/hermes-skilleval@v0.2.1` from GitHub
+fixtures, then calls `Raidriar7170/hermes-skilleval@v0.3.0` from GitHub
 Actions.
 
 ## Good PR Scenario

--- a/docs/evidence-map.md
+++ b/docs/evidence-map.md
@@ -11,7 +11,7 @@ Boundary: This is a reusable repository Action, not a Marketplace-published Acti
 
 | Artifact | Helps verify | Limit |
 |---|---|---|
-| [`README.md`](../README.md) | Developer-tool front door, current `v0.2.1` onboarding, Action usage, dashboard preview, and compact evidence links. | The README summarizes; source artifacts remain authoritative. |
+| [`README.md`](../README.md) | Developer-tool front door, current `v0.3.0` release-prep onboarding, Action usage, dashboard preview, and compact evidence links. | The README summarizes; source artifacts remain authoritative. |
 | [`CONTEXT.md`](../CONTEXT.md) | Durable domain language for routing reliability, Skill Library Maintainers, diagnostics, and release gates. | It defines vocabulary, not a new release result. |
 | [`docs/release-handoff.md`](release-handoff.md) | Reviewer-ready handoff for Phase 16-18, historical release review, and post-release evidence. | It is not release approval or product readiness. |
 | [`docs/failure-gallery.md`](failure-gallery.md) | Gallery of blocked regressions and diagnostic risks. | It is an example index, not canonical evidence or a new verdict. |
@@ -34,6 +34,19 @@ Boundary: This is a reusable repository Action, not a Marketplace-published Acti
 | [`v0.2.0 post-release evidence`](demo/v0.2.0-post-release/post-release.md) | Current publication record: actual GitHub tag and GitHub Release facts after explicit human GO. | It is not Marketplace publication, PR comment automation, SaaS, or a runtime MCP router. |
 | [`v0.2.0 post-release JSON`](demo/v0.2.0-post-release/post-release.json) | Machine-readable current publication facts, release URL, tag, and verification commands. | It is not a public release action by itself. |
 | [`docs/phase18.md`](phase18.md) | Narrative summary for the CI-backed reproducibility pack. | It should be read with the manifest and release-check summary. |
+
+## v0.3 Stage 2 Evidence Chain
+
+| Artifact | Helps verify | Limit |
+|---|---|---|
+| [`v0.3.0 release-prep notes`](release-notes/v0.3.0.md) | Release framing for the Stage 2 real Codex pilot evidence-chain release. | This prepares release metadata only; it does not create a tag or GitHub Release. |
+| [`PR #30 closeout artifact`](../artifacts/v0.3/skillsbench-pilot/v0.3-stage2-real-codex-evidence-gate-closeout-20260708T080414Z/stage2-real-codex-evidence-gate-closeout.json) | Final closeout posture: `REVIEW_REQUIRED / KEEP_BASELINE`, `blocking_failure_count=0`, and `live_agent.overlap_status` as the remaining caveat. | `REVIEW_REQUIRED` is not PASS and `KEEP_BASELINE` is not a performance conclusion. |
+| [`PR #25 execution artifact`](../artifacts/v0.3/skillsbench-pilot/v0.3-stage2-real-codex-12-run-execution-20260707T072652Z/stage2-real-codex-12-run-execution.json) | Real Codex 12-run execution evidence over the frozen 4x3x1 plan. | Raw verifier facts only; no performance claim or router promotion. |
+| [`PR #25 matrix report`](../artifacts/v0.3/skillsbench-pilot/v0.3-stage2-real-codex-12-run-execution-20260707T072652Z/stage2-real-codex-12-run-matrix-report.json) | 12 runs completed with verifier output; raw verifier facts are 6 passed and 6 failed. | Process exit code is not task success; deterministic verifier output is the only task success source. |
+| [`PR #22 frozen pilot plan`](../artifacts/v0.3/skillsbench-pilot/v0.3-stage2-pilot-freeze-20260707T025315Z/stage2-pilot-plan.frozen.json) | Frozen 4 tasks x 3 conditions x 1 trial plan and fixed run order. | It is a plan artifact, not execution evidence. |
+| [`PR #27 adapter artifact`](../artifacts/v0.3/skillsbench-pilot/v0.3-stage2-real-codex-evidence-gate-adapter-20260708T032000Z/stage2-real-codex-evidence-gate-adapter.json) | Adapter contract for mapping Stage 2 real Codex artifacts into the evidence gate. | Adapter support is not a router promotion. |
+| [`PR #29 data-root provenance repair`](../artifacts/v0.3/skillsbench-pilot/v0.3-external-matrix-data-root-provenance-repair-20260708T065712Z/external-matrix-data-root-provenance-repair.json) | External matrix data-root provenance/materialization repair with `blocking_failure_count=0` after repair. | The 402MB external data root is not committed. |
+| [`v0.3.0 release readiness artifact`](../artifacts/v0.3/release/v0.3.0-release-readiness.json) | Machine-readable release-prep summary of source PRs, key artifacts, non-claims, and validation commands. | It is not a tag, GitHub Release, benchmark PASS, or performance claim. |
 
 ## Diagnostic Onboarding Evidence
 
@@ -67,7 +80,7 @@ Boundary: This is a reusable repository Action, not a Marketplace-published Acti
 |---|---|---|
 | [`action.yml`](../action.yml) | Root composite action metadata for running the offline SkillEval gate from an external repository. | It is a reusable repository Action, not Marketplace publication or PR automation. |
 | [`examples/github-action/README.md`](../examples/github-action/README.md) | Public-safe fresh-clone fixture with two skills, two labeled tasks, and local gate commands. | It is an example fixture, not benchmark status or production readiness. |
-| [`examples/github-action/.github/workflows/skilleval.yml`](../examples/github-action/.github/workflows/skilleval.yml) | Current copy/paste workflow using `Raidriar7170/hermes-skilleval@v0.2.1` with bounded thresholds. | It does not post PR comments or annotations and does not approve merges automatically. |
+| [`examples/github-action/.github/workflows/skilleval.yml`](../examples/github-action/.github/workflows/skilleval.yml) | Current copy/paste workflow using `Raidriar7170/hermes-skilleval@v0.3.0` with bounded thresholds. | It does not post PR comments or annotations and does not approve merges automatically. |
 | [`docs/demo-repo-plan.md`](demo-repo-plan.md) | Future external demo repository plan for `Raidriar7170/hermes-skilleval-demo`. | It is a plan only; it does not claim the repository exists. |
 | [`OpenSpec: reusable-github-action-rc`](../openspec/specs/reusable-github-action-rc/spec.md) | Archived/root capability contract including the post-release cleanup delta. | The capability name is historical; current onboarding uses the published Action ref. |
 
@@ -83,7 +96,7 @@ Boundary: This is a reusable repository Action, not a Marketplace-published Acti
 
 | Artifact | Helps verify | Limit |
 |---|---|---|
-| [`Hosted Consumer Action Smoke`](demo/hosted-consumer-action-smoke/README.md) | Historical hosted smoke run from a dedicated consumer repository. | Captured action refs are historical; current onboarding recommends `Raidriar7170/hermes-skilleval@v0.2.1`. |
+| [`Hosted Consumer Action Smoke`](demo/hosted-consumer-action-smoke/README.md) | Historical hosted smoke run from a dedicated consumer repository. | Captured action refs are historical; current onboarding recommends `Raidriar7170/hermes-skilleval@v0.3.0` after the v0.3.0 tag is published. |
 | [`Hosted run metadata`](demo/hosted-consumer-action-smoke/run-metadata.json) | Run URL, run id, workflow name, conclusion, action ref, commit, and artifact names. | It is a captured run record, not ongoing monitoring. |
 | [`Hosted consumer gate report`](demo/hosted-consumer-action-smoke/output/gate-report.md) | Downloaded hosted artifact with `ALLOW_MERGE`, `recall_at_5=1.0`, and `negative_hit_rate=0.0`. | It is smoke evidence, not benchmark status or automatic merge approval. |
 | [`Hosted consumer CI summary`](demo/hosted-consumer-action-smoke/output/ci-summary.md) | Downloaded step-summary style Markdown from the hosted consumer run. | It does not post GitHub API PR comments or PR annotations. |
@@ -98,6 +111,8 @@ Boundary: This is a reusable repository Action, not a Marketplace-published Acti
 | [`v0.2.1 patch release notes`](release-notes/v0.2.1.md) | Patch release notes for packaging the post-release onboarding cleanup. | It is not a feature expansion, Marketplace publication, SaaS, or runtime routing. |
 | [`v0.2.1 post-release evidence`](demo/v0.2.1-post-release/post-release.md) | Current patch publication record: tag and GitHub Release exist, Marketplace remains false. | It is not PR automation, SaaS, or runtime routing. |
 | [`v0.2.1 post-release JSON`](demo/v0.2.1-post-release/post-release.json) | Machine-readable patch publication facts and verification commands. | It is evidence only, not a release command. |
+| [`v0.3.0 release-prep notes`](release-notes/v0.3.0.md) | Stage 2 real Codex pilot evidence-chain release notes and non-claims. | It does not create the v0.3.0 tag or GitHub Release. |
+| [`v0.3.0 release readiness artifact`](../artifacts/v0.3/release/v0.3.0-release-readiness.json) | Machine-readable readiness state for the v0.3.0 release-prep PR. | Tag and GitHub Release require separate explicit human approval after merge. |
 
 ## OpenSpec Specs
 

--- a/docs/human-briefs/2026-07-08-v0.3.0-release-readiness.html
+++ b/docs/human-briefs/2026-07-08-v0.3.0-release-readiness.html
@@ -1,0 +1,69 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8">
+  <title>v0.3.0 release readiness</title>
+  <style>
+    body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; margin: 32px; color: #17202a; line-height: 1.5; }
+    main { max-width: 960px; margin: 0 auto; }
+    h1 { font-size: 26px; margin-bottom: 8px; }
+    h2 { font-size: 18px; margin-top: 28px; }
+    code { background: #eef2f6; padding: 2px 5px; border-radius: 4px; }
+    .status { border-left: 4px solid #7a5c00; padding: 12px 16px; background: #fff9e8; }
+    .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 12px; }
+    .card { border: 1px solid #d6dde5; border-radius: 8px; padding: 12px; background: #ffffff; }
+    ul { padding-left: 20px; }
+  </style>
+</head>
+<body>
+<main>
+  <h1>v0.3.0 release readiness</h1>
+  <p class="status"><strong>结论：</strong>v0.3.0 是 Stage 2 real Codex pilot evidence-chain release-prep；最终 gate posture 保持 <code>REVIEW_REQUIRED / KEEP_BASELINE</code>，不是 benchmark PASS、性能提升结论或 router promotion。</p>
+
+  <section class="grid">
+    <div class="card"><strong>Target</strong><br><code>v0.3.0</code></div>
+    <div class="card"><strong>Gate status</strong><br><code>REVIEW_REQUIRED</code></div>
+    <div class="card"><strong>Router decision</strong><br><code>KEEP_BASELINE</code></div>
+    <div class="card"><strong>Remaining caveat</strong><br><code>live_agent.overlap_status</code></div>
+  </section>
+
+  <h2>本阶段完成什么</h2>
+  <ul>
+    <li>将 package metadata 从 <code>0.2.1</code> 准备到 <code>0.3.0</code>。</li>
+    <li>新增 <code>docs/release-notes/v0.3.0.md</code>。</li>
+    <li>新增 <code>artifacts/v0.3/release/v0.3.0-release-readiness.json</code>。</li>
+    <li>更新 README、usage、evidence map 和 release handoff 的当前 release-prep 入口。</li>
+  </ul>
+
+  <h2>证据链状态</h2>
+  <ul>
+    <li>Stage 2 real Codex 12-run execution evidence 已存在。</li>
+    <li>12 runs completed with verifier output；raw verifier facts 为 6 passed / 6 failed。</li>
+    <li>这些只是 raw verifier facts，不是 performance claim。</li>
+    <li><code>blocking_failure_count=0</code>。</li>
+  </ul>
+
+  <h2>明确不声明</h2>
+  <ul>
+    <li>不声明 benchmark PASS。</li>
+    <li>不声明性能提升。</li>
+    <li>不声明 routed-skill beats baseline。</li>
+    <li>不 promote router。</li>
+    <li>不把 <code>REVIEW_REQUIRED</code> 当作 PASS。</li>
+    <li>不把 <code>KEEP_BASELINE</code> 当作性能结论。</li>
+  </ul>
+
+  <h2>验证结果</h2>
+  <ul>
+    <li><code>python -m pytest -q</code>: 668 passed。</li>
+    <li><code>openspec validate --all --strict</code>: 25 passed, 0 failed。</li>
+    <li><code>python -m hermes_skilleval.cli release-check</code>: PASS。</li>
+    <li><code>git diff --check</code>: PASS。</li>
+    <li>JSON/hash-pointer、secret/token、boundary、overclaim scans: PASS。</li>
+  </ul>
+
+  <h2>下一步</h2>
+  <p>review/merge release-prep PR；合并后如果要发布，必须单独请求 <code>v0.3.0</code> tag 和 GitHub Release approval。</p>
+</main>
+</body>
+</html>

--- a/docs/interview-project-overview.html
+++ b/docs/interview-project-overview.html
@@ -197,7 +197,7 @@
     <h2>当前证据读法</h2>
     <div class="grid">
       <div class="card">
-        <span class="metric">419 tests</span>
+        <span class="metric">668 tests</span>
         <p>轻量 pytest 验证覆盖 parser、loader、router、metrics、reports、CLI 和 release gate。</p>
       </div>
       <div class="card">

--- a/docs/release-handoff.md
+++ b/docs/release-handoff.md
@@ -23,6 +23,7 @@ HTML artifacts.
 | v0.2.0 historical decision | Pre-publish human release review package | `docs/demo/v0.2.0-release-decision/release-decision.md` |
 | v0.2.0 historical final approval | Pre-publish human approval checklist | `docs/demo/v0.2.0-final-approval/final-approval.md` |
 | v0.2.0 post-release | Current GitHub tag and GitHub Release record | `docs/demo/v0.2.0-post-release/post-release.md` |
+| v0.3.0 release-prep | Stage 2 real Codex pilot evidence-chain closeout | `docs/release-notes/v0.3.0.md` |
 
 ## Reviewer Entry Points
 
@@ -46,6 +47,9 @@ HTML artifacts.
 - v0.2.0 post-release evidence: `docs/demo/v0.2.0-post-release/post-release.md`
 - v0.2.1 patch release notes: `docs/release-notes/v0.2.1.md`
 - v0.2.1 post-release evidence: `docs/demo/v0.2.1-post-release/post-release.md`
+- v0.3.0 release-prep notes: `docs/release-notes/v0.3.0.md`
+- v0.3.0 release readiness artifact: `artifacts/v0.3/release/v0.3.0-release-readiness.json`
+- v0.3.0 evidence-gate closeout: `artifacts/v0.3/skillsbench-pilot/v0.3-stage2-real-codex-evidence-gate-closeout-20260708T080414Z/stage2-real-codex-evidence-gate-closeout.json`
 - Provenance: `docs/demo/phase15-held-out-generalization/provenance.md`
 - Release check: `docs/demo/phase17-calibrated-release-selector/release-check-summary.json`
 
@@ -94,6 +98,16 @@ Release facts: Published: `true`, Tag created: `true`, GitHub Release created:
 `true`, Marketplace published: `false`, release URL
 `https://github.com/Raidriar7170/hermes-skilleval/releases/tag/v0.2.1`, and
 target commit `c667c4d00bddff05c2b5feb357a76182cef2134e`.
+
+The v0.3.0 release-prep package records the Stage 2 real Codex pilot
+evidence-chain release framing. The real 4x3x1 Codex pilot evidence chain was
+executed, validated, adapted, reviewed, and closed out. The final closeout
+posture is `REVIEW_REQUIRED / KEEP_BASELINE`, `blocking_failure_count=0`, with
+`live_agent.overlap_status` remaining as a review caveat. The raw PR #25
+verifier facts are 12 completed runs with verifier output, 6 passed and 6
+failed. These are raw verifier facts only, not performance claims. The v0.3.0
+release-prep package does not claim benchmark PASS, does not promote the
+router, and does not create a tag or GitHub Release.
 
 ## Boundaries
 

--- a/docs/release-notes/v0.3.0.md
+++ b/docs/release-notes/v0.3.0.md
@@ -1,0 +1,105 @@
+# v0.3.0 - Stage 2 real Codex pilot evidence-chain release
+
+These notes prepare the `v0.3.0` release metadata for the Stage 2 real Codex
+pilot evidence chain. This is not a benchmark PASS release, not a performance
+improvement release, and not a router-promotion release.
+
+This release-prep PR does not create the `v0.3.0` tag or GitHub Release. Tag
+and release publication require separate explicit human approval after this PR
+is reviewed and merged.
+
+## What shipped
+
+- Stage 2 four-task input package.
+- Oracle/verifier qualification artifacts.
+- Human privacy acceptance for the Stage 2 package.
+- Strict routed predictions from the approved non-execution router config.
+- Codex real-runner preflight and isolated-auth smoke/preflight evidence.
+- Frozen 4x3x1 pilot plan.
+- Real Codex 12-run execution evidence.
+- Evidence-gate Stage 2 adapter.
+- External matrix data-root provenance/materialization repair.
+- Evidence-gate closeout record.
+
+## Final status
+
+- Final gate posture: `REVIEW_REQUIRED / KEEP_BASELINE`.
+- Benchmark Validity Gate: `REVIEW_REQUIRED`.
+- Router Promotion Gate: `KEEP_BASELINE`.
+- `blocking_failure_count=0`.
+- Remaining caveat: `live_agent.overlap_status`.
+- `REVIEW_REQUIRED` is not PASS.
+- `KEEP_BASELINE` is not a performance conclusion.
+
+## Raw verifier facts
+
+PR #25 records exactly 12 frozen Stage 2 real Codex runs completed with
+deterministic verifier output.
+
+- Planned runs: 12.
+- Codex exec invocations: 12.
+- Runs with verifier output: 12.
+- Raw verifier facts: 6 passed, 6 failed.
+
+These are raw verifier-output facts only. They are not performance claims, not
+benchmark PASS claims, and not a router-promotion decision.
+
+## Non-claims
+
+- Summary: no benchmark PASS, no performance improvement claim, no router promotion.
+- No benchmark PASS is claimed.
+- No evidence-gate PASS is claimed.
+- No performance improvement is claimed.
+- No routed-skill-over-baseline claim is made.
+- No router promotion is made.
+- `REVIEW_REQUIRED` is not treated as PASS.
+- `KEEP_BASELINE` is preserved as the promotion decision.
+
+## Safety
+
+- Deterministic verifier output is the only task success source.
+- Process exit code is recorded but is not task success.
+- LLM judge was not used.
+- PR #25 execution evidence was not rewritten.
+- Verifier outputs were not rewritten.
+- Routed predictions were not rewritten.
+- No Codex rerun, Stage 2 rerun, new traces, evidence-gate rerun, tag, or
+  GitHub Release is performed by this release-prep PR.
+
+## Key PR chain
+
+| PR | Role |
+|---|---|
+| #13 | Stage 2 input package candidate, oracle qualification, validator artifacts |
+| #15 | Privacy provenance blocker record |
+| #16 | Human privacy acceptance |
+| #18 | Codex real-runner smoke/preflight auth blocker record |
+| #19 | Codex real-runner smoke/preflight archive |
+| #20 | Isolated-auth smoke/preflight reached model |
+| #21 | Isolated-auth smoke/preflight archive |
+| #22 | Frozen 4x3x1 pilot plan |
+| #23 | Historical preflight blocker |
+| #24 | Workspace isolation fix |
+| #25 | Stage 2 real Codex 12-run execution |
+| #26 | Initial evidence-gate fail-closed review |
+| #27 | Stage 2 evidence-gate schema adapter |
+| #28 | Formal evidence-gate review |
+| #29 | External matrix data-root provenance repair |
+| #30 | Evidence-gate closeout |
+
+## Key artifacts
+
+| Artifact | SHA256 |
+|---|---|
+| `artifacts/v0.3/skillsbench-pilot/v0.3-stage2-pilot-freeze-20260707T025315Z/stage2-pilot-plan.frozen.json` | `aaa0f4c4d1939cff9bcba08ce6549284726353ed199d7bedd31614be970f579b` |
+| `artifacts/v0.3/skillsbench-pilot/v0.3-stage2-real-codex-12-run-execution-20260707T072652Z/stage2-real-codex-12-run-execution.json` | `70adb8e1e7dd953fcd1efdf541a0174dfae559e8b4efaa194f1641a8f8f6a243` |
+| `artifacts/v0.3/skillsbench-pilot/v0.3-stage2-real-codex-12-run-execution-20260707T072652Z/stage2-real-codex-12-run-matrix-report.json` | `4205f8e8f5e141a67afdebb388a7c6927cc7b45f03a1c6966326e5cc5efc8f7f` |
+| `artifacts/v0.3/skillsbench-pilot/v0.3-stage2-real-codex-evidence-gate-adapter-20260708T032000Z/stage2-real-codex-evidence-gate-adapter.json` | `c773910a631c129f43f8f60e8d2dc8ea2a4746a666df334b5eb7b9aae3f467ce` |
+| `artifacts/v0.3/skillsbench-pilot/v0.3-external-matrix-data-root-provenance-repair-20260708T065712Z/external-matrix-data-root-provenance-repair.json` | `2b2819245a909cbfe7e7da73ce554cb1db3d122b5000c81282b4388cbd880fad` |
+| `artifacts/v0.3/skillsbench-pilot/v0.3-stage2-real-codex-evidence-gate-closeout-20260708T080414Z/stage2-real-codex-evidence-gate-closeout.json` | `ac5b7faa337d484461b3424ad8f7f63f311cf19347de1c02b40463b26c95aaf1` |
+
+## Remaining caveat
+
+`live_agent.overlap_status` remains the explicit review caveat. Resolving it,
+if desired, requires a separate explicit scoping/review phase. It is not
+resolved by this release-prep PR.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -8,7 +8,11 @@ Human Brief evidence, see [`docs/evidence-map.md`](evidence-map.md); it is a
 navigation layer, not a second source of truth, and not release approval.
 For concrete blocked-regression and diagnostic-risk examples, use
 [`docs/failure-gallery.md`](failure-gallery.md) as a review aid.
-For current patch release notes, use
+For current v0.3.0 release-prep notes, use
+[`docs/release-notes/v0.3.0.md`](release-notes/v0.3.0.md). The v0.3.0 notes
+record the Stage 2 real Codex pilot evidence-chain closeout as
+`REVIEW_REQUIRED / KEEP_BASELINE`, not benchmark PASS, performance improvement,
+or router promotion. For the previous v0.2.1 patch release notes, use
 [`docs/release-notes/v0.2.1.md`](release-notes/v0.2.1.md). For the historical
 pre-publish v0.2.0 release decision package, use
 [`docs/demo/v0.2.0-release-decision/release-decision.md`](demo/v0.2.0-release-decision/release-decision.md);
@@ -105,7 +109,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
-      - uses: Raidriar7170/hermes-skilleval@v0.2.1
+      - uses: Raidriar7170/hermes-skilleval@v0.3.0
         with:
           skill-path: skills
           benchmark-path: benchmark
@@ -613,7 +617,7 @@ pytest -q
 Expected:
 
 ```text
-419 passed
+668 passed
 ```
 
 ## 18. Regenerate the External Skill Library Validation Pack
@@ -730,7 +734,7 @@ skilleval github-action-gate \
 
 The example workflow under
 [`examples/github-action/.github/workflows/skilleval.yml`](../examples/github-action/.github/workflows/skilleval.yml)
-uses `Raidriar7170/hermes-skilleval@v0.2.1`. Use a pinned commit SHA only when
+uses `Raidriar7170/hermes-skilleval@v0.3.0`. Use a pinned commit SHA only when
 you intentionally want to test an exact commit instead of the published tag.
 
 The historical local external-consumer smoke pack under
@@ -771,13 +775,15 @@ not GitHub API PR comments, not PR annotations, not SaaS, not a runtime MCP
 router, not a SOTA claim, not benchmark status, not production readiness, not
 release approval, not automatic merge approval, and not automatic publication.
 Any further patch tag, GitHub Release, Marketplace publication, or public
-release action after v0.2.1 still requires explicit human confirmation.
+release action after v0.3.0 release-prep still requires explicit human
+confirmation.
 
 ## 23. Review the v0.2.0 Release Notes And Final Approval Checklist
 
 The v0.2.0 release notes remain the release notes for that published version.
-The current patch release notes are in
-[`release-notes/v0.2.1.md`](release-notes/v0.2.1.md). The final approval
+The v0.2.1 patch release notes remain historical post-release cleanup evidence,
+and the current v0.3.0 release-prep notes are in
+[`release-notes/v0.3.0.md`](release-notes/v0.3.0.md). The final approval
 checklist is historical pre-publish review evidence:
 
 - [`release-notes/v0.2.0.md`](release-notes/v0.2.0.md)

--- a/examples/github-action/.github/workflows/skilleval.yml
+++ b/examples/github-action/.github/workflows/skilleval.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
-      - uses: Raidriar7170/hermes-skilleval@v0.2.1
+      - uses: Raidriar7170/hermes-skilleval@v0.3.0
         with:
           skill-path: examples/github-action/skills
           benchmark-path: examples/github-action/benchmark

--- a/examples/github-action/README.md
+++ b/examples/github-action/README.md
@@ -3,7 +3,7 @@
 This directory is a public-safe fixture for trying the Reusable GitHub Action
 from a fresh checkout. It includes two small skills, two labeled benchmark
 tasks, and a workflow that references the published
-`Raidriar7170/hermes-skilleval@v0.2.1` repository Action.
+`Raidriar7170/hermes-skilleval@v0.3.0` repository Action.
 
 Run the same gate locally:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hermes-skilleval"
-version = "0.2.1"
+version = "0.3.0"
 description = "Offline skill routing evaluation harness for Hermes-style agent skills"
 readme = "README.md"
 license = "MIT"

--- a/src/hermes_skilleval/__init__.py
+++ b/src/hermes_skilleval/__init__.py
@@ -1,3 +1,3 @@
 """Hermes SkillEval: offline skill routing evaluation harness."""
 
-__version__ = "0.2.1"
+__version__ = "0.3.0"

--- a/tests/test_phase14_artifacts.py
+++ b/tests/test_phase14_artifacts.py
@@ -66,8 +66,8 @@ def test_phase14_real_eval_artifacts_pass_hard_negative_guard():
 def test_readme_test_counts_match_verified_suite_size():
     readme = README.read_text(encoding="utf-8")
 
-    assert "| Test cases | 419 |" in readme
-    assert "419 passed" in readme
+    assert "| Test cases | 668 |" in readme
+    assert "668 passed" in readme
     assert "| Test cases | 399 |" not in readme
     assert "399 passed" not in readme
     assert "| Test cases | 386 |" not in readme

--- a/tests/test_phase15_artifacts.py
+++ b/tests/test_phase15_artifacts.py
@@ -76,8 +76,8 @@ def test_phase15_docs_and_readme_reference_the_pack_without_overclaiming():
     assert "does not establish SOTA" in phase15
     assert "standard external benchmark" in phase15
     assert "production readiness" in phase15
-    assert "| Test cases | 419 |" in readme
-    assert "419 passed" in readme
+    assert "| Test cases | 668 |" in readme
+    assert "668 passed" in readme
     assert "| Test cases | 399 |" not in readme
     assert "399 passed" not in readme
     assert "| Test cases | 386 |" not in readme

--- a/tests/test_phase16_artifacts.py
+++ b/tests/test_phase16_artifacts.py
@@ -95,8 +95,8 @@ def test_phase16_docs_and_release_handoff_exist() -> None:
     assert "REVIEW_REQUIRED" in handoff_text
     assert "docs/phase16.md" in readme_text
     assert "docs/release-handoff.md" in readme_text
-    assert "| Test cases | 419 |" in readme_text
-    assert "419 passed" in readme_text
+    assert "| Test cases | 668 |" in readme_text
+    assert "668 passed" in readme_text
     assert "| Test cases | 399 |" not in readme_text
     assert "399 passed" not in readme_text
     assert "| Test cases | 386 |" not in readme_text

--- a/tests/test_project_surface.py
+++ b/tests/test_project_surface.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
-CURRENT_FULL_SUITE_COUNT = "419"
+CURRENT_FULL_SUITE_COUNT = "668"
 README = ROOT / "README.md"
 RESUME = ROOT / "docs" / "resume.md"
 INTERVIEW_OVERVIEW = ROOT / "docs" / "interview-project-overview.html"
@@ -140,11 +140,11 @@ def test_post_release_metadata_and_action_onboarding_are_current():
         ]
     )
 
-    assert pyproject["project"]["version"] == "0.2.1"
-    assert '__version__ = "0.2.1"' in package_init
+    assert pyproject["project"]["version"] == "0.3.0"
+    assert '__version__ = "0.3.0"' in package_init
     assert "Hermes SkillEval Reusable GitHub Action" in action
     assert "Hermes SkillEval Reusable Action RC" not in action
-    assert "Raidriar7170/hermes-skilleval@v0.2.1" in current_docs
+    assert "Raidriar7170/hermes-skilleval@v0.3.0" in current_docs
     assert "Raidriar7170/hermes-skilleval@main" not in "\n".join(
         path.read_text(encoding="utf-8")
         for path in [
@@ -301,7 +301,10 @@ def test_readme_presents_post_release_developer_tool_front_door():
     assert "多类路由策略" in first_screen
     assert "错误的 negative skill" in first_screen
     assert "继续保留 `baseline-minilm`" in first_screen
-    assert "`v0.2.1` 已发布，`419` 个 pytest 用例通过" in first_screen
+    assert "`v0.3.0` release-prep 记录 Stage 2 real Codex pilot evidence-chain closeout" in first_screen
+    assert "`REVIEW_REQUIRED / KEEP_BASELINE`" in first_screen
+    assert "`live_agent.overlap_status`" in first_screen
+    assert "这不是 benchmark PASS、性能提升结论或 router promotion" in first_screen
     assert (
         "[中文完整说明](https://raidriar7170.github.io/hermes-skilleval/docs/interview-project-overview.html)"
         in first_screen
@@ -316,6 +319,7 @@ def test_readme_presents_post_release_developer_tool_front_door():
         "## What it does",
         "## Why skill routing is hard",
         "## Quick Start",
+        "## v0.3.0 release-prep status",
         "## Use as GitHub Action",
         "## Example failure caught",
         "## Dashboard preview",
@@ -327,8 +331,8 @@ def test_readme_presents_post_release_developer_tool_front_door():
     assert dashboard_preview < screenshot < architecture
     assert limitations < architecture
     assert "actions/workflows/validate.yml/badge.svg" in readme
-    assert "badge/release-v0.2.1" in readme
-    assert "badge/tests-419%20passed" in readme
+    assert "badge/release-v0.3.0" in readme
+    assert "badge/tests-668%20passed" in readme
     assert "badge/action-reusable%20repo%20Action" in readme
     assert "badge/A100-validated" not in first_screen
     assert "run filtering" in readme
@@ -432,7 +436,9 @@ def test_readme_keeps_quick_start_short_and_links_full_usage():
 
     assert "For full CLI usage, see [`docs/usage.md`](docs/usage.md)." in readme
     assert "skilleval github-action-gate" in readme
-    assert "Raidriar7170/hermes-skilleval@v0.2.1" in readme
+    assert "Raidriar7170/hermes-skilleval@v0.3.0" in readme
+    assert "No performance claim" in readme
+    assert "router promotion" in readme
     assert "### 1. Index a Hermes-style Skill Library" not in readme
     assert "## Fresh-clone local demo" in usage
     assert "## GitHub Action trial" in usage
@@ -780,7 +786,7 @@ def test_v0_2_0_release_decision_surfaces_are_linked_and_bounded():
         "Published: `false`",
         "post-release evidence",
         "current publication record",
-        "Raidriar7170/hermes-skilleval@v0.2.1",
+        "Raidriar7170/hermes-skilleval@v0.3.0",
     ]:
         assert phrase in current
 
@@ -854,7 +860,7 @@ def test_v0_2_0_final_approval_surfaces_are_linked_and_bounded():
         "reusable GitHub Action support",
         "post-release evidence",
         "current publication record",
-        "Raidriar7170/hermes-skilleval@v0.2.1",
+        "Raidriar7170/hermes-skilleval@v0.3.0",
     ]:
         assert phrase in current
 
@@ -1265,6 +1271,8 @@ def _historical_count_boundary_phrases() -> list[str]:
         "baseline before implementation",
         "phase-time",
         "at the time",
+        "本阶段",
+        "当时",
     ]
 
 

--- a/tests/test_reusable_github_action_rc.py
+++ b/tests/test_reusable_github_action_rc.py
@@ -108,7 +108,7 @@ def test_github_action_example_contains_public_safe_external_fixture():
     assert EXAMPLE_WORKFLOW.is_file()
     workflow = EXAMPLE_WORKFLOW.read_text(encoding="utf-8")
 
-    assert "Raidriar7170/hermes-skilleval@v0.2.1" in workflow
+    assert "Raidriar7170/hermes-skilleval@v0.3.0" in workflow
     assert "skill-path: examples/github-action/skills" in workflow
     assert "benchmark-path: examples/github-action/benchmark" in workflow
     assert "upload-artifacts: 'true'" in workflow
@@ -277,7 +277,7 @@ def test_reusable_action_docs_and_briefs_are_bounded():
 
     for phrase in [
         "Reusable GitHub Action",
-        "Raidriar7170/hermes-skilleval@v0.2.1",
+        "Raidriar7170/hermes-skilleval@v0.3.0",
         "skilleval github-action-gate",
         "This is a reusable repository Action, not a Marketplace-published Action, not a GitHub API PR comment bot, not a SaaS dashboard, and not a runtime MCP router.",
         "not GitHub API PR comments",


### PR DESCRIPTION
## Summary

This prepares v0.3.0 release metadata/docs/artifacts only. v0.3.0 is a Stage 2 real Codex pilot evidence-chain release.

Final gate status remains `REVIEW_REQUIRED / KEEP_BASELINE`. `blocking_failure_count=0`; the remaining caveat is `live_agent.overlap_status`.

## Boundaries

- No benchmark PASS is claimed.
- No performance claim is made.
- No router promotion is made.
- No Codex rerun.
- No Stage 2 rerun.
- No new traces.
- No evidence rewrite.
- No tag or GitHub Release is created by this PR.
- Tag/release requires separate explicit human approval after merge.

## Validation

- `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=src python -m pytest -q` -> 668 passed
- `OPENSPEC_TELEMETRY=0 openspec validate --all --strict` -> 25 passed, 0 failed
- `PYTHONPATH=src python -m hermes_skilleval.cli release-check` -> PASS
- `git diff --check` -> PASS
- JSON/hash-pointer, secret/token, boundary, overclaim, REVIEW_REQUIRED-not-PASS, KEEP_BASELINE preservation, and oversized artifact scans -> PASS

## Key Artifacts

- Release readiness: `artifacts/v0.3/release/v0.3.0-release-readiness.json`
- Release notes: `docs/release-notes/v0.3.0.md`
- Human brief: `docs/human-briefs/2026-07-08-v0.3.0-release-readiness.html`
