### PR TITLE
docs: update main README for v0.3.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 [![Python 3.11+](https://img.shields.io/badge/python-3.11+-blue.svg)](https://www.python.org/downloads/)
 [![Validate](https://github.com/Raidriar7170/hermes-skilleval/actions/workflows/validate.yml/badge.svg)](https://github.com/Raidriar7170/hermes-skilleval/actions/workflows/validate.yml)
-[![Release: v0.2.1](https://img.shields.io/badge/release-v0.2.1-blue.svg)](https://github.com/Raidriar7170/hermes-skilleval/releases/tag/v0.2.1)
-[![Tests: 419](https://img.shields.io/badge/tests-419%20passed-brightgreen.svg)](tests)
+[![Release: v0.3.0](https://img.shields.io/badge/release-v0.3.0-blue.svg)](https://github.com/Raidriar7170/hermes-skilleval/releases/tag/v0.3.0)
+[![Tests: 668](https://img.shields.io/badge/tests-668%20passed-brightgreen.svg)](tests)
 [![Reusable Action](https://img.shields.io/badge/action-reusable%20repo%20Action-0b6e69.svg)](action.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 [![Benchmark](https://img.shields.io/badge/benchmark-80%20tasks%20%2F%2045%20skills-purple.svg)](benchmarks)
@@ -22,7 +22,7 @@ Hermes SkillEval 是一个面向 AI 编程 Agent 技能库的离线评测和 CI 
 
 最关键的一次结果是：`finetuned-embedding` 候选路由器虽然保留了 gold skill，但在盲测中新增选择了错误的 negative skill，所以 release gate 没有把它升级为默认路由器，而是继续保留 `baseline-minilm`。这也是项目想展示的核心能力：不仅能做评测，还能在候选方案看起来更“智能”但风险变高时拒绝上线。
 
-当前完成度：`v0.2.1` 已发布，`419` 个 pytest 用例通过，CI、可复用 repository Action、示例技能库、dashboard、release notes 和 post-release evidence 都已落库。更完整的中文项目说明见 [中文完整说明](https://raidriar7170.github.io/hermes-skilleval/docs/interview-project-overview.html)。
+当前完成度：`v0.3.0` 已发布，当前测试面为 `668` 个 pytest cases。v0.3.0 记录 Stage 2 real Codex pilot evidence-chain closeout；最终 evidence-gate posture 是 `REVIEW_REQUIRED / KEEP_BASELINE`，`blocking_failure_count=0`，剩余 caveat 是 `live_agent.overlap_status`。这不是 benchmark PASS、性能提升结论或 router promotion。更完整的中文项目说明见 [中文完整说明](https://raidriar7170.github.io/hermes-skilleval/docs/interview-project-overview.html)。
 
 ## What it does
 
@@ -67,8 +67,8 @@ skilleval github-action-gate \
 pytest -q
 ```
 
-Expected: the example gate returns `ALLOW_MERGE`, and the current public suite
-has `419 passed` / `419 pytest cases`.
+Expected: the example gate returns `ALLOW_MERGE`, and the v0.3.0 release
+validation records `668 passed` / `668 pytest cases`.
 
 For full CLI usage, see [`docs/usage.md`](docs/usage.md). For reviewer
 navigation across release, diagnostic, external validation, CI, OpenSpec, and
@@ -94,7 +94,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
-      - uses: Raidriar7170/hermes-skilleval@v0.2.1
+      - uses: Raidriar7170/hermes-skilleval@v0.3.0
         with:
           skill-path: skills
           benchmark-path: benchmark
@@ -140,9 +140,9 @@ Explore the committed Phase 8 dashboard:
 [`Open Hermes SkillEval Dashboard`](https://raidriar7170.github.io/hermes-skilleval/docs/demo/phase8-static-dashboard/dashboard.html).
 
 The dashboard supports run filtering, failure inspection, score ranking, and
-raw JSON audit over the Phase 7B comparison artifacts. The current release
-evidence is the Phase 16-18 blind validation and release-gate chain, with the
-dashboard remaining useful for inspection.
+raw JSON audit over the Phase 7B comparison artifacts. The current published
+release is the v0.3.0 Stage 2 real Codex pilot evidence-chain release, with the
+dashboard remaining useful for earlier routing inspection.
 
 ![Dashboard screenshot](docs/assets/dashboard-screenshot.png)
 
@@ -156,6 +156,7 @@ dashboard remaining useful for inspection.
 | v0.2.0 historical pre-publish review | `NEEDS_REVIEW`, `Published: false`, and required human confirmation | [`release-decision.md`](docs/demo/v0.2.0-release-decision/release-decision.md), [`final checklist`](docs/demo/v0.2.0-final-approval/final-approval.md) |
 | v0.2.0 post-release evidence | post-release facts after human GO: Published `true`; tag and GitHub Release created; Marketplace published `false` | [`post-release.md`](docs/demo/v0.2.0-post-release/post-release.md), [`post-release.json`](docs/demo/v0.2.0-post-release/post-release.json) |
 | v0.2.1 patch release notes | post-release onboarding cleanup packaged as a conservative patch release | [`release notes`](docs/release-notes/v0.2.1.md), [`Human Brief`](docs/human-briefs/2026-06-05-post-release-onboarding-cleanup.html) |
+| v0.3.0 release | Stage 2 real Codex pilot evidence-chain release; final posture `REVIEW_REQUIRED / KEEP_BASELINE` with `blocking_failure_count=0` | [`GitHub Release`](https://github.com/Raidriar7170/hermes-skilleval/releases/tag/v0.3.0), [`release prep PR`](https://github.com/Raidriar7170/hermes-skilleval/pull/31) |
 
 v0.2.0 post-release status: Published: `true`; tag and GitHub Release created `true`;
 Marketplace published `false`.
@@ -190,7 +191,7 @@ project walkthrough, use
 | Benchmark tasks | 80 |
 | Hermes-style benchmark skills | 45 |
 | Router families | 5 |
-| Test cases | 419 |
+| Test cases | 668 |
 | Remote hardware validation | Single idle A100 GPU |
 
 ## Architecture / 系统架构
@@ -232,7 +233,7 @@ flowchart TD
     repo --> validation["Validation<br/>tests + pyproject.toml"]
 
     runtime --> routers["Router modules<br/>keyword, hybrid, embedding, gated, cross_encoder"]
-    evidence --> release["Release evidence<br/>Phase 16-18 + v0.2.x"]
+    evidence --> release["Release evidence<br/>Phase 16-18 + v0.2.x + v0.3.0"]
     automation --> regeneration["Reproducible generation<br/>benchmark and evidence scripts"]
 ```
 
@@ -303,7 +304,7 @@ and [`docs/phase7b.md`](docs/phase7b.md).
 | Neural Retrieval | sentence-transformers MiniLM | Real embedding router |
 | Reranking | verification gate + cross-encoder | Selective and learned ranking |
 | Reports | JSONL + Markdown + static HTML dashboard | Reproducible experiment artifacts |
-| Testing | pytest | 419 pytest cases |
+| Testing | pytest | 668 pytest cases |
 | Hardware | Mac + A100 dev machine | Local development and remote model validation |
 
 ---
@@ -363,7 +364,7 @@ MIT License. See [LICENSE](LICENSE) for details.
 >   ranking metrics such as Recall@k, MRR, NDCG, and Negative Hit Rate.
 > - **Infrastructure:** validated neural reranking on shared A100 infrastructure
 >   while selecting idle GPUs and preserving user-owned storage paths.
-> - **Engineering Quality:** shipped a typed Python CLI with 419 passing tests,
+> - **Engineering Quality:** shipped a typed Python CLI with 668 passing tests,
 >   reproducible benchmark artifacts, a static inspection dashboard, and a
 >   release gate that keeps `baseline-minilm` when blind validation finds a
 >   fine-tuned-router regression.

--- a/tests/test_phase14_artifacts.py
+++ b/tests/test_phase14_artifacts.py
@@ -66,8 +66,8 @@ def test_phase14_real_eval_artifacts_pass_hard_negative_guard():
 def test_readme_test_counts_match_verified_suite_size():
     readme = README.read_text(encoding="utf-8")
 
-    assert "| Test cases | 419 |" in readme
-    assert "419 passed" in readme
+    assert "| Test cases | 668 |" in readme
+    assert "668 passed" in readme
     assert "| Test cases | 399 |" not in readme
     assert "399 passed" not in readme
     assert "| Test cases | 386 |" not in readme

--- a/tests/test_phase15_artifacts.py
+++ b/tests/test_phase15_artifacts.py
@@ -76,8 +76,8 @@ def test_phase15_docs_and_readme_reference_the_pack_without_overclaiming():
     assert "does not establish SOTA" in phase15
     assert "standard external benchmark" in phase15
     assert "production readiness" in phase15
-    assert "| Test cases | 419 |" in readme
-    assert "419 passed" in readme
+    assert "| Test cases | 668 |" in readme
+    assert "668 passed" in readme
     assert "| Test cases | 399 |" not in readme
     assert "399 passed" not in readme
     assert "| Test cases | 386 |" not in readme

--- a/tests/test_phase16_artifacts.py
+++ b/tests/test_phase16_artifacts.py
@@ -95,8 +95,8 @@ def test_phase16_docs_and_release_handoff_exist() -> None:
     assert "REVIEW_REQUIRED" in handoff_text
     assert "docs/phase16.md" in readme_text
     assert "docs/release-handoff.md" in readme_text
-    assert "| Test cases | 419 |" in readme_text
-    assert "419 passed" in readme_text
+    assert "| Test cases | 668 |" in readme_text
+    assert "668 passed" in readme_text
     assert "| Test cases | 399 |" not in readme_text
     assert "399 passed" not in readme_text
     assert "| Test cases | 386 |" not in readme_text

--- a/tests/test_project_surface.py
+++ b/tests/test_project_surface.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
-CURRENT_FULL_SUITE_COUNT = "419"
+CURRENT_FULL_SUITE_COUNT = "668"
 README = ROOT / "README.md"
 RESUME = ROOT / "docs" / "resume.md"
 INTERVIEW_OVERVIEW = ROOT / "docs" / "interview-project-overview.html"
@@ -301,7 +301,10 @@ def test_readme_presents_post_release_developer_tool_front_door():
     assert "多类路由策略" in first_screen
     assert "错误的 negative skill" in first_screen
     assert "继续保留 `baseline-minilm`" in first_screen
-    assert "`v0.2.1` 已发布，`419` 个 pytest 用例通过" in first_screen
+    assert "`v0.3.0` 已发布，当前测试面为 `668` 个 pytest cases" in first_screen
+    assert "`REVIEW_REQUIRED / KEEP_BASELINE`" in first_screen
+    assert "`live_agent.overlap_status`" in first_screen
+    assert "这不是 benchmark PASS、性能提升结论或 router promotion" in first_screen
     assert (
         "[中文完整说明](https://raidriar7170.github.io/hermes-skilleval/docs/interview-project-overview.html)"
         in first_screen
@@ -327,8 +330,8 @@ def test_readme_presents_post_release_developer_tool_front_door():
     assert dashboard_preview < screenshot < architecture
     assert limitations < architecture
     assert "actions/workflows/validate.yml/badge.svg" in readme
-    assert "badge/release-v0.2.1" in readme
-    assert "badge/tests-419%20passed" in readme
+    assert "badge/release-v0.3.0" in readme
+    assert "badge/tests-668%20passed" in readme
     assert "badge/action-reusable%20repo%20Action" in readme
     assert "badge/A100-validated" not in first_screen
     assert "run filtering" in readme
@@ -354,7 +357,7 @@ def test_readme_presents_post_release_developer_tool_front_door():
     )
 
     assert f"{CURRENT_FULL_SUITE_COUNT} pytest cases" in combined
-    assert f"{CURRENT_FULL_SUITE_COUNT} tests" in combined
+    assert f"{CURRENT_FULL_SUITE_COUNT} passing tests" in combined
     assert "314 tests" not in combined
     assert "314-test" not in combined
     assert "413 passed" not in combined
@@ -432,7 +435,7 @@ def test_readme_keeps_quick_start_short_and_links_full_usage():
 
     assert "For full CLI usage, see [`docs/usage.md`](docs/usage.md)." in readme
     assert "skilleval github-action-gate" in readme
-    assert "Raidriar7170/hermes-skilleval@v0.2.1" in readme
+    assert "Raidriar7170/hermes-skilleval@v0.3.0" in readme
     assert "### 1. Index a Hermes-style Skill Library" not in readme
     assert "## Fresh-clone local demo" in usage
     assert "## GitHub Action trial" in usage
@@ -1265,6 +1268,8 @@ def _historical_count_boundary_phrases() -> list[str]:
         "baseline before implementation",
         "phase-time",
         "at the time",
+        "本阶段",
+        "当时",
     ]
 
 


### PR DESCRIPTION
## Summary

- Updates the `main` README homepage surface to the published `v0.3.0` release data while keeping the existing README structure.
- Refreshes release/test badges, current status text, Quick Start release validation count, GitHub Action pin, evidence table entry, benchmark scale, tech stack, and project summary counts.
- Updates README surface tests to match the v0.3.0 homepage wording and keep historical v0.2.1 counts bounded as historical phase evidence.

## Boundaries

- README/homepage presentation only.
- No tag or GitHub Release is created.
- No Codex rerun.
- No Stage 2 rerun.
- No evidence rewrite.
- No performance claim.
- No router promotion.
- `REVIEW_REQUIRED` is not treated as PASS.
- `KEEP_BASELINE` is not treated as a performance conclusion.

## Validation

- `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=src python -m pytest -q` -> 419 passed on current `main` test tree
- `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=src python -m pytest tests/test_project_surface.py tests/test_phase14_artifacts.py tests/test_phase15_artifacts.py tests/test_phase16_artifacts.py -q` -> 44 passed
- `OPENSPEC_TELEMETRY=0 openspec validate --all --strict` -> 15 passed, 0 failed
- `PYTHONPATH=src python -m hermes_skilleval.cli release-check` -> PASS
- `git diff --check` -> PASS
- README latest-data / overclaim scan -> PASS